### PR TITLE
Add example module for AlpineBits examples

### DIFF
--- a/examples/housekeeping/pom.xml
+++ b/examples/housekeeping/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>it.bz.idm.alpinebits</groupId>
+        <artifactId>examples-root</artifactId>
+        <version>0.0.8</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>examples-housekeeping</artifactId>
+    <version>0.0.8</version>
+
+    <packaging>war</packaging>
+    <name>IDM AlpineBits examples - housekeeping</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.25</version>
+        </dependency>
+        <dependency>
+            <groupId>it.bz.idm.alpinebits</groupId>
+            <artifactId>alpinebits-housekeeping-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>it.bz.idm.alpinebits</groupId>
+            <artifactId>alpinebits-routing-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>it.bz.idm.alpinebits</groupId>
+            <artifactId>alpinebits-servlet-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.cargo</groupId>
+                <artifactId>cargo-maven2-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/housekeeping/src/main/java/it/bz/idm/alpinebits/examples/housekeeping/middleware/ConfiguringMiddleware.java
+++ b/examples/housekeeping/src/main/java/it/bz/idm/alpinebits/examples/housekeeping/middleware/ConfiguringMiddleware.java
@@ -1,0 +1,69 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.examples.housekeeping.middleware;
+
+import it.bz.idm.alpinebits.common.constants.HousekeepingActionEnum;
+import it.bz.idm.alpinebits.common.utils.middleware.ComposingMiddlewareBuilder;
+import it.bz.idm.alpinebits.housekeeping.middleware.HousekeepingGetCapabilitiesMiddleware;
+import it.bz.idm.alpinebits.housekeeping.middleware.HousekeepingGetVersionMiddleware;
+import it.bz.idm.alpinebits.middleware.Context;
+import it.bz.idm.alpinebits.middleware.Middleware;
+import it.bz.idm.alpinebits.middleware.MiddlewareChain;
+import it.bz.idm.alpinebits.routing.DefaultRouter;
+import it.bz.idm.alpinebits.routing.VersionRoutingBuilder;
+import it.bz.idm.alpinebits.routing.middleware.RoutingMiddleware;
+import it.bz.idm.alpinebits.servlet.middleware.AlpineBitsClientProtocolMiddleware;
+import it.bz.idm.alpinebits.servlet.middleware.BasicAuthenticationMiddleware;
+import it.bz.idm.alpinebits.servlet.middleware.GzipUnsupportedMiddleware;
+import it.bz.idm.alpinebits.servlet.middleware.HousekeepingWriterMiddleware;
+import it.bz.idm.alpinebits.servlet.middleware.MultipartFormDataParserMiddleware;
+
+import java.util.Arrays;
+
+/**
+ * This {@link Middleware} configures a set of middlewares, such that
+ * the resulting server is able to respond to Housekeeping requests.
+ * <p>
+ * The resulting server supports the version defined by
+ * {@link ConfiguringMiddleware#DEFAULT_VERSION} only (typically 2017-10).
+ * <p>
+ * A basic authentication check is enforced, although any username and
+ * password combination is valid. In other words: a request MUST contain
+ * basic authentication information, but that information is not checked
+ * any further.
+ */
+public class ConfiguringMiddleware implements Middleware {
+
+    public static final String DEFAULT_VERSION = "2017-10";
+
+    private final Middleware middleware;
+
+    public ConfiguringMiddleware() {
+        this.middleware = ComposingMiddlewareBuilder.compose(Arrays.asList(
+                new AlpineBitsClientProtocolMiddleware(),
+                new BasicAuthenticationMiddleware(),
+                new GzipUnsupportedMiddleware(),
+                new MultipartFormDataParserMiddleware(),
+                new HousekeepingWriterMiddleware(),
+                this.buildRoutingMiddleware()
+        ));
+    }
+
+    @Override
+    public void handleContext(Context ctx, MiddlewareChain chain) {
+        this.middleware.handleContext(ctx, chain);
+    }
+
+    private Middleware buildRoutingMiddleware() {
+        VersionRoutingBuilder builder = new DefaultRouter.Builder()
+                .forVersion(DEFAULT_VERSION)
+                .addMiddleware(HousekeepingActionEnum.GET_VERSION.getAction(), new HousekeepingGetVersionMiddleware())
+                .addMiddleware(HousekeepingActionEnum.GET_CAPABLILITIES.getAction(), new HousekeepingGetCapabilitiesMiddleware())
+                .done();
+        return new RoutingMiddleware(builder.buildRouter());
+    }
+}

--- a/examples/housekeeping/src/main/webapp/WEB-INF/web.xml
+++ b/examples/housekeeping/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=" http://java.sun.com/xml/ns/javaee
+    http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <servlet>
+        <servlet-name>AlpineBits Servlet</servlet-name>
+        <servlet-class>it.bz.idm.alpinebits.servlet.impl.AlpineBitsServlet</servlet-class>
+        <init-param>
+            <param-name>MIDDLEWARE_CLASSNAME</param-name>
+            <param-value>it.bz.idm.alpinebits.examples.housekeeping.middleware.ConfiguringMiddleware</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>AlpineBits Servlet</servlet-name>
+        <url-pattern>/AlpineBits</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/examples/housekeeping/src/main/webapp/index.html
+++ b/examples/housekeeping/src/main/webapp/index.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html>
+    <head>
+        <title>AlpineBits example: Housekeeping actions</title>
+    </head>
+<body>
+    <h1>AlpineBits Housekeeping actions</h1>
+    <p>
+        <a href="#" onclick='callGetVersion()'>Click here to execute the AlpineBits getVersion Housekeeping action</a>
+    </p>
+    <p>
+        <a href="#" onclick='callGetCapabilities()'>Click here to execute the AlpineBits getCapabilities Housekeeping action</a>
+    </p>
+    <p>
+        <textarea id="log" cols="80" rows="25" readonly style="background: #eee; margin-top: 20px;"></textarea>
+    </p>
+
+    <script>
+        var logArea = document.getElementById('log');
+
+        function callGetVersion() {
+            logAction('Invoking AlpineBits endpoint with getVersion action...');
+            post('./AlpineBits', {action: 'getVersion'});
+        }
+
+        function callGetCapabilities() {
+            logAction('Invoking AlpineBits endpoint with getCapabilities action...');
+            post('./AlpineBits', {action: 'getCapabilities'});
+        }
+
+        function post(path, params) {
+            var xhr = new XMLHttpRequest();
+            var formData = new FormData();
+            var start = null;
+
+            for (var key in params) {
+                formData.append(key, params[key]);
+            }
+
+            xhr.addEventListener('load', function (event) {
+                var end = new Date();
+                console.log(event);
+                logAction(xhr.responseText + ' (took ' + (end.getTime() - start.getTime()) + 'ms)');
+            });
+
+            xhr.addEventListener('error', function (event) {
+                console.log(event);
+                logAction('Oops! Something went wrong: ' + xhr.statusText);
+            });
+
+            xhr.open('POST', path, true);
+            xhr.setRequestHeader('X-AlpineBits-ClientProtocolVersion', '2017-10');
+            xhr.setRequestHeader('Authorization', 'Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==');
+
+            start = new Date()
+            xhr.send(formData);
+        }
+
+        function logAction(message) {
+            var now = new Date();
+            var hours = ('0' + now.getHours()).slice(-2);
+            var minutes = ('0' + now.getMinutes()).slice(-2);
+            var seconds = ('0' + now.getSeconds()).slice(-2);
+            var time = hours + ':' + minutes + ':' + seconds;
+            logArea.value += '[' + time + ']: ' + message + '\n';
+        }
+    </script>
+</body>
+<html>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>it.bz.idm.alpinebits</groupId>
+        <artifactId>alpinebits-root</artifactId>
+        <version>0.0.8</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>examples-root</artifactId>
+    <version>0.0.8</version>
+
+    <packaging>pom</packaging>
+    <name>IDM AlpineBits examples - root</name>
+
+    <modules>
+        <module>housekeeping</module>
+    </modules>
+
+    <properties>
+        <maven-war-plugin.version>3.2.2</maven-war-plugin.version>
+        <cargo-maven2-plugin.version>1.6.11</cargo-maven2-plugin.version>
+    </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>${maven-war-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.cargo</groupId>
+                    <artifactId>cargo-maven2-plugin</artifactId>
+                    <version>${cargo-maven2-plugin.version}</version>
+                    <configuration>
+                        <container>
+                            <containerId>tomcat8x</containerId>
+                            <artifactInstaller>
+                                <groupId>org.apache.tomcat</groupId>
+                                <artifactId>tomcat</artifactId>
+                                <version>${tomcat-embedded.version}</version>
+                            </artifactInstaller>
+                        </container>
+                        <configuration>
+                            <type>standalone</type>
+                            <home>
+                                ${project.build.directory}/apache-tomcat-${tomcat-embedded.version}
+                            </home>
+                            <properties>
+                                <cargo.servlet.port>8080</cargo.servlet.port>
+                                <cargo.logging>high</cargo.logging>
+                            </properties>
+                        </configuration>
+                        <deployables>
+                            <deployable>
+                                <groupId>${project.groupId}</groupId>
+                                <artifactId>${project.artifactId}</artifactId>
+                                <type>war</type>
+                                <properties>
+                                    <context>/${project.artifactId}</context>
+                                </properties>
+                            </deployable>
+                        </deployables>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <module>alpinebits-server</module>
         <module>alpinebits-servlet</module>
         <module>build-tools</module>
+        <module>examples</module>
     </modules>
 
     <properties>
@@ -190,6 +191,11 @@
             <dependency>
                 <groupId>it.bz.idm.alpinebits</groupId>
                 <artifactId>alpinebits-servlet-impl</artifactId>
+                <version>0.0.8</version>
+            </dependency>
+            <dependency>
+                <groupId>it.bz.idm.alpinebits</groupId>
+                <artifactId>examples-housekeeping</artifactId>
                 <version>0.0.8</version>
             </dependency>
 


### PR DESCRIPTION
The example module contains an example configuration for AlpineBits
Housekeeping actions. Using the cargo maven module, the example can
actually be run on a Tomcat instance by invoking mvn cargo:run