### PR TITLE
Add response message to AlpineBitsException

### DIFF
--- a/alpinebits-common/src/main/java/it/idm/alpinebits/common/AlpineBitsException.java
+++ b/alpinebits-common/src/main/java/it/idm/alpinebits/common/AlpineBitsException.java
@@ -8,39 +8,87 @@ package it.idm.alpinebits.common;
 
 /**
  * Base class for all AlpineBits exceptions.
+ * <p>
+ * It provides constructors to define a code, that can be used e.g. as HTTP response status. In addition,
+ * it is possible to define a response message that is returned to the client.
  */
 public class AlpineBitsException extends RuntimeException {
 
     private final int code;
+    private final String responseMessage;
 
     /**
      * Constructs an {@code AlpineBitsException} with the specified message, code and root
-     * cause.
+     * cause. The responseText is the same as the message.
      *
-     * @param msg the detail message
+     * @param msg  the detail message
      * @param code the error code
-     * @param t the root cause
+     * @param t    the root cause
      */
     public AlpineBitsException(String msg, int code, Throwable t) {
         super(msg, t);
         this.code = code;
+        this.responseMessage = msg;
+    }
+
+    /**
+     * Constructs an {@code AlpineBitsException} with the specified message, responseText,
+     * code and root cause.
+     *
+     * @param msg  the detail message
+     * @param code the error code
+     * @param responseMessage the response message that should be returned to the client
+     * @param t    the root cause
+     */
+    public AlpineBitsException(String msg, int code, String responseMessage, Throwable t) {
+        super(msg, t);
+        this.code = code;
+        this.responseMessage = responseMessage;
     }
 
     /**
      * Constructs an {@code AlpineBitsException} with the specified message, code and no
-     * root cause.
+     * root cause. The responseText is the same as the message.
      *
-     * @param msg the detail message
+     * @param msg  the detail message
      * @param code the error code
      */
     public AlpineBitsException(String msg, int code) {
         super(msg);
         this.code = code;
+        this.responseMessage = msg;
     }
 
+    /**
+     * Constructs an {@code AlpineBitsException} with the specified message, responseText,
+     * code and no root cause.
+     *
+     * @param msg  the detail message
+     * @param code the error code
+     * @param responseMessage the response message that should be returned to the client
+     */
+    public AlpineBitsException(String msg, int code, String responseMessage) {
+        super(msg);
+        this.code = code;
+        this.responseMessage = responseMessage;
+    }
 
+    /**
+     * Return the exception's response message, that may be different than the exception message.
+     *
+     * @return the exception's response message
+     */
+    public String getResponseMessage() {
+        return this.responseMessage;
+    }
 
+    /**
+     * Return the exception code.
+     *
+     * @return the exception code
+     */
     public int getCode() {
         return code;
     }
+
 }

--- a/alpinebits-http/api/src/main/java/it/idm/alpinebits/http/UndefinedActionException.java
+++ b/alpinebits-http/api/src/main/java/it/idm/alpinebits/http/UndefinedActionException.java
@@ -22,7 +22,7 @@ public class UndefinedActionException extends AlpineBitsException {
      * @param msg the detail message
      */
     public UndefinedActionException(String msg) {
-        super(msg, STATUS);
+        super(msg, STATUS, "unknown or missing action");
     }
 
 }

--- a/alpinebits-http/impl/src/main/java/it/idm/alpinebits/http/impl/DefaultRequestExceptionHandler.java
+++ b/alpinebits-http/impl/src/main/java/it/idm/alpinebits/http/impl/DefaultRequestExceptionHandler.java
@@ -53,7 +53,9 @@ public class DefaultRequestExceptionHandler implements RequestExceptionHandler {
     }
 
     public String getErrorMessage(Exception e) {
-        return "ERROR:" + e.getMessage();
+        return e instanceof AlpineBitsException
+                ? "ERROR:" + ((AlpineBitsException)e).getResponseMessage()
+                : "ERROR:" + e.getMessage();
     }
 
     private int getStatus(AlpineBitsException e) {


### PR DESCRIPTION
Add the possibility to define an alternative response message for an
AlpineBitsException, that can be returned to the client instead of
the exception message