### PR TITLE
Feature oa 43 implement xml converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 target
 
 *.iml
+
+/alpinebits-mapping
+/alpinebits-persistence
+/alpinebits-validation

--- a/alpinebits-common/api/pom.xml
+++ b/alpinebits-common/api/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-common</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alpinebits-common-api</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <name>IDM AlpineBits common API</name>
 

--- a/alpinebits-common/api/src/main/java/it/bz/idm/alpinebits/common/constants/AlpineBitsVersion.java
+++ b/alpinebits-common/api/src/main/java/it/bz/idm/alpinebits/common/constants/AlpineBitsVersion.java
@@ -1,0 +1,31 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.common.constants;
+
+/**
+ * This class provides constants for all known AlpineBits versions (as of 2018-10-31).
+ */
+public final class AlpineBitsVersion {
+
+    public static final String V_2017_10 = "2017-10";
+    public static final String V_2015_07B = "2015-07b";
+    public static final String V_2015_07 = "2015-07";
+    public static final String V_2014_04 = "2014-04";
+    public static final String V_2013_04 = "2013-04";
+    public static final String V_2012_05B = "2012-05b";
+    public static final String V_2012_05 = "2012-05";
+    public static final String V_2011_11 = "2011-11";
+    public static final String V_2011_10 = "2011-10";
+    public static final String V_2011_09 = "2011-09";
+    public static final String V_2010_10 = "2010-10";
+    public static final String V_2010_08 = "2010-08";
+
+    private AlpineBitsVersion() {
+        // Empty
+    }
+
+}

--- a/alpinebits-common/api/src/main/java/it/bz/idm/alpinebits/common/context/RequestContextKey.java
+++ b/alpinebits-common/api/src/main/java/it/bz/idm/alpinebits/common/context/RequestContextKey.java
@@ -8,7 +8,7 @@ package it.bz.idm.alpinebits.common.context;
 
 import it.bz.idm.alpinebits.middleware.Key;
 
-import java.io.OutputStream;
+import java.io.InputStream;
 import java.util.function.Supplier;
 
 /**
@@ -57,8 +57,8 @@ public final class RequestContextKey {
     /**
      * Context key for AlpineBits request content in its plain form, i.e. the XML.
      */
-    public static final Key<OutputStream> REQUEST_CONTENT_STREAM = Key.key(
-            "request.content.stream", OutputStream.class
+    public static final Key<InputStream> REQUEST_CONTENT_STREAM = Key.key(
+            "request.content.stream", InputStream.class
     );
 
     private RequestContextKey() {

--- a/alpinebits-common/api/src/main/java/it/bz/idm/alpinebits/common/context/ResponseContextKeys.java
+++ b/alpinebits-common/api/src/main/java/it/bz/idm/alpinebits/common/context/ResponseContextKeys.java
@@ -8,6 +8,7 @@ package it.bz.idm.alpinebits.common.context;
 
 import it.bz.idm.alpinebits.middleware.Key;
 
+import java.io.OutputStream;
 import java.util.Collection;
 
 /**
@@ -28,6 +29,13 @@ public final class ResponseContextKeys {
      */
     public static final Key<String> RESPONSE_VERSION = Key.key(
             "response.version", String.class
+    );
+
+    /**
+     * Context key for AlpineBits request content in its plain form, i.e. the XML.
+     */
+    public static final Key<OutputStream> RESPONSE_CONTENT_STREAM = Key.key(
+            "response.content.stream", OutputStream.class
     );
 
     private ResponseContextKeys() {

--- a/alpinebits-common/api/src/test/java/it/bz/idm/alpinebits/common/context/RequestContextKeyTest.java
+++ b/alpinebits-common/api/src/test/java/it/bz/idm/alpinebits/common/context/RequestContextKeyTest.java
@@ -8,7 +8,7 @@ package it.bz.idm.alpinebits.common.context;
 
 import org.testng.annotations.Test;
 
-import java.io.OutputStream;
+import java.io.InputStream;
 import java.util.function.Supplier;
 
 import static org.testng.Assert.assertEquals;
@@ -44,8 +44,8 @@ public class RequestContextKeyTest {
     }
 
     @Test
-    public void testContextKey_RequestOutputStream() {
-        assertEquals(RequestContextKey.REQUEST_CONTENT_STREAM.getType(), OutputStream.class);
+    public void testContextKey_RequestInputStream() {
+        assertEquals(RequestContextKey.REQUEST_CONTENT_STREAM.getType(), InputStream.class);
     }
 
 }

--- a/alpinebits-common/api/src/test/java/it/bz/idm/alpinebits/common/context/ResponseContextKeysTest.java
+++ b/alpinebits-common/api/src/test/java/it/bz/idm/alpinebits/common/context/ResponseContextKeysTest.java
@@ -1,0 +1,36 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.common.context;
+
+import org.testng.annotations.Test;
+
+import java.io.OutputStream;
+import java.util.Collection;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for {@link ResponseContextKeys} class.
+ */
+public class ResponseContextKeysTest {
+
+    @Test
+    public void testContextKey_ResponseCapabilities() {
+        assertEquals(ResponseContextKeys.RESPONSE_CAPABILITIES.getType(), Collection.class);
+    }
+
+    @Test
+    public void testContextKey_ResponseVersion() {
+        assertEquals(ResponseContextKeys.RESPONSE_VERSION.getType(), String.class);
+    }
+
+    @Test
+    public void testContextKey_ResponseContentStream() {
+        assertEquals(ResponseContextKeys.RESPONSE_CONTENT_STREAM.getType(), OutputStream.class);
+    }
+
+}

--- a/alpinebits-common/pom.xml
+++ b/alpinebits-common/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-root</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alpinebits-common</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <packaging>pom</packaging>
     <name>IDM AlpineBits common</name>

--- a/alpinebits-common/utils/pom.xml
+++ b/alpinebits-common/utils/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-common</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alpinebits-common-utils</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <name>IDM AlpineBits common utils</name>
 

--- a/alpinebits-housekeeping/api/pom.xml
+++ b/alpinebits-housekeeping/api/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-housekeeping</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alpinebits-housekeeping-api</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <name>IDM AlpineBits housekeeping API</name>
 

--- a/alpinebits-housekeeping/impl/pom.xml
+++ b/alpinebits-housekeeping/impl/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-housekeeping</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alpinebits-housekeeping-impl</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <name>IDM AlpineBits housekeeping impl</name>
 

--- a/alpinebits-housekeeping/impl/src/test/java/it/bz/idm/alpinebits/housekeeping/middleware/utils/IntegrationTestingMiddleware.java
+++ b/alpinebits-housekeeping/impl/src/test/java/it/bz/idm/alpinebits/housekeeping/middleware/utils/IntegrationTestingMiddleware.java
@@ -10,12 +10,12 @@ import it.bz.idm.alpinebits.common.context.ResponseContextKeys;
 import it.bz.idm.alpinebits.middleware.Context;
 import it.bz.idm.alpinebits.middleware.Middleware;
 import it.bz.idm.alpinebits.middleware.MiddlewareChain;
-import it.bz.idm.alpinebits.servlet.ServletContextKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -37,17 +37,17 @@ public class IntegrationTestingMiddleware implements Middleware {
     public void handleContext(Context ctx, MiddlewareChain chain) {
         this.routingMiddleware.handleContext(ctx, chain);
 
-        HttpServletResponse response = ctx.getOrThrow(ServletContextKey.SERVLET_RESPONSE);
+        OutputStream os = ctx.getOrThrow(ResponseContextKeys.RESPONSE_CONTENT_STREAM);
 
-        this.tryToAddVersionToResponse(ctx, response);
-        this.tryToAddCapabilitiesToResponse(ctx, response);
+        this.tryToAddVersionToResponse(ctx, os);
+        this.tryToAddCapabilitiesToResponse(ctx, os);
     }
 
-    private void tryToAddVersionToResponse(Context ctx, HttpServletResponse response) {
+    private void tryToAddVersionToResponse(Context ctx, OutputStream os) {
         Optional<String> versionOptional = ctx.get(ResponseContextKeys.RESPONSE_VERSION);
         versionOptional.ifPresent(version -> {
             try {
-                response.getWriter().print(version);
+                os.write(version.getBytes(Charset.forName("UTF-8")));
             } catch (IOException e) {
                 LOG.error("Could not write response", e);
             }
@@ -55,11 +55,11 @@ public class IntegrationTestingMiddleware implements Middleware {
     }
 
 
-    private void tryToAddCapabilitiesToResponse(Context ctx, HttpServletResponse response) {
+    private void tryToAddCapabilitiesToResponse(Context ctx, OutputStream os) {
         Optional<Collection> capabilitiesOptional = ctx.get(ResponseContextKeys.RESPONSE_CAPABILITIES);
         capabilitiesOptional.ifPresent(capabilities -> {
             try {
-                response.getWriter().print(String.join(",", capabilities));
+                os.write(String.join(",", capabilities).getBytes(Charset.forName("UTF-8")));
             } catch (IOException e) {
                 LOG.error("Could not write response", e);
             }

--- a/alpinebits-housekeeping/pom.xml
+++ b/alpinebits-housekeeping/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-root</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alpinebits-housekeeping</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <packaging>pom</packaging>
     <name>IDM AlpineBits housekeeping</name>

--- a/alpinebits-middleware/api/pom.xml
+++ b/alpinebits-middleware/api/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-middleware</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alpinebits-middleware-api</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <name>IDM AlpineBits middleware API</name>
 

--- a/alpinebits-middleware/impl/pom.xml
+++ b/alpinebits-middleware/impl/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-middleware</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alpinebits-middleware-impl</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <name>IDM AlpineBits middleware impl</name>
 

--- a/alpinebits-middleware/pom.xml
+++ b/alpinebits-middleware/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-root</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alpinebits-middleware</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <packaging>pom</packaging>
     <name>IDM AlpineBits middleware</name>

--- a/alpinebits-routing/api/pom.xml
+++ b/alpinebits-routing/api/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-routing</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alpinebits-routing-api</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <name>IDM AlpineBits routing API</name>
 

--- a/alpinebits-routing/impl/pom.xml
+++ b/alpinebits-routing/impl/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-routing</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alpinebits-routing-impl</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <name>IDM AlpineBits routing impl</name>
 

--- a/alpinebits-routing/pom.xml
+++ b/alpinebits-routing/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-root</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alpinebits-routing</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <packaging>pom</packaging>
     <name>IDM AlpineBits routing</name>

--- a/alpinebits-server/api/pom.xml
+++ b/alpinebits-server/api/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-server</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alpinebits-server-api</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <name>IDM AlpineBits server API</name>
 </project>

--- a/alpinebits-server/impl/pom.xml
+++ b/alpinebits-server/impl/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-server</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alpinebits-server-impl</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <name>IDM AlpineBits server impl</name>
 

--- a/alpinebits-server/pom.xml
+++ b/alpinebits-server/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-root</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alpinebits-server</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <packaging>pom</packaging>
     <name>IDM AlpineBits server</name>

--- a/alpinebits-servlet/api/pom.xml
+++ b/alpinebits-servlet/api/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-servlet</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alpinebits-servlet-api</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <name>IDM AlpineBits servlet API</name>
 

--- a/alpinebits-servlet/api/src/main/java/it/bz/idm/alpinebits/servlet/ContextBuildingException.java
+++ b/alpinebits-servlet/api/src/main/java/it/bz/idm/alpinebits/servlet/ContextBuildingException.java
@@ -1,0 +1,28 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.servlet;
+
+import it.bz.idm.alpinebits.common.exception.AlpineBitsException;
+
+/**
+ * This exception is thrown if there was an error during context building.
+ */
+public class ContextBuildingException extends AlpineBitsException {
+
+    private static final int STATUS = 500;
+
+    /**
+     * Constructs a {@code ContextBuildingException} with the specified message and no
+     * root cause.
+     *
+     * @param msg the detail message
+     */
+    public ContextBuildingException(String msg, Throwable t) {
+        super(msg, STATUS, "Error while building context", t);
+    }
+
+}

--- a/alpinebits-servlet/impl/pom.xml
+++ b/alpinebits-servlet/impl/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-servlet</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alpinebits-servlet-impl</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <name>IDM AlpineBits servlet impl</name>
 

--- a/alpinebits-servlet/impl/src/main/java/it/bz/idm/alpinebits/servlet/impl/DefaultContextBuilder.java
+++ b/alpinebits-servlet/impl/src/main/java/it/bz/idm/alpinebits/servlet/impl/DefaultContextBuilder.java
@@ -7,13 +7,16 @@
 package it.bz.idm.alpinebits.servlet.impl;
 
 import it.bz.idm.alpinebits.common.context.RequestContextKey;
+import it.bz.idm.alpinebits.common.context.ResponseContextKeys;
 import it.bz.idm.alpinebits.middleware.Context;
 import it.bz.idm.alpinebits.middleware.impl.SimpleContext;
 import it.bz.idm.alpinebits.servlet.ContextBuilder;
+import it.bz.idm.alpinebits.servlet.ContextBuildingException;
 import it.bz.idm.alpinebits.servlet.ServletContextKey;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 /**
  * This is a default implementation for {@link ContextBuilder}.
@@ -37,6 +40,11 @@ public class DefaultContextBuilder implements ContextBuilder {
         ctx.put(ServletContextKey.SERVLET_REQUEST, request);
         ctx.put(ServletContextKey.SERVLET_RESPONSE, response);
         ctx.put(RequestContextKey.REQUEST_ID, requestId);
+        try {
+            ctx.put(ResponseContextKeys.RESPONSE_CONTENT_STREAM, response.getOutputStream());
+        } catch (IOException e) {
+            throw new ContextBuildingException("Error while building middleware context from request", e);
+        }
         return ctx;
     }
 

--- a/alpinebits-servlet/impl/src/main/java/it/bz/idm/alpinebits/servlet/impl/DefaultRequestExceptionHandler.java
+++ b/alpinebits-servlet/impl/src/main/java/it/bz/idm/alpinebits/servlet/impl/DefaultRequestExceptionHandler.java
@@ -77,7 +77,7 @@ public class DefaultRequestExceptionHandler implements RequestExceptionHandler {
      */
     private void sendError(HttpServletResponse response, int status, Exception e) throws IOException {
         response.setStatus(status);
-        response.getWriter().print(this.getErrorMessage(e));
+        response.getOutputStream().print(this.getErrorMessage(e));
     }
 
 }

--- a/alpinebits-servlet/impl/src/main/java/it/bz/idm/alpinebits/servlet/middleware/BasicAuthenticationMiddleware.java
+++ b/alpinebits-servlet/impl/src/main/java/it/bz/idm/alpinebits/servlet/middleware/BasicAuthenticationMiddleware.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import javax.servlet.http.HttpServletRequest;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.Base64;
 
 /**
@@ -76,11 +76,7 @@ public class BasicAuthenticationMiddleware implements Middleware {
      */
     private String[] extractAndDecodeHeader(String header) {
         byte[] base64Token;
-        try {
-            base64Token = header.substring(6).getBytes("UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new BasicAuthenticationException("Failed to decode basic authentication header string", e);
-        }
+        base64Token = header.substring(6).getBytes(Charset.forName("UTF-8"));
 
         byte[] decoded;
         try {
@@ -90,11 +86,7 @@ public class BasicAuthenticationMiddleware implements Middleware {
         }
 
         String token;
-        try {
-            token = new String(decoded, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new BasicAuthenticationException("Failed to build string from decoded basic authentication header string", e);
-        }
+        token = new String(decoded, Charset.forName("UTF-8"));
 
         int delim = token.indexOf(':');
 

--- a/alpinebits-servlet/impl/src/main/java/it/bz/idm/alpinebits/servlet/middleware/HousekeepingWriterMiddleware.java
+++ b/alpinebits-servlet/impl/src/main/java/it/bz/idm/alpinebits/servlet/middleware/HousekeepingWriterMiddleware.java
@@ -13,12 +13,13 @@ import it.bz.idm.alpinebits.middleware.Context;
 import it.bz.idm.alpinebits.middleware.Middleware;
 import it.bz.idm.alpinebits.middleware.MiddlewareChain;
 import it.bz.idm.alpinebits.servlet.ResponseWritingException;
-import it.bz.idm.alpinebits.servlet.ServletContextKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -82,12 +83,12 @@ public class HousekeepingWriterMiddleware implements Middleware {
     }
 
     private void writeResponse(Context ctx, String message) {
-        HttpServletResponse response = ctx.getOrThrow(ServletContextKey.SERVLET_RESPONSE);
+        OutputStream os = ctx.getOrThrow(ResponseContextKeys.RESPONSE_CONTENT_STREAM);
 
         String responseMessage = "OK:" + message;
         try {
             LOG.debug("Writing AlpineBits Housekeeping action response: {}", responseMessage);
-            response.getWriter().print(responseMessage);
+            os.write(responseMessage.getBytes(Charset.forName("UTF-8")));
         } catch (IOException e) {
             throw new ResponseWritingException(
                     "Error while writing Housekeeping action response. Response message" +

--- a/alpinebits-servlet/impl/src/main/java/it/bz/idm/alpinebits/servlet/middleware/MultipartFormDataParserMiddleware.java
+++ b/alpinebits-servlet/impl/src/main/java/it/bz/idm/alpinebits/servlet/middleware/MultipartFormDataParserMiddleware.java
@@ -20,11 +20,11 @@ import org.apache.commons.fileupload.FileItemStream;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.fileupload.util.Streams;
+import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -87,7 +87,7 @@ public class MultipartFormDataParserMiddleware implements Middleware {
         List<String> formParts = new ArrayList<>();
 
         String abAction = null;
-        OutputStream abRequest = null;
+        InputStream abRequest = null;
 
         // Parse the request
         try {
@@ -98,14 +98,12 @@ public class MultipartFormDataParserMiddleware implements Middleware {
                 formParts.add(name);
 
                 try (InputStream stream = item.openStream()) {
-
                     if (FORM_PART_ACTION.equalsIgnoreCase(name)) {
                         abAction = Streams.asString(stream, "UTF-8");
                     }
 
                     if (FORM_PART_REQUEST.equalsIgnoreCase(name)) {
-                        abRequest = new ByteArrayOutputStream();
-                        Streams.copy(stream, abRequest, true);
+                        abRequest = IOUtils.toBufferedInputStream(stream);
                     }
                 }
             }

--- a/alpinebits-servlet/impl/src/test/java/it/bz/idm/alpinebits/servlet/impl/AlpineBitsServletTest.java
+++ b/alpinebits-servlet/impl/src/test/java/it/bz/idm/alpinebits/servlet/impl/AlpineBitsServletTest.java
@@ -7,6 +7,7 @@
 package it.bz.idm.alpinebits.servlet.impl;
 
 import it.bz.idm.alpinebits.servlet.impl.utils.ResponseStatusSettingMiddleware;
+import it.bz.idm.alpinebits.servlet.impl.utils.ServletOutputStreamBuilder;
 import it.bz.idm.alpinebits.servlet.impl.utils.ThrowingMiddleware;
 import org.testng.annotations.Test;
 
@@ -14,7 +15,6 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.PrintWriter;
 import java.io.StringWriter;
 
 import static org.mockito.Mockito.*;
@@ -45,7 +45,7 @@ public class AlpineBitsServletTest {
         HttpServletResponse response = mock(HttpServletResponse.class);
 
         StringWriter stringWriter = new StringWriter();
-        when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
+        when(response.getOutputStream()).thenReturn(ServletOutputStreamBuilder.getServletOutputStream(stringWriter));
 
         AlpineBitsServlet servlet = new AlpineBitsServlet();
         servlet.init(config);
@@ -67,6 +67,8 @@ public class AlpineBitsServletTest {
 
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
+
+        when(response.getOutputStream()).thenReturn(ServletOutputStreamBuilder.getServletOutputStream(null));
 
         AlpineBitsServlet servlet = new AlpineBitsServlet();
         servlet.init(config);

--- a/alpinebits-servlet/impl/src/test/java/it/bz/idm/alpinebits/servlet/impl/DefaultContextBuilderTest.java
+++ b/alpinebits-servlet/impl/src/test/java/it/bz/idm/alpinebits/servlet/impl/DefaultContextBuilderTest.java
@@ -8,14 +8,19 @@ package it.bz.idm.alpinebits.servlet.impl;
 
 import it.bz.idm.alpinebits.common.context.RequestContextKey;
 import it.bz.idm.alpinebits.servlet.ContextBuilder;
+import it.bz.idm.alpinebits.servlet.ContextBuildingException;
 import it.bz.idm.alpinebits.servlet.ServletContextKey;
 import it.bz.idm.alpinebits.middleware.Context;
+import it.bz.idm.alpinebits.servlet.impl.utils.ServletOutputStreamBuilder;
 import org.testng.annotations.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import java.io.IOException;
+
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 /**
@@ -23,12 +28,27 @@ import static org.testng.Assert.assertEquals;
  */
 public class DefaultContextBuilderTest {
 
-    @Test
-    public void testFromRequest() {
+    @Test(expectedExceptions = ContextBuildingException.class)
+    public void testFromRequest_OutputStreamError() throws Exception {
         ContextBuilder builder = new DefaultContextBuilder();
 
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
+        when(response.getOutputStream()).thenThrow(new IOException("Throwing on response#getOutputStream()"));
+
+        String requestId = "REQUEST-ID";
+
+        builder.fromRequest(request, response, requestId);
+    }
+
+    @Test
+    public void testFromRequest() throws Exception {
+        ContextBuilder builder = new DefaultContextBuilder();
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(response.getOutputStream()).thenReturn(ServletOutputStreamBuilder.getServletOutputStream(null));
+
         String requestId = "REQUEST-ID";
 
         Context ctx = builder.fromRequest(request, response, requestId);

--- a/alpinebits-servlet/impl/src/test/java/it/bz/idm/alpinebits/servlet/impl/DefaultRequestExceptionHandlerTest.java
+++ b/alpinebits-servlet/impl/src/test/java/it/bz/idm/alpinebits/servlet/impl/DefaultRequestExceptionHandlerTest.java
@@ -8,12 +8,12 @@ package it.bz.idm.alpinebits.servlet.impl;
 
 import it.bz.idm.alpinebits.common.exception.AlpineBitsException;
 import it.bz.idm.alpinebits.middleware.RequiredContextKeyMissingException;
+import it.bz.idm.alpinebits.servlet.impl.utils.ServletOutputStreamBuilder;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.PrintWriter;
 import java.io.StringWriter;
 
 import static org.mockito.Mockito.*;
@@ -45,7 +45,7 @@ public class DefaultRequestExceptionHandlerTest {
         HttpServletResponse response = mock(HttpServletResponse.class);
 
         StringWriter stringWriter = new StringWriter();
-        when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
+        when(response.getOutputStream()).thenReturn(ServletOutputStreamBuilder.getServletOutputStream(stringWriter));
 
         DefaultRequestExceptionHandler handler = new DefaultRequestExceptionHandler();
 

--- a/alpinebits-servlet/impl/src/test/java/it/bz/idm/alpinebits/servlet/impl/utils/ServletOutputStreamBuilder.java
+++ b/alpinebits-servlet/impl/src/test/java/it/bz/idm/alpinebits/servlet/impl/utils/ServletOutputStreamBuilder.java
@@ -7,7 +7,6 @@
 package it.bz.idm.alpinebits.servlet.impl.utils;
 
 import javax.servlet.ServletOutputStream;
-import java.io.IOException;
 import java.io.StringWriter;
 
 /**

--- a/alpinebits-servlet/impl/src/test/java/it/bz/idm/alpinebits/servlet/impl/utils/ServletOutputStreamBuilder.java
+++ b/alpinebits-servlet/impl/src/test/java/it/bz/idm/alpinebits/servlet/impl/utils/ServletOutputStreamBuilder.java
@@ -1,0 +1,32 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.servlet.impl.utils;
+
+import javax.servlet.ServletOutputStream;
+import java.io.IOException;
+import java.io.StringWriter;
+
+/**
+ * This class provides builders for {@link ServletOutputStream}, used for testing.
+ */
+public class ServletOutputStreamBuilder {
+
+    /**
+     * Build a {@link ServletOutputStream} that writes the data to
+     * the provided {@link StringWriter}.
+     *
+     * @return a {@link ServletOutputStream}
+     */
+    public static ServletOutputStream getServletOutputStream(StringWriter sw) {
+        return new ServletOutputStream() {
+            @Override
+            public void write(int b) {
+                sw.write(b);
+            }
+        };
+    }
+}

--- a/alpinebits-servlet/impl/src/test/java/it/bz/idm/alpinebits/servlet/middleware/MultipartFormDataParserMiddlewareTest.java
+++ b/alpinebits-servlet/impl/src/test/java/it/bz/idm/alpinebits/servlet/middleware/MultipartFormDataParserMiddlewareTest.java
@@ -16,11 +16,12 @@ import it.bz.idm.alpinebits.servlet.MultipartFormDataParseException;
 import it.bz.idm.alpinebits.servlet.ServletContextKey;
 import it.bz.idm.alpinebits.servlet.UndefinedActionException;
 import it.bz.idm.alpinebits.servlet.impl.utils.MultipartFormDataRequestBuilder;
+import org.apache.commons.io.IOUtils;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import javax.servlet.http.HttpServletRequest;
-import java.io.OutputStream;
+import java.io.InputStream;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -90,8 +91,8 @@ public class MultipartFormDataParserMiddlewareTest {
         HttpServletRequest request = MultipartFormDataRequestBuilder.buildRequest(s);
 
         Context ctx = this.executeMiddleware(request);
-        OutputStream stream = ctx.getOrThrow(RequestContextKey.REQUEST_CONTENT_STREAM);
-        String alpineBitsRequest = stream.toString();
+        InputStream stream = ctx.getOrThrow(RequestContextKey.REQUEST_CONTENT_STREAM);
+        String alpineBitsRequest = IOUtils.toString(stream);
         assertEquals(alpineBitsRequest, MultipartFormDataRequestBuilder.ALPINEBITS_REQUEST_PARAM);
     }
 

--- a/alpinebits-servlet/pom.xml
+++ b/alpinebits-servlet/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-root</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>alpinebits-servlet</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <packaging>pom</packaging>
     <name>IDM AlpineBits servlet</name>

--- a/alpinebits-xml/api/pom.xml
+++ b/alpinebits-xml/api/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>it.bz.idm.alpinebits</groupId>
+        <artifactId>alpinebits-xml</artifactId>
+        <version>0.0.9</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>alpinebits-xml-api</artifactId>
+    <version>0.0.9</version>
+
+    <name>IDM AlpineBits XML API</name>
+
+    <properties>
+        <jaxb2-maven.version>2.2</jaxb2-maven.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>it.bz.idm.alpinebits</groupId>
+            <artifactId>alpinebits-common-api</artifactId>
+        </dependency>
+
+        <!-- testing -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <version>${jaxb2-maven.version}</version>
+                <configuration>
+                    <xjbSources>
+                        <xjbSource>src/main/resources/global.xjb</xjbSource>
+                    </xjbSources>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>alpinebits-2017-10</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/main/resources/alpinebits-2017-10.xsd</source>
+                            </sources>
+                            <packageName>it.bz.idm.alpinebits.xml.schema.v_2017_10</packageName>
+                            <clearOutputDir>false</clearOutputDir>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>alpinebits-2015-07b</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/main/resources/alpinebits-2015-07b.xsd</source>
+                            </sources>
+                            <packageName>it.bz.idm.alpinebits.xml.schema.v_2015_07b</packageName>
+                            <clearOutputDir>false</clearOutputDir>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <!--
+                    This plugin is used to replace Object class definitions with String
+                    classes in the generated AlpineBits source files. This is accomplished
+                    by simple string replacement.
+
+                    The source files are generated using the jaxb2-maven-plugin, which in
+                    turn invokes xjc.
+
+                    There seems to be no easy way to configure xjc in such a way, that
+                    elements with an empty definition in the XSD file (see below for example)
+                    get mapped to String. Unfortunately, this is necessary, since
+                    JAXB throws Exceptions when confronted with Object.class
+
+                    Example (see alpinebits-2017-10.xsd, line 330):
+                    By default, the definition <xs:element name="Success"/> will be converted
+                    to Object.class. JAXB throws an Exceptions when confronted with Object.class,
+                    therefor that type is changed to String.class by replacing all occurrences
+                    of "Object " with "String " in the generated source files.
+                -->
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <ignoreMissingFile>false</ignoreMissingFile>
+                    <includes>
+                        <include>
+                            ${project.build.directory}/generated-sources/jaxb/it/bz/idm/alpinebits/xml/schema/**/*.java
+                        </include>
+                    </includes>
+                    <replacements>
+                        <replacement>
+                            <token xml:space="preserve">Object </token>
+                            <value xml:space="preserve">String </value>
+                        </replacement>
+                    </replacements>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/alpinebits-xml/api/src/main/java/it/bz/idm/alpinebits/xml/InvalidSchemaException.java
+++ b/alpinebits-xml/api/src/main/java/it/bz/idm/alpinebits/xml/InvalidSchemaException.java
@@ -1,0 +1,30 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml;
+
+import it.bz.idm.alpinebits.common.exception.AlpineBitsException;
+
+/**
+ * This exception is thrown if an XML validation schema (XSD/RNG)
+ * could not be created.
+ */
+public class InvalidSchemaException extends AlpineBitsException {
+
+    public static final int STATUS = 500;
+
+    /**
+     * Constructs a {@link InvalidSchemaException} with the specified message,
+     * root cause and {@link InvalidSchemaException#STATUS}.
+     *
+     * @param msg the detail message
+     * @param t the root cause
+     */
+    public InvalidSchemaException(String msg, Throwable t) {
+        super(msg, InvalidSchemaException.STATUS, t);
+    }
+
+}

--- a/alpinebits-xml/api/src/main/java/it/bz/idm/alpinebits/xml/ObjectToXmlConverter.java
+++ b/alpinebits-xml/api/src/main/java/it/bz/idm/alpinebits/xml/ObjectToXmlConverter.java
@@ -1,0 +1,30 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml;
+
+import java.io.OutputStream;
+
+/**
+ * This interfaces defines methods for object-to-XML conversions.
+ *
+ * @param <T> the object type
+ */
+public interface ObjectToXmlConverter<T> {
+
+    /**
+     * Try to convert <code>objectToConvert</code> to an XML and write
+     * that XML to the given {@link OutputStream}.
+     *
+     * @param objectToConvert this object will be converted to XML
+     * @param os              an {@link OutputStream} where the converted XML
+     *                        will be written to
+     * @throws XmlConversionException if the conversion was not successful
+     */
+
+    void toXml(T objectToConvert, OutputStream os);
+
+}

--- a/alpinebits-xml/api/src/main/java/it/bz/idm/alpinebits/xml/XmlConversionException.java
+++ b/alpinebits-xml/api/src/main/java/it/bz/idm/alpinebits/xml/XmlConversionException.java
@@ -1,0 +1,42 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml;
+
+import it.bz.idm.alpinebits.common.exception.AlpineBitsException;
+
+/**
+ * This exception is thrown if there was an error during XML marshalling/unmarshalling.
+ */
+public class XmlConversionException extends AlpineBitsException {
+
+    public static final int STATUS = 500;
+
+    /**
+     * Constructs a {@link XmlConversionException} with the specified message,
+     * code and root cause. The response message
+     * sent to the client is the same as <code>msg</code>.
+     *
+     * @param msg the detail message
+     * @param t the root cause
+     */
+    public XmlConversionException(String msg, int code, Throwable t) {
+        super(msg, code, msg, t);
+    }
+
+    /**
+     * Constructs a {@link XmlConversionException} with the specified message,
+     * root cause and {@link XmlConversionException#STATUS}. The response message
+     * sent to the client is the same as <code>msg</code>.
+     *
+     * @param msg the detail message
+     * @param t the root cause
+     */
+    public XmlConversionException(String msg, Throwable t) {
+        super(msg, XmlConversionException.STATUS, msg, t);
+    }
+
+}

--- a/alpinebits-xml/api/src/main/java/it/bz/idm/alpinebits/xml/XmlToObjectConverter.java
+++ b/alpinebits-xml/api/src/main/java/it/bz/idm/alpinebits/xml/XmlToObjectConverter.java
@@ -1,0 +1,32 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml;
+
+import java.io.InputStream;
+
+/**
+ * This interfaces defines methods for XML-to-object conversions.
+ *
+ * @param <T> the object type
+ */
+public interface XmlToObjectConverter<T> {
+
+    /**
+     * Try to convert the content of the given {@link InputStream} to an
+     * object of type <code>T</code>. The InputStream must provide a
+     * valid XML document.
+     *
+     * @param is an {@link InputStream} providing a valid XML
+     *           document, that should be converted to an instance
+     *           of type <code>T</code>
+     * @return an instance of type <code>T</code> as a result of
+     * XML-to-object conversion
+     * @throws XmlConversionException if the conversion was not successful
+     */
+    T toObject(InputStream is);
+
+}

--- a/alpinebits-xml/api/src/main/java/it/bz/idm/alpinebits/xml/xmladapter/LocalDateAdapter.java
+++ b/alpinebits-xml/api/src/main/java/it/bz/idm/alpinebits/xml/xmladapter/LocalDateAdapter.java
@@ -1,0 +1,25 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.xmladapter;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import java.time.LocalDate;
+
+/**
+ * XML adapter to convert xs:date values to {@link LocalDate}.
+ */
+public class LocalDateAdapter extends XmlAdapter<String, LocalDate> {
+    @Override
+    public LocalDate unmarshal(String v) {
+        return LocalDate.parse(v);
+    }
+
+    @Override
+    public String marshal(LocalDate v) {
+        return v != null ? v.toString() : null;
+    }
+}

--- a/alpinebits-xml/api/src/main/java/it/bz/idm/alpinebits/xml/xmladapter/ZonedDateTimeAdapter.java
+++ b/alpinebits-xml/api/src/main/java/it/bz/idm/alpinebits/xml/xmladapter/ZonedDateTimeAdapter.java
@@ -1,0 +1,26 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.xmladapter;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * XML adapter to convert xs:dateTime values to {@link ZonedDateTime}.
+ */
+public class ZonedDateTimeAdapter extends XmlAdapter<String, ZonedDateTime> {
+    @Override
+    public ZonedDateTime unmarshal(String v) {
+        return ZonedDateTime.parse(v, DateTimeFormatter.ISO_ZONED_DATE_TIME);
+    }
+
+    @Override
+    public String marshal(ZonedDateTime v) {
+        return v != null ? v.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME) : null;
+    }
+}

--- a/alpinebits-xml/api/src/main/resources/alpinebits-2015-07b.xsd
+++ b/alpinebits-xml/api/src/main/resources/alpinebits-2015-07b.xsd
@@ -1,0 +1,1987 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2015-07b
+     http://www.alpinebits.org/
+
+     W3C XML Schema file
+
+     changelog:
+
+    v. 2015-07b 1.4 - weaken the schema for Inventory (to prepare for upcoming release that will support Inventory deltas):
+
+                      - the RoomAmenityCode attribute becomes optional to allow empty Amenity elements 
+                      - the MultimediaDescription element can be empty
+
+    v. 2015-07b 1.3 - RatePlans > RatePlan > Description > TextFormat can now also be "HTML" (besides "PlainText")
+
+    v. 2015-07b 1.2 - added optional attributes RatePlanID and RatePlanQualifier to RatePlan
+                      for the new OTA_HotelRatePlanNotif_accept_RatePlanJoin capability
+
+    v. 2015-07b 1.1 - added def_invTypeCode_string type (string with up to 8 chars) used for the following attributes that identify room categories:
+
+                      FreeRooms:     OTA_HotelAvailNotifRQ -> AvailStatusMessages -> AvailStatusMessage -> StatusApplicationControl -> InvTypeCode
+                      GuestRequests: OTA_ResRetrieveRS -> ReservationList -> HotelReservation -> RoomStays -> RoomStay -> RoomTypes > RoomType -> RoomTypeCode
+                      Inventory:     OTA_HotelDescriptiveContentNotifRQ -> HotelDescriptiveContents -> HotelDescriptiveContent -> FacilityInfo -> GuestRooms -> GuestRoom -> Code
+                      RatePlan:      OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> BookingRules -> BookingRules -> Code
+                      RatePlan:      OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Rates -> Rate -> InvTypeCode
+
+                      (derived from Lukas Braun's pull request)
+
+    v. 2015-07b 1.0 - RatePlans > RatePlan > Rates > Rate > BaseByGuestAmts > AmountAfterTax
+                      must be > 0.0 (was: >= 0.0)
+
+     v. 2015-07 2.9 - Inventory: added a missing maxOccurs="unbounded" to the ImageItem
+
+     v. 2015-07 2.8 - Inventory: reconciled with the definitions given in the updated document
+
+     v. 2015-07 2.7 - changes to Inventory: removed the old Inventory, added MaxChildOccupancy to GuestRoom,
+                      made some of the attributes mandatory, formating changes
+
+     v. 2015-07 2.6 - made sub-elements of HotelReservation > ... > Customer > Address {0,1} optional
+
+     v. 2015-07 2.5 - added a choice of 'Modify' for ResStatusValue
+
+     v. 2015-07 2.4 - added MinCount attribute to Offer>>Guest
+
+     v. 2015-07 2.3 - changes to Supplement: a few attributes are removed and many attributes are made optional
+
+     v. 2015-07 2.2 - RatePlans/Supplements: changed format of description
+
+     v. 2015-07 2.1 - GuestRequests: ResGuests >> Customer: attributes Gender and Language are now optional
+
+     v. 2015-07 2.0 - allow Warnings in OTA_NotifReportRQ messages
+
+     v. 2015-07 1.9 - GuestRequests: use CardNumber -> PlainText instead of the Remark attribute of
+                      PaymentCard under Guarantee; add BasicPropertyInfo element at the end of the 
+                      ResGlobalInfo block for OTA-2015A compatiblity
+
+     v. 2015-07 1.8 - added section for New Inventory (exact name pending)
+
+     v. 2015-07 1.7 - allowed more than one HotelReservationID
+
+     v. 2015-07 1.6 - RatePlans: allow optional PrerequisiteInventory element under Supplement element
+
+     v. 2015-07 1.5 - Inventory: removed Amenities and added optional Room -> RoomTypeCode
+
+     v. 2015-07 1.4 - HotelReservationID -> ResID_Type is not limited to 13 anymore
+
+     v. 2015-07 1.3 - new section in RoomStays: Guarantee -> GuaranteesAccepted -> GuaranteeAccepted -> PaymentCard
+
+     v. 2015-07 1.2 - new section in ResGlobalInfo: Profiles -> ProfileInfo -> Profile -> CompanyInfo
+
+     v. 2015-07 1.1 - HotelReservation > RoomStays > RoomStay > RoomTypes > RoomType is now
+                      mandatory and has a new optional attribute RoomClassificationCode
+
+     v. 2015-07 1.0 - OTA_NotifReportRS besides Success, now also allows Error responses 
+
+     v. 2014-04 1.6 - [fixed] InvCode attribute in Supplement changed from def_int_ge0 to def_nonempty_string
+
+     v. 2014-04 1.5 - [strictness improvement] made NumberOfGuests attribute mandatory
+
+     v. 2014-04 1.4 - [fixed] RatePlans: optional Rate attributes RateTimeUnit and UnitMultiplier added
+
+     v. 2014-04 1.3 - [fixed] GuestRequests: ReservationsList can be empy
+
+     v. 2014-04 1.2 - follow-up to fix 1.1 that allowed empty AvailStatusMessages elements too
+                      (reverted)
+
+     v. 2014-04 1.1 - empty AvailStatusMessage elements in FreeRooms now allowed
+                      (see https://groups.google.com/d/msg/alpinebits/B-orBE9eJCk/rKyIYbNBFNoJ )
+                    - Version and TimeStamp also added to OTA_NotifReportRS 
+                      (see https://groups.google.com/d/msg/alpinebits/jwaPC3XAafo/yDDYCkpNPYEJ )
+
+     v. 2014-04 1.0 - major rewrite for 2014-04
+
+     previous changelogs:
+
+     v. 2013-04 1.0 - the XML schema is now flattened into this single file;
+                      some improvements by Martin;
+                      added optional RatePlanCode attribute to RatePlan;
+                      removed restrictions on the form of the ID attribute in UniqueID
+
+     W3C XML Schema for OTA_HotelAvailNotifRQ:
+     v. 2013-04 1.0 - added MessageContentCode attribute for delta messages
+     v. 2012-05 1.2 - changed Thu -> Thur and Wed -> Weds for OTA compatibility
+     v. 2012-05 1.1 - added optional TimeStamp attribute for OTA_HotelAvailNotifRQ to be compatible with AlpineBits 2011-11 documents
+     v. 2012-05 1.0
+      
+     W3C XML Schema for OTA_HotelAvailNotifRS:
+     v. 2013-04 1.0 - added warnings
+     v. 2012-05 1.0
+  
+     W3C XML Schema for OTA_ReadRQ:
+     v. 2012-05 1.0
+   
+     W3C XML Schema for OTA_ResRetrieveRS:
+     v. 2013-04 1.0 - simplified the definition of GuestCounts for XSD conformance,
+                      moved UniqueID and RatePlans elements to common to support schema flattening
+     v. 2012-05 1.0
+  
+     W3C XML Schema for OTA_HotelRatePlanNotifRQ:
+     v. 2013-04 1.0 - removed def_plaintext and simplified def_rate_plan to fix an issue with the parsing of the schema,
+                      moved UniqueID and RatePlans elements to common
+     v. 2012-05 1.2 - changed Thu -> Thur and Wed -> Weds for OTA compatibility
+     v. 2012-05 1.0
+  
+     W3C XML Schema for OTA_HotelRatePlanNotifRS:
+     v. 2013-04 1.0 - added warnings
+     v. 2012-05 1.0
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           targetNamespace="http://www.opentravel.org/OTA/2003/05"
+           xmlns="http://www.opentravel.org/OTA/2003/05">
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * FreeRooms                                                                     -->
+  <!-- ******************************************************************************* -->
+
+  <!-- FreeRooms: OTA_HotelAvailNotifRQ -->
+
+  <xs:element name="OTA_HotelAvailNotifRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <!-- UniqueID {0,1} -->
+
+        <xs:element name="UniqueID" minOccurs="0">
+          <xs:complexType>
+            <xs:attribute name="Type" use="required">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="16"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="ID" use="required" type="xs:string"/> <!-- an ID is required by OTA, we ignore the value -->
+            <xs:attribute name="Instance" use="required">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="CompleteSet"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+
+        <!-- AvailStatusMessages {1} -->
+
+        <xs:element name="AvailStatusMessages">
+          <xs:complexType>
+            <xs:sequence>
+
+              <!-- AvailStatusMessages > AvailStatusMessage (1,} -->
+              
+              <xs:element name="AvailStatusMessage" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <!-- AvailStatusMessages > AvailStatusMessage > StatusApplicationControl {0,1} -->
+
+                    <xs:element name="StatusApplicationControl" minOccurs="0">
+                      <xs:complexType>
+                        <xs:attribute name="Start"        use="required" type="def_date"/>
+                        <xs:attribute name="End"          use="required" type="def_date"/>
+                        <xs:attribute name="InvTypeCode"                 type="def_invTypeCode_string"/>
+                        <xs:attribute name="InvCode"                     type="def_nonempty_string"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                  </xs:sequence>
+                  <xs:attribute name="BookingLimitMessageType">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="SetLimit"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="BookingLimit" type="def_int_ge0"/>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+            <xs:attribute name="HotelCode" type="def_nonempty_string"/>
+            <xs:attribute name="HotelName" type="def_nonempty_string"/>
+          </xs:complexType> 
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- FreeRooms: OTA_HotelAvailNotifRS -->
+
+  <xs:element name="OTA_HotelAvailNotifRS">
+    <xs:complexType>
+      <xs:group   ref="def_generic_response"/>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * GuestRequests                                                                 -->
+  <!-- ******************************************************************************* -->
+
+  <!-- GuestRequests: OTA_ReadRQ -->
+
+  <xs:element name="OTA_ReadRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <xs:element name="ReadRequests">
+          <xs:complexType>
+            <xs:sequence>
+
+              <xs:element name="HotelReadRequest">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <xs:element name="SelectionCriteria" minOccurs="0">
+                      <xs:complexType>
+                        <xs:attribute name="Start" use="required" type="def_datetime"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                  </xs:sequence>
+                  <xs:attribute name="HotelCode" type="def_nonempty_string"/> 
+                  <xs:attribute name="HotelName" type="def_nonempty_string"/>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- GuestRequests: OTA_ResRetrieveRS -->
+
+  <xs:element name="OTA_ResRetrieveRS">
+    <xs:complexType>
+
+      <xs:choice>
+
+        <!-- choice: Errors {1} -->
+
+        <xs:element name="Errors">
+          <xs:complexType>
+            <xs:sequence>
+   
+              <!-- Errors > Error {1,} -->
+   
+              <xs:element name="Error" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type" use="required">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="13"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="Code" use="required" type="def_int_ge0"/>
+                </xs:complexType>
+              </xs:element>
+   
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:sequence>
+
+          <!-- choice: Success {1} + ReservationsList {1} -->
+
+          <xs:element name="Success"/>
+
+          <xs:element name="ReservationsList">
+            <xs:complexType>
+              <xs:sequence>
+
+               <!-- HotelReservation {0,} -->
+ 
+                <xs:element name="HotelReservation" maxOccurs="unbounded" minOccurs="0">
+                  <xs:complexType>
+                    <xs:sequence>
+
+                      <!-- HotelReservation > UniqueID {1} -->
+
+                      <xs:element name="UniqueID">
+                        <xs:complexType>
+                          <xs:attribute name="Type" use="required">
+                            <xs:simpleType>
+                              <xs:restriction base="xs:string">
+                                <xs:enumeration value="14"/>
+                                <xs:enumeration value="15"/>
+                              </xs:restriction>
+                            </xs:simpleType>
+                          </xs:attribute>
+                          <xs:attribute name="ID" use="required" type="def_nonempty_string"/>
+                        </xs:complexType>
+                      </xs:element>
+
+                      <!-- HotelReservation > RoomStays {0,1} -->
+
+                      <xs:element name="RoomStays" minOccurs="0">
+                        <xs:complexType>
+                          <xs:sequence>
+
+                            <!-- HotelReservation > RoomStays > RoomStay {1,} -->
+
+                            <xs:element name="RoomStay" maxOccurs="unbounded">
+                              <xs:complexType>
+                                <xs:sequence>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > RoomTypes {0,1} -->
+
+                                  <xs:element name="RoomTypes">
+                                    <xs:complexType>
+                                      <xs:sequence>
+
+                                        <!-- HotelReservation > RoomStays > RoomStay > RoomTypes > RoomType {1} -->
+
+                                        <xs:element name="RoomType">
+                                          <xs:complexType>
+                                            <xs:attribute name="RoomTypeCode"           type="def_invTypeCode_string"/>
+                                            <xs:attribute name="RoomClassificationCode" type="def_int_ge0"/>
+                                          </xs:complexType>
+                                        </xs:element>
+
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > RatePlans {0,1} -->
+
+                                  <xs:element name="RatePlans" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:sequence>
+
+                                        <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan {1} -->
+
+                                        <xs:element name="RatePlan">
+                                          <xs:complexType>
+                                            <xs:sequence>
+
+                                              <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan > MealsIncluded {0,1} -->
+
+                                              <xs:element name="MealsIncluded" minOccurs="0">
+                                                <xs:complexType>
+                                                  <xs:attribute name="MealPlanIndicator" use="required">
+                                                    <xs:simpleType>
+                                                      <xs:restriction base="xs:string">
+                                                        <xs:enumeration value="1"/>
+                                                        <xs:enumeration value="true"/>
+                                                      </xs:restriction>
+                                                    </xs:simpleType>
+                                                  </xs:attribute>
+                                                  <xs:attribute name="MealPlanCodes" use="required">
+                                                    <xs:simpleType>
+                                                      <xs:restriction base="xs:string">
+                                                        <xs:enumeration value="1"/>
+                                                        <xs:enumeration value="3"/>
+                                                        <xs:enumeration value="10"/>
+                                                        <xs:enumeration value="12"/>
+                                                        <xs:enumeration value="14"/>
+                                                      </xs:restriction>
+                                                    </xs:simpleType>
+                                                  </xs:attribute>
+                                                </xs:complexType>
+                                              </xs:element>
+
+                                            </xs:sequence>
+                                            <xs:attribute name="RatePlanCode" type="def_nonempty_string"/>
+                                          </xs:complexType>
+                                        </xs:element>
+
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > GuestCounts {0,1} -->
+
+                                  <xs:element name="GuestCounts" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:sequence>
+
+                                        <!-- HotelReservation > RoomStays > RoomStay > GuestCounts > GuestCount {1,} -->
+
+                                        <xs:element name="GuestCount" maxOccurs="unbounded">
+                                          <xs:complexType>
+                                            <xs:attribute name="Count" use="required" type="def_int_gt0"/>
+                                            <xs:attribute name="Age"                  type="def_int_ge0"/>
+                                          </xs:complexType>
+                                        </xs:element>
+
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > TimeSpan {1} -->
+
+                                  <xs:element name="TimeSpan">
+                                    <xs:complexType>
+                                      <xs:sequence>
+
+                                        <!-- HotelReservation > RoomStays > RoomStay > TimeSpan > StartDateWindow {0,1} -->
+
+                                        <xs:element name="StartDateWindow" minOccurs="0">
+                                          <xs:complexType>
+                                            <xs:attribute name="EarliestDate" use="required" type="def_date"/>
+                                            <xs:attribute name="LatestDate"   use="required" type="def_date"/>
+                                          </xs:complexType>
+                                        </xs:element>
+
+                                      </xs:sequence>
+                                      <xs:attribute name="Start" type="def_date"/>
+                                      <xs:attribute name="End"   type="def_date"/>
+                                      <xs:attribute name="Duration">
+                                        <xs:simpleType>
+                                          <xs:restriction base="xs:string">
+                                            <xs:pattern value="P[0-9]+N"/>
+                                          </xs:restriction>
+                                        </xs:simpleType>
+                                      </xs:attribute>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > Guarantee {0,1} -->
+
+                                  <xs:element name="Guarantee" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="GuaranteesAccepted">
+                                          <xs:complexType>
+                                            <xs:sequence>
+                                              <xs:element name="GuaranteeAccepted">
+                                                <xs:complexType>
+                                                  <xs:sequence>
+                                      
+                                                    <xs:element name="PaymentCard">
+                                                      <xs:complexType>
+                                                        <xs:sequence>
+                                                          <xs:element name="CardHolderName" type="def_nonempty_string"/>
+                                                          <xs:element name="CardNumber">
+                                                            <xs:complexType>
+                                                              <xs:sequence>
+                                                                <xs:element name="PlainText" type="def_nonempty_string"/>
+                                                              </xs:sequence>
+                                                            </xs:complexType>
+                                                          </xs:element>
+                                                        </xs:sequence>
+                                                        <xs:attribute name="CardCode" use="required">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="[A-Z][A-Z]?"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                        <xs:attribute name="ExpireDate" use="required">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="[0-9][0-9][0-9][0-9]"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                      </xs:complexType>
+                                                    </xs:element>
+                                      
+                                                  </xs:sequence>
+                                                </xs:complexType>
+                                              </xs:element>
+                                            </xs:sequence>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > Total {0,1} -->
+
+                                  <xs:element name="Total" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:attribute name="AmountAfterTax" use="required" type="def_decimal_ge0"/>
+                                      <xs:attribute name="CurrencyCode"   use="required" type="def_nonempty_string"/>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+
+                      <!-- HotelReservation > ResGuests {0, 1} -->
+
+                      <xs:element name="ResGuests" minOccurs="0">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="ResGuest">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="Profiles">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="ProfileInfo">
+                                          <xs:complexType>
+                                            <xs:sequence>
+                                              <xs:element name="Profile">
+                                                <xs:complexType>
+                                                  <xs:sequence>
+
+                                                    <!-- HotelReservation > ... > Customer {1} -->
+
+                                                    <xs:element name="Customer">
+                                                      <xs:complexType>
+                                                        <xs:sequence>
+
+                                                          <!-- HotelReservation > ... > Customer > PersonName {1} -->
+
+                                                          <xs:element name="PersonName">
+                                                            <xs:complexType>
+                                                              <xs:sequence>
+                                                                <xs:element name="NamePrefix" minOccurs="0" type="def_nonempty_string"/>
+                                                                <xs:element name="GivenName"                type="def_nonempty_string"/>
+                                                                <xs:element name="Surname"                  type="def_nonempty_string"/>
+                                                                <xs:element name="NameTitle"  minOccurs="0" type="def_nonempty_string"/>
+                                                              </xs:sequence>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                          <!-- HotelReservation > ... > Customer > Telephone {0,} -->
+
+                                                          <xs:element name="Telephone" minOccurs="0" maxOccurs="unbounded">
+                                                            <xs:complexType>
+                                                              <xs:attribute name="PhoneTechType" use="required">
+                                                                <xs:simpleType>
+                                                                  <xs:restriction base="xs:string">
+                                                                    <xs:pattern value="(1|3|5)"/>
+                                                                  </xs:restriction>
+                                                                </xs:simpleType>
+                                                              </xs:attribute>
+                                                              <xs:attribute name="PhoneNumber" use="required">
+                                                                <xs:simpleType>
+                                                                  <xs:restriction base="xs:string">
+                                                                    <xs:pattern value="\+?[0-9]+"/>
+                                                                  </xs:restriction>
+                                                                </xs:simpleType>
+                                                              </xs:attribute>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                          <!-- HotelReservation > ... > Customer > Email {0,1} -->
+
+                                                          <xs:element name="Email" minOccurs="0">
+                                                            <xs:complexType>
+                                                              <xs:simpleContent>
+                                                                <xs:extension base="def_email_string"> 
+                                                                  <xs:attribute name="Remark">
+                                                                    <xs:simpleType>
+                                                                      <xs:restriction base="xs:string">
+                                                                        <xs:pattern value="newsletter:(no|yes)"/>
+                                                                      </xs:restriction>
+                                                                    </xs:simpleType>
+                                                                  </xs:attribute>
+                                                                </xs:extension>
+                                                              </xs:simpleContent>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                          <!-- HotelReservation > ... > Customer > Address {0,1} -->
+
+                                                          <xs:element name="Address" minOccurs="0">
+                                                            <xs:complexType>
+                                                              <xs:sequence>
+                                                                <xs:element name="AddressLine"  type="def_nonempty_string" minOccurs="0"/>
+                                                                <xs:element name="CityName"     type="def_nonempty_string" minOccurs="0"/>
+                                                                <xs:element name="PostalCode"   type="def_nonempty_string" minOccurs="0"/>
+                                                                <xs:element name="CountryName"  minOccurs="0">
+                                                                  <xs:complexType>
+                                                                    <xs:attribute name="Code" use="required">
+                                                                      <xs:simpleType>
+                                                                        <xs:restriction base="xs:string">
+                                                                          <xs:pattern value="[A-Z][A-Z]"/>
+                                                                        </xs:restriction>
+                                                                      </xs:simpleType>
+                                                                    </xs:attribute>
+                                                                  </xs:complexType>
+                                                                </xs:element>
+                                                              </xs:sequence>
+                                                              <xs:attribute name="Remark">
+                                                                <xs:simpleType>
+                                                                  <xs:restriction base="xs:string">
+                                                                    <xs:pattern value="catalog:(no|yes)"/>
+                                                                  </xs:restriction>
+                                                                </xs:simpleType>
+                                                              </xs:attribute>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                        </xs:sequence>
+                                                        <xs:attribute name="Gender">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="(Unknown|Male|Female)"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                        <xs:attribute name="BirthDate" type="def_date"/>
+                                                        <xs:attribute name="Language">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:language">
+                                                              <xs:pattern value="[a-z][a-z]"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                      </xs:complexType>
+                                                    </xs:element>
+
+                                                  </xs:sequence>
+                                                </xs:complexType>
+                                              </xs:element>
+                                            </xs:sequence>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+
+                      <!-- HotelReservation > ResGlobalInfo {0,1} -->
+
+                      <xs:element name="ResGlobalInfo" minOccurs="0">
+                        <xs:complexType>
+                          <xs:sequence>
+
+                            <!-- HotelReservation > ResGlobalInfo > Comments {0,1} -->
+
+                            <xs:element name="Comments" minOccurs="0">
+                              <xs:complexType>
+                                <xs:sequence>
+
+                                 <!-- HotelReservation > ResGlobalInfo > Comments {1,2} -->
+
+                                  <xs:element name="Comment" maxOccurs="2">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:choice>
+
+                                          <xs:element name="ListItem" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                              <xs:simpleContent>
+                                                <xs:extension base="def_nonempty_string">
+                                                  <xs:attribute name="ListItem" use="required" type="def_int_ge0"/>
+                                                  <xs:attribute name="Language" use="required">
+                                                    <xs:simpleType>
+                                                      <xs:restriction base="xs:language">
+                                                        <xs:pattern value="[a-z][a-z]"/>
+                                                      </xs:restriction>
+                                                    </xs:simpleType>
+                                                  </xs:attribute>
+                                                </xs:extension>
+                                              </xs:simpleContent>
+                                            </xs:complexType>
+                                          </xs:element>
+
+                                          <xs:element name="Text" minOccurs="0" type="def_nonempty_string"/>
+
+                                        </xs:choice>
+                                      </xs:sequence>
+                                      <xs:attribute name="Name" use="required">
+                                        <xs:simpleType>
+                                          <xs:restriction base="xs:string">
+                                            <xs:enumeration value="included services"/>
+                                            <xs:enumeration value="customer comment"/>
+                                          </xs:restriction>
+                                        </xs:simpleType>
+                                      </xs:attribute>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+
+                            <!-- HotelReservation > ResGlobalInfo > CancelPenalties {0,1} -->
+
+                            <xs:element name="CancelPenalties" minOccurs="0">
+                              <xs:complexType>        
+                                <xs:sequence>         
+                                  <xs:element name="CancelPenalty">
+                                    <xs:complexType>  
+                                      <xs:sequence>   
+                                        <xs:element name="PenaltyDescription">
+                                          <xs:complexType>
+                                            <xs:sequence>
+                                              <xs:element name="Text" type="def_nonempty_string"/>
+                                            </xs:sequence>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>  
+                                    </xs:complexType> 
+                                  </xs:element>       
+                                </xs:sequence>        
+                              </xs:complexType>       
+                            </xs:element>             
+
+                            <!-- HotelReservation > ResGlobalInfo > HotelReservationIDs {0,1} -->
+
+                            <xs:element name="HotelReservationIDs" minOccurs="0">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="HotelReservationID" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                      <xs:attribute name="ResID_Type" use="required" type="def_int_gt0"/>
+                                      <xs:attribute name="ResID_Value"               type="def_nonempty_string"/>
+                                      <xs:attribute name="ResID_Source"              type="def_nonempty_string"/>
+                                      <xs:attribute name="ResID_SourceContext"       type="def_nonempty_string"/>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+
+                            <!-- HotelReservation > ResGlobalInfo > Profiles {0,1} -->
+
+                            <xs:element name="Profiles" minOccurs="0">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="ProfileInfo">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="Profile">
+                                          <xs:complexType>
+                                            <xs:sequence>
+                                              <xs:element name="CompanyInfo">
+                                                <xs:complexType>
+                                                  <xs:sequence>
+
+                                                    <xs:element name="CompanyName">
+                                                      <xs:complexType>
+                                                        <xs:simpleContent>
+                                                          <xs:extension base="def_nonempty_string"> 
+                                                            <xs:attribute name="Code"        use="required" type="def_nonempty_string"/>
+                                                            <xs:attribute name="CodeContext" use="required" type="def_nonempty_string"/>
+                                                          </xs:extension>
+                                                        </xs:simpleContent>
+                                                      </xs:complexType>
+                                                    </xs:element>
+
+                                                    <xs:element name="AddressInfo" minOccurs="0">
+                                                      <xs:complexType>
+                                                        <xs:sequence>
+                                                          <xs:element name="AddressLine"  type="def_nonempty_string"/>
+                                                          <xs:element name="CityName"     type="def_nonempty_string"/>
+                                                          <xs:element name="PostalCode"   type="def_nonempty_string"/>
+                                                          <xs:element name="CountryName">
+                                                            <xs:complexType>
+                                                              <xs:attribute name="Code" use="required">
+                                                                <xs:simpleType>
+                                                                  <xs:restriction base="xs:string">
+                                                                    <xs:pattern value="[A-Z][A-Z]"/>
+                                                                  </xs:restriction>
+                                                                </xs:simpleType>
+                                                              </xs:attribute>
+                                                            </xs:complexType>
+                                                          </xs:element>
+                                                        </xs:sequence>
+                                                      </xs:complexType>
+                                                    </xs:element>
+
+                                                    <xs:element name="TelephoneInfo" minOccurs="0">
+                                                      <xs:complexType>
+                                                        <xs:attribute name="PhoneTechType" use="required">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="(1|3|5)"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                        <xs:attribute name="PhoneNumber" use="required">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="\+?[0-9]+"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                      </xs:complexType>
+                                                    </xs:element>
+
+                                                    <xs:element name="Email" minOccurs="0" type="def_nonempty_string"/>
+
+                                                  </xs:sequence>
+                                                </xs:complexType>
+                                              </xs:element>
+                                            </xs:sequence>
+                                            <xs:attribute name="ProfileType" use="required">
+                                              <xs:simpleType>
+                                                <xs:restriction base="xs:string">
+                                                  <xs:enumeration value="4"/>
+                                                </xs:restriction>
+                                              </xs:simpleType>
+                                            </xs:attribute>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+
+
+                            <xs:element name="BasicPropertyInfo"/>
+
+
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+
+                    </xs:sequence>
+                    <xs:attribute name="CreateDateTime" use="required" type="def_datetime"/>
+                    <xs:attribute name="ResStatus"      use="required">
+                      <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                          <xs:enumeration value="Requested"/>
+                          <xs:enumeration value="Reserved"/>
+                          <xs:enumeration value="Cancelled"/>
+                          <xs:enumeration value="Modify"/>
+                        </xs:restriction>
+                      </xs:simpleType>
+                    </xs:attribute>
+                  </xs:complexType>
+                </xs:element>
+
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+
+        </xs:sequence>
+
+      </xs:choice>
+
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- GuestRequests: OTA_NotifReportRQ -->
+
+  <xs:element name="OTA_NotifReportRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <xs:element name="Success"/>
+
+        <xs:element name="Warnings" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Warning" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type"     use="required" type="def_int_gt0"/>
+                  <xs:attribute name="Code"     use="required" type="def_int_gt0"/>
+                  <xs:attribute name="RecordID" use="required" type="def_nonempty_string"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="NotifDetails" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+
+              <xs:element name="HotelNotifReport">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <xs:element name="HotelReservations">
+                      <xs:complexType>
+                        <xs:sequence>
+
+                          <xs:element name="HotelReservation" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:sequence>
+
+                                <xs:element name="UniqueID">
+                                  <xs:complexType>
+                                    <xs:attribute name="Type" use="required">
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="14"/>
+                                          <xs:enumeration value="15"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:attribute>
+                                    <xs:attribute name="ID" use="required" type="def_nonempty_string"/>
+                                  </xs:complexType>
+                                </xs:element>
+                 
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- GuestRequests: OTA_NotifReportRS -->
+
+  <xs:element name="OTA_NotifReportRS">
+    <xs:complexType>
+
+      <xs:choice>
+
+        <!-- choice: Errors {1} -->
+
+        <xs:element name="Errors">
+          <xs:complexType>
+            <xs:sequence>
+   
+              <!-- Errors > Error {1,} -->
+   
+              <xs:element name="Error" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type" use="required">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="13"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="Code" use="required" type="def_int_ge0"/>
+                </xs:complexType>
+              </xs:element>
+   
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <!-- choice: Success {1} -->
+
+        <xs:sequence>
+          <xs:element name="Success"/>
+        </xs:sequence>
+
+      </xs:choice>
+
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+
+    </xs:complexType>
+  </xs:element>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * Inventory                                                                     -->
+  <!-- ******************************************************************************* -->
+
+  <!-- Inventory: OTA_HotelDescriptiveContentNotifRQ -->
+
+  <xs:element name="OTA_HotelDescriptiveContentNotifRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <xs:element name="HotelDescriptiveContents" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+
+              <xs:element name="HotelDescriptiveContent" maxOccurs="1">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <xs:element name="FacilityInfo" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+
+                          <xs:element name="GuestRooms" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:sequence>
+
+                                <xs:element name="GuestRoom" minOccurs="1" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:sequence>
+
+                                      <xs:element name="TypeRoom" minOccurs="0">
+                                        <xs:complexType>
+                                          <xs:attribute name="StandardOccupancy"      type="def_int_gt0" />
+                                          <xs:attribute name="RoomClassificationCode" type="def_int_ge0" />
+                                          <xs:attribute name="RoomID"                 type="def_nonempty_string" />
+                                        </xs:complexType>
+                                      </xs:element>
+
+                                      <xs:element name="Amenities" minOccurs="0">
+                                        <xs:complexType>
+                                          <xs:sequence>
+
+                                            <xs:element name="Amenity" maxOccurs="unbounded">
+                                              <xs:complexType>
+                                                <xs:attribute name="RoomAmenityCode" type="def_int_gt0"/>
+                                              </xs:complexType>
+                                            </xs:element>
+
+                                          </xs:sequence>
+                                        </xs:complexType>
+                                      </xs:element>
+
+                                      <xs:element name="MultimediaDescriptions" minOccurs="0">
+                                        <xs:complexType>
+                                          <xs:sequence>
+
+                                            <xs:element name="MultimediaDescription" maxOccurs="unbounded" minOccurs="0">
+                                              <xs:complexType>
+                                                <xs:choice>
+
+                                                  <xs:element name="TextItems" minOccurs="0">
+                                                    <xs:complexType>
+                                                      <xs:sequence>
+
+                                                        <xs:element name="TextItem">
+                                                          <xs:complexType>
+                                                            <xs:sequence>
+
+                                                              <xs:element name="Description" maxOccurs="unbounded">
+                                                                <xs:complexType>
+                                                                  <xs:simpleContent>
+                                                                    <xs:extension base="def_nonempty_string">
+                                                                      <xs:attribute name="TextFormat" use="required">
+                                                                        <xs:simpleType>
+                                                                          <xs:restriction base="xs:string">
+                                                                            <xs:enumeration value="PlainText"/>
+                                                                          </xs:restriction>
+                                                                        </xs:simpleType>
+                                                                      </xs:attribute>
+                                                                      <xs:attribute name="Language" use="required">
+                                                                        <xs:simpleType>
+                                                                          <xs:restriction base="xs:language">
+                                                                            <xs:pattern value="[a-z][a-z]"/>
+                                                                          </xs:restriction>
+                                                                        </xs:simpleType>
+                                                                      </xs:attribute>
+                                                                    </xs:extension>
+                                                                  </xs:simpleContent>
+                                                                </xs:complexType>
+                                                              </xs:element>
+
+                                                            </xs:sequence>
+                                                          </xs:complexType>
+                                                        </xs:element>
+
+                                                      </xs:sequence>
+                                                    </xs:complexType>
+                                                  </xs:element>
+
+                                                  <xs:element name="ImageItems" minOccurs="0">
+                                                    <xs:complexType>
+                                                      <xs:sequence>
+
+                                                        <xs:element name="ImageItem" maxOccurs="unbounded">
+                                                          <xs:complexType>
+                                                            <xs:sequence>
+
+                                                              <xs:element name="ImageFormat">
+                                                                <xs:complexType>
+                                                                  <xs:sequence>
+                                                                    <xs:element name="URL" type="def_url_string" />
+                                                                  </xs:sequence>
+                                                                  <xs:attribute name="CopyrightNotice" type="def_nonempty_string" />
+                                                                </xs:complexType>
+                                                              </xs:element>
+
+                                                              <xs:element name="Description" minOccurs="0" maxOccurs="unbounded">
+                                                                <xs:complexType>
+                                                                  <xs:simpleContent>
+                                                                    <xs:extension base="def_nonempty_string">
+                                                                      <xs:attribute name="TextFormat" use="required">
+                                                                        <xs:simpleType>
+                                                                          <xs:restriction base="xs:string">
+                                                                            <xs:enumeration value="PlainText"/>
+                                                                          </xs:restriction>
+                                                                        </xs:simpleType>
+                                                                      </xs:attribute>
+                                                                      <xs:attribute name="Language" use="required">
+                                                                        <xs:simpleType>
+                                                                          <xs:restriction base="xs:language">
+                                                                            <xs:pattern value="[a-z][a-z]"/>
+                                                                          </xs:restriction>
+                                                                        </xs:simpleType>
+                                                                      </xs:attribute>
+                                                                    </xs:extension>
+                                                                  </xs:simpleContent>
+                                                                </xs:complexType>
+                                                              </xs:element>
+
+                                                            </xs:sequence>
+                                                            <xs:attribute name="Category" use="required" type="def_int_gt0" />
+                                                          </xs:complexType>
+                                                        </xs:element>
+
+                                                      </xs:sequence>
+                                                    </xs:complexType>
+                                                  </xs:element>
+
+                                                </xs:choice>
+                                                <xs:attribute name="InfoCode">
+                                                  <xs:simpleType>
+                                                    <xs:restriction base="def_int_gt0">
+                                                      <xs:enumeration value="1"/>
+                                                      <xs:enumeration value="23"/>
+                                                      <xs:enumeration value="25"/>
+                                                    </xs:restriction>
+                                                  </xs:simpleType>
+                                                </xs:attribute>
+                                              </xs:complexType>
+                                            </xs:element>
+
+                                          </xs:sequence>
+                                        </xs:complexType>
+                                      </xs:element>
+
+                                    </xs:sequence>
+                                    <xs:attribute name="Code"              use="required" type="def_invTypeCode_string" />
+                                    <xs:attribute name="MaxOccupancy"                     type="def_int_gt0" />
+                                    <xs:attribute name="MinOccupancy"                     type="def_int_gt0" />
+                                    <xs:attribute name="MaxChildOccupancy"                type="def_int_gt0" />
+                                  </xs:complexType>
+                                </xs:element>
+
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+
+                  </xs:sequence>
+                  <xs:attribute name="HotelCode" type="def_nonempty_string" />
+                  <xs:attribute name="HotelName" type="def_nonempty_string" />
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+
+      <xs:attribute name="Version" use="required" />
+      <xs:attribute name="TimeStamp" />
+    </xs:complexType>
+  </xs:element>
+
+  <!-- Inventory: OTA_HotelDescriptiveContentNotifRS -->
+  
+  <xs:element name="OTA_HotelDescriptiveContentNotifRS">
+    <xs:complexType>
+      <xs:group ref="def_generic_response"/>
+      <xs:attribute name="Version" use="required" />
+      <xs:attribute name="TimeStamp" />
+    </xs:complexType>
+  </xs:element>
+  
+  
+  <!-- ******************************************************************************* -->
+  <!-- * SimplePackages & RatePlans                                                    -->
+  <!-- ******************************************************************************* -->
+
+  <!-- SimplePackages & RatePlans: OTA_HotelRatePlanNotifRQ -->
+
+  <xs:element name="OTA_HotelRatePlanNotifRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <!-- UniqueID {0,1} -->
+
+        <xs:element name="UniqueID" minOccurs="0">
+          <xs:complexType>
+            <xs:attribute name="Type" use="required">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="16"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="ID" use="required" type="xs:string"/> <!-- an ID is required by OTA, we ignore the value -->
+            <xs:attribute name="Instance" use="required">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="CompleteSet"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+
+        <!-- RatePlans {1} -->
+ 
+        <xs:element name="RatePlans">
+          <xs:complexType>
+            <xs:sequence>
+
+              <!-- RatePlans > RatePlan {1,} -->
+
+              <xs:element name="RatePlan" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <!-- RatePlans > RatePlan > BookingRules {0,1}   (RatePlans) -->
+
+                    <xs:element name="BookingRules" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+
+                          <xs:element name="BookingRule" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:sequence>
+
+                                <xs:element name="LengthsOfStay" minOccurs="0">
+                                  <xs:complexType>
+                                    <xs:sequence>
+
+                                      <xs:element name="LengthOfStay" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                          <xs:attribute name="Time" use="required" type="def_decimal_ge0"/>
+                                          <xs:attribute name="TimeUnit" use="required">
+                                            <xs:simpleType>
+                                              <xs:restriction base="xs:string">
+                                                <xs:enumeration value="Day"/>
+                                              </xs:restriction>
+                                            </xs:simpleType>
+                                          </xs:attribute>
+                                          <xs:attribute name="MinMaxMessageType" use="required">
+                                            <xs:simpleType>
+                                              <xs:restriction base="xs:string">
+                                                <xs:enumeration value="SetMinLOS"/>
+                                                <xs:enumeration value="SetMaxLOS"/>
+                                              </xs:restriction>
+                                            </xs:simpleType>
+                                          </xs:attribute>
+                                        </xs:complexType>
+                                      </xs:element>
+
+                                    </xs:sequence>
+                                  </xs:complexType>
+                                </xs:element>
+
+                                <xs:element name="DOW_Restrictions" minOccurs="0">
+                                  <xs:complexType>
+                                    <xs:sequence>
+                                      <xs:element name="ArrivalDaysOfWeek" minOccurs="0">
+                                        <xs:complexType>
+                                          <xs:attribute name="Mon"  type="def_bool"/>
+                                          <xs:attribute name="Tue"  type="def_bool"/>
+                                          <xs:attribute name="Weds" type="def_bool"/>
+                                          <xs:attribute name="Thur" type="def_bool"/>
+                                          <xs:attribute name="Fri"  type="def_bool"/>
+                                          <xs:attribute name="Sat"  type="def_bool"/>
+                                          <xs:attribute name="Sun"  type="def_bool"/>
+                                        </xs:complexType>
+                                      </xs:element>
+                                      <xs:element name="DepartureDaysOfWeek" minOccurs="0">
+                                        <xs:complexType>
+                                          <xs:attribute name="Mon"  type="def_bool"/>
+                                          <xs:attribute name="Tue"  type="def_bool"/>
+                                          <xs:attribute name="Weds" type="def_bool"/>
+                                          <xs:attribute name="Thur" type="def_bool"/>
+                                          <xs:attribute name="Fri"  type="def_bool"/>
+                                          <xs:attribute name="Sat"  type="def_bool"/>
+                                          <xs:attribute name="Sun"  type="def_bool"/>
+                                        </xs:complexType>
+                                      </xs:element>
+                                    </xs:sequence>
+                                  </xs:complexType>
+                                </xs:element>
+
+                                <xs:element name="RestrictionStatus" minOccurs="0">
+                                  <xs:complexType>
+                                    <xs:attribute name="Restriction">
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Master"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:attribute>
+                                    <xs:attribute name="Status">
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="Open"/>
+                                          <xs:enumeration value="Close"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:attribute>
+                                  </xs:complexType>
+                                </xs:element>
+
+                              </xs:sequence>
+                              <xs:attribute name="CodeContext">
+                                <xs:simpleType>
+                                  <xs:restriction base="xs:string">
+                                    <xs:enumeration value="ROOMTYPE"/>
+                                  </xs:restriction>
+                                </xs:simpleType>
+                              </xs:attribute>
+                              <xs:attribute name="Code"  type="def_invTypeCode_string"/>
+                              <xs:attribute name="Start" type="def_date"/>
+                              <xs:attribute name="End"   type="def_date"/>
+                            </xs:complexType>
+                          </xs:element>
+
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+
+                    <!-- RatePlans > RatePlan > Rates {0,1}          (SimplePackages & RatePlans) -->
+
+                    <xs:element name="Rates" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+
+                          <xs:element name="Rate" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:sequence>
+
+                                <xs:element name="BaseByGuestAmts" minOccurs="0">
+                                  <xs:complexType>
+                                    <xs:sequence>
+
+                                      <xs:element name="BaseByGuestAmt" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                          <xs:attribute name="NumberOfGuests" use="required" type="def_int_gt0"/>
+                                          <xs:attribute name="AmountAfterTax" type="def_decimal_gt0"/>
+                                          <xs:attribute name="CurrencyCode">
+                                            <xs:simpleType>
+                                              <xs:restriction base="xs:string">
+                                                <xs:enumeration value="EUR"/>
+                                              </xs:restriction>
+                                            </xs:simpleType>
+                                          </xs:attribute>
+                                          <xs:attribute name="Type">
+                                            <xs:simpleType>
+                                              <xs:restriction base="xs:string">
+                                                <xs:enumeration value="7"/>
+                                                <xs:enumeration value="25"/>
+                                              </xs:restriction>
+                                            </xs:simpleType>
+                                          </xs:attribute>
+                                          <xs:attribute name="AgeQualifyingCode" type="def_int_gt0"/>
+                                        </xs:complexType>
+                                      </xs:element>
+
+                                    </xs:sequence>
+                                  </xs:complexType>
+                                </xs:element>
+
+                                <xs:element name="AdditionalGuestAmounts" minOccurs="0">
+                                  <xs:complexType>
+                                    <xs:sequence>
+
+                                      <xs:element name="AdditionalGuestAmount" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                          <xs:attribute name="Amount"            type="def_decimal_ge0"/>
+                                          <xs:attribute name="AgeQualifyingCode" type="def_int_gt0"/>
+                                          <xs:attribute name="MinAge"            type="def_int_gt0"/>
+                                          <xs:attribute name="MaxAge"            type="def_int_gt0"/>
+                                        </xs:complexType>
+                                      </xs:element>
+
+                                    </xs:sequence>
+                                  </xs:complexType>
+                                </xs:element>
+
+                                <xs:element name="RateDescription" minOccurs="0">
+                                  <xs:complexType>
+                                    <xs:sequence>
+
+                                      <xs:element name="ListItem" maxOccurs="unbounded">
+                                        <xs:complexType>                    
+                                           <xs:simpleContent>                
+                                             <xs:extension base="def_nonempty_string">
+                                               <xs:attribute name="ListItem" use="required" type="def_int_ge0"/>
+                                               <xs:attribute name="Language" use="required">
+                                                 <xs:simpleType>             
+                                                   <xs:restriction base="xs:language">
+                                                     <xs:pattern value="[a-z][a-z]"/>
+                                                   </xs:restriction>         
+                                                 </xs:simpleType>            
+                                               </xs:attribute>               
+                                             </xs:extension>                 
+                                           </xs:simpleContent>               
+                                         </xs:complexType>                   
+                                      </xs:element>
+       
+                                    </xs:sequence>
+                                      <xs:attribute name="Name" use="required">
+                                        <xs:simpleType>
+                                          <xs:restriction base="xs:string">
+                                            <xs:enumeration value="included services"/>
+                                          </xs:restriction>
+                                        </xs:simpleType>
+                                      </xs:attribute>
+                                  </xs:complexType>
+                                </xs:element>
+
+                                <xs:element name="MealsIncluded" minOccurs="0">
+                                  <xs:complexType>
+                                    <xs:attribute name="Breakfast" type="def_bool"/>
+                                    <xs:attribute name="Lunch"     type="def_bool"/>
+                                    <xs:attribute name="Dinner"    type="def_bool"/>
+                                    <xs:attribute name="MealPlanCodes">
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="1"/>
+                                          <xs:enumeration value="3"/>
+                                          <xs:enumeration value="10"/>
+                                          <xs:enumeration value="12"/>
+                                          <xs:enumeration value="14"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:attribute>
+                                    <xs:attribute name="MealPlanIndicator">
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="1"/>
+                                          <xs:enumeration value="true"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:attribute>
+                                  </xs:complexType>
+                                </xs:element>
+                        
+                              </xs:sequence>
+                              <xs:attribute name="MinGuestApplicable" type="def_int_gt0"/>
+                              <xs:attribute name="Start"              type="def_date"/>
+                              <xs:attribute name="End"                type="def_date"/>
+                              <xs:attribute name="RateTimeUnit">
+                                <xs:simpleType>
+                                  <xs:restriction base="xs:string">
+                                    <xs:enumeration value="Day"/>
+                                  </xs:restriction>
+                                </xs:simpleType>
+                              </xs:attribute>
+                              <xs:attribute name="UnitMultiplier"     type="def_int_gt0"/>
+                              <xs:attribute name="Mon"                type="def_bool"/>
+                              <xs:attribute name="Tue"                type="def_bool"/>
+                              <xs:attribute name="Weds"               type="def_bool"/>
+                              <xs:attribute name="Thur"               type="def_bool"/>
+                              <xs:attribute name="Fri"                type="def_bool"/>
+                              <xs:attribute name="Sat"                type="def_bool"/>
+                              <xs:attribute name="Sun"                type="def_bool"/>
+                              <xs:attribute name="Duration">
+                                <xs:simpleType>
+                                  <xs:restriction base="xs:string">
+                                    <xs:pattern value="P[0-9]+N"/>
+                                  </xs:restriction>
+                                </xs:simpleType>
+                              </xs:attribute>
+                              <xs:attribute name="InvTypeCode" type="def_invTypeCode_string"/>
+
+                            </xs:complexType>
+                          </xs:element>
+                        
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+
+                    <!-- RatePlans > RatePlan > Supplements {0,1}    (RatePlans) -->
+
+                    <xs:element name="Supplements" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+
+                          <xs:element name="Supplement" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:sequence>
+
+                                <xs:element name="Description" minOccurs="0" maxOccurs="2">
+                                  <xs:complexType>
+
+                                    <xs:sequence maxOccurs="unbounded">
+                                        <xs:element name="Text" maxOccurs="unbounded">
+                                          <xs:complexType>                    
+                                             <xs:simpleContent>                
+                                               <xs:extension base="def_nonempty_string">
+                                                 <xs:attribute name="TextFormat" use="required">
+                                                   <xs:simpleType>             
+                                                     <xs:restriction base="xs:string">
+                                                       <xs:enumeration value="PlainText"/>
+                                                     </xs:restriction>         
+                                                   </xs:simpleType>            
+                                                 </xs:attribute>               
+                                                 <xs:attribute name="Language" use="required">
+                                                   <xs:simpleType>             
+                                                     <xs:restriction base="xs:language">
+                                                       <xs:pattern value="[a-z][a-z]"/>
+                                                     </xs:restriction>         
+                                                   </xs:simpleType>            
+                                                 </xs:attribute>               
+                                               </xs:extension>                 
+                                             </xs:simpleContent>               
+                                           </xs:complexType>                   
+                                        </xs:element>
+                                    </xs:sequence>
+
+                                    <xs:attribute name="Name" use="required">
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="title"/>
+                                          <xs:enumeration value="intro"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:attribute>
+
+                                  </xs:complexType>
+
+                                </xs:element>
+
+                              </xs:sequence>
+
+                              <xs:attribute name="AddToBasicRateIndicator">
+                                <xs:simpleType>
+                                  <xs:restriction base="xs:string">
+                                    <xs:enumeration value="1"/>
+                                    <xs:enumeration value="true"/>
+                                  </xs:restriction>
+                                </xs:simpleType>
+                              </xs:attribute>
+
+                              <xs:attribute name="ChargeTypeCode">
+                                <xs:simpleType>
+                                  <xs:restriction base="xs:string">
+                                    <xs:enumeration value="1"/>
+                                    <xs:enumeration value="12"/>
+                                    <xs:enumeration value="18"/>
+                                    <xs:enumeration value="19"/>
+                                    <xs:enumeration value="20"/>
+                                    <xs:enumeration value="21"/>
+                                    <xs:enumeration value="24"/>
+                                  </xs:restriction>
+                                </xs:simpleType>
+                              </xs:attribute>
+
+                              <xs:attribute name="Amount" type="def_decimal_ge0"/>
+
+                              <xs:attribute name="InvType" use="required">
+                                <xs:simpleType>
+                                  <xs:restriction base="xs:string">
+                                    <xs:enumeration value="EXTRA"/>
+                                    <xs:enumeration value="ALPINEBITSEXTRA"/>
+                                  </xs:restriction>
+                                </xs:simpleType>
+                              </xs:attribute>
+
+                              <xs:attribute name="InvCode" type="def_nonempty_string" use="required"/>
+
+                              <xs:attribute name="MandatoryIndicator" type="def_bool"/>
+
+                              <xs:attribute name="Start" type="def_date"/>
+                              <xs:attribute name="End"   type="def_date"/>
+
+                            </xs:complexType>
+                          </xs:element>
+
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+
+                    <!-- RatePlans > RatePlan > Offers {0,1}         (RatePlans) -->
+
+                    <xs:element name="Offers" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+
+                          <xs:element name="Offer" maxOccurs="2">
+                            <xs:complexType>
+                              <xs:sequence>
+
+                                <xs:element name="Discount">
+                                  <xs:complexType>
+                                    <xs:attribute name="Percent" use="required">
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="100"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:attribute>
+                                    <xs:attribute name="NightsRequired"   type="def_int_gt0"/>
+                                    <xs:attribute name="NightsDiscounted" type="def_int_gt0"/>
+                                    <xs:attribute name="DiscountPattern">
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:pattern value="0*1*"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:attribute>
+                                  </xs:complexType>
+                                </xs:element>
+
+                                <xs:element name="Guests" minOccurs="0">
+                                  <xs:complexType>
+                                    <xs:sequence>
+
+                                      <xs:element name="Guest">
+                                        <xs:complexType>
+                                          <xs:attribute name="AgeQualifyingCode" use="required" type="def_int_gt0"/>
+                                          <xs:attribute name="MaxAge"            use="required" type="def_int_gt0"/>
+                                          <xs:attribute name="MinCount"          use="required" type="def_int_ge0"/>
+                                            <xs:attribute name="FirstQualifyingPosition" use="required">
+                                              <xs:simpleType>
+                                                <xs:restriction base="xs:string">
+                                                  <xs:enumeration value="1"/>
+                                                </xs:restriction>
+                                              </xs:simpleType>
+                                            </xs:attribute>
+                                            <xs:attribute name="LastQualifyingPosition" use="required" type="def_int_gt0"/>
+                                        </xs:complexType>
+                                      </xs:element>
+
+                                    </xs:sequence>
+                                  </xs:complexType>
+                                </xs:element>
+
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+
+                    <!-- RatePlans > RatePlan > Description {0,4}    (SimplePackages & RatePlans) -->
+
+                    <!-- Note: RatePlans only supports Text with TextFormat="PlainText" or TextFormat="HTML", the
+                               rest ist for SimplePackages only -->
+
+                    <xs:element name="Description" minOccurs="0" maxOccurs="4">
+                      <xs:complexType>
+                        <xs:sequence maxOccurs="unbounded">
+                          <xs:choice>
+
+                            <xs:element name="Text">
+                              <xs:complexType>                    
+                                 <xs:simpleContent>                
+                                   <xs:extension base="def_nonempty_string">
+                                     <xs:attribute name="TextFormat" use="required">
+                                       <xs:simpleType>             
+                                         <xs:restriction base="xs:string">
+                                           <xs:enumeration value="PlainText"/>
+                                           <xs:enumeration value="HTML"/> 
+                                         </xs:restriction>         
+                                       </xs:simpleType>            
+                                     </xs:attribute>               
+                                     <xs:attribute name="Language" use="required">
+                                       <xs:simpleType>             
+                                         <xs:restriction base="xs:language">
+                                           <xs:pattern value="[a-z][a-z]"/>
+                                         </xs:restriction>         
+                                       </xs:simpleType>            
+                                     </xs:attribute>               
+                                   </xs:extension>                 
+                                 </xs:simpleContent>               
+                               </xs:complexType>                   
+                            </xs:element>
+                        
+                            <xs:element name="ListItem">
+                              <xs:complexType>                    
+                                 <xs:simpleContent>                
+                                   <xs:extension base="def_nonempty_string">
+                                     <xs:attribute name="ListItem" use="required" type="def_int_ge0"/>
+                                     <xs:attribute name="Language" use="required">
+                                       <xs:simpleType>             
+                                         <xs:restriction base="xs:language">
+                                           <xs:pattern value="[a-z][a-z]"/>
+                                         </xs:restriction>         
+                                       </xs:simpleType>            
+                                     </xs:attribute>               
+                                   </xs:extension>                 
+                                 </xs:simpleContent>               
+                               </xs:complexType>                   
+                            </xs:element>
+                        
+                            <xs:element name="Image" type="def_url_string"/>
+                        
+                            <xs:element name="URL"   type="def_url_string"/>
+
+                          </xs:choice>
+                        </xs:sequence>
+
+                        <xs:attribute name="Name" use="required">
+                          <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                              <xs:enumeration value="title"/>
+                              <xs:enumeration value="intro"/>
+                              <xs:enumeration value="gallery"/>
+                              <xs:enumeration value="details"/>
+                            </xs:restriction>
+                          </xs:simpleType>
+                        </xs:attribute>
+                      </xs:complexType>
+                    </xs:element>
+
+                    <!-- RatePlans > RatePlan > UniqueID {0,1}       (SimplePackages) -->
+
+                    <xs:element name="UniqueID" minOccurs="0">
+                      <xs:complexType>
+                        <xs:attribute name="Type" use="required">
+                          <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                              <xs:enumeration value="18"/>
+                            </xs:restriction>
+                          </xs:simpleType>
+                        </xs:attribute>
+                        <xs:attribute name="ID" use="required" type="def_nonempty_string"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                    <!-- RatePlans > RatePlan > HotelRef {0,1}       (SimplePackages) -->
+
+                    <xs:element name="HotelRef" minOccurs="0">
+                      <xs:complexType>
+                          <xs:attribute name="HotelCode" use="required" type="def_nonempty_string"/>
+                          <xs:attribute name="HotelName" use="required" type="def_nonempty_string"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                  </xs:sequence>
+                  <xs:attribute name="Start" type="def_date"/>
+                  <xs:attribute name="End"   type="def_date"/>
+                  <xs:attribute name="RatePlanNotifType">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="Overlay"/>
+                        <xs:enumeration value="New"/>
+                        <xs:enumeration value="Remove"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="CurrencyCode">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="EUR"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="RatePlanCode" type="def_nonempty_string"/>
+                  <xs:attribute name="RatePlanType">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="12"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>                
+                  <xs:attribute name="RatePlanCategory" type="def_nonempty_string"/>
+                  <xs:attribute name="RatePlanID" type="def_nonempty_string"/>
+                  <xs:attribute name="RatePlanQualifier" type="def_bool"/>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+            <xs:attribute name="HotelCode" type="def_nonempty_string"/>
+            <xs:attribute name="HotelName" type="def_nonempty_string"/>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- SimplePackages & RatePlans: OTA_HotelRatePlanNotifRS -->
+
+  <xs:element name="OTA_HotelRatePlanNotifRS">
+    <xs:complexType>
+      <xs:group   ref="def_generic_response"/>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for success/advisory/warning/error responses                -->
+  <!-- ******************************************************************************* -->
+
+  <xs:group name="def_generic_response">
+    <xs:choice>
+
+      <!-- choice: Errors {1} -->
+
+      <xs:element name="Errors">
+        <xs:complexType>
+          <xs:sequence>
+
+            <!-- Errors > Error {1,} -->
+
+            <xs:element name="Error" maxOccurs="unbounded">
+              <xs:complexType mixed="true">
+                <xs:attribute name="Type" use="required">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                      <xs:enumeration value="13"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="Code" use="required" type="def_int_gt0"/>
+              </xs:complexType>
+            </xs:element>
+
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+      <!-- choice: Success {1} + Warnings {0,1} -->
+
+      <xs:sequence>
+
+        <xs:element name="Success"/>
+
+        <xs:element name="Warnings" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+
+            <!-- Warnings > Warning {1,} -->
+
+              <xs:element name="Warning" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type"     use="required" type="def_int_gt0"/>
+                  <xs:attribute name="RecordID"                type="def_nonempty_string"/>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+
+    </xs:choice>
+  </xs:group>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for recurring, simple types                                 -->
+  <!-- ******************************************************************************* -->
+
+  <!-- A generic non-empty string type. -->
+
+  <xs:simpleType name="def_nonempty_string">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic string type containing an @ char, like an email address -->
+
+  <xs:simpleType name="def_email_string">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\S+@\S+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- String type defining room category codes (like InvTypeCode)  -->
+
+  <xs:simpleType name="def_invTypeCode_string">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+      <xs:maxLength value="8"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic string type starting with http:// or https:// -->
+
+  <xs:simpleType name="def_url_string">
+    <xs:restriction base="xs:anyURI">
+      <xs:pattern value="https?://.+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+  <!-- A generic integer > 0 type. -->
+
+  <xs:simpleType name="def_int_gt0">
+    <xs:restriction base="xs:positiveInteger">
+      <xs:pattern value="[0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic integer >= 0 type. -->
+
+  <xs:simpleType name="def_int_ge0">
+    <xs:restriction base="xs:nonNegativeInteger">
+      <xs:pattern value="[0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic decimal >= 0 type. -->
+
+  <xs:simpleType name="def_decimal_ge0">
+    <xs:restriction base="xs:decimal">
+      <xs:minInclusive value="0.0"/>
+      <xs:pattern value="[0-9]*\.?[0-9]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic decimal > 0 type. -->
+
+  <xs:simpleType name="def_decimal_gt0">
+    <xs:restriction base="xs:decimal">
+      <xs:minExclusive value="0.0"/>
+      <xs:pattern value="[0-9]*\.?[0-9]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic date type. -->
+
+  <xs:simpleType name="def_date">
+    <xs:restriction base="xs:date">
+      <xs:pattern value="\S+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic datetime type. -->
+
+  <xs:simpleType name="def_datetime">
+    <xs:restriction base="xs:dateTime">
+      <xs:pattern value="\S+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic boolean type (1,true,0,false). -->
+
+  <xs:simpleType name="def_bool">
+    <xs:restriction base="xs:boolean">
+      <xs:pattern value="\S+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+</xs:schema>

--- a/alpinebits-xml/api/src/main/resources/alpinebits-2017-10.rng
+++ b/alpinebits-xml/api/src/main/resources/alpinebits-2017-10.rng
@@ -1,0 +1,2821 @@
+<?xml version="1.0"?>
+
+<!--
+     AlpineBits 2017-10
+     http://www.alpinebits.org/
+
+     Relax-NG grammar file
+
+     changelog:
+
+    v. 2017-10  1.3 -  Inventory common type def_hoteldescriptivecontents -> FacilityInfo -> ... -> MultimediaDescription (allow one or more ImageItem elements for InfoCode="23")
+
+    v. 2017-10  1.2 -  FreeRooms:       OTA_HotelAvailNotifRQ -> AvailStatusMessages -> ...  -> StatusApplicationControl (make BookingThreshold not mandatory)
+
+    v. 2017-10  1.1 -  RatePlans:       RatePlans > RatePlan > Offers: allow only MinLOS and MaxLOS attributes (not the forward ones too)
+
+    v. 2017-10  1.0 -  FreeRooms:       OTA_HotelAvailNotifRQ -> UniqueID (added allowed value to attribute Type, by Luca Rainone)
+                       FreeRooms:       OTA_HotelAvailNotifRQ -> AvailStatusMessages -> ...  -> StatusApplicationControl (added new mandatory attribute BookingThreshold)
+
+                       GuestRequests:   OTA_ResRetrieveRS -> ReservationsList -> ... -> RatePlan (added element Commission)
+                       GuestRequests:   OTA_ResRetrieveRS -> ReservationsList -> ... -> CardNumber (added attributes EncryptedValue and EncryptionMethod) 
+                       GuestRequests:   OTA_ResRetrieveRS -> ReservationsList -> ... -> RoomStay > RoomTypes (made optional)
+
+                       SimplePackages section removed
+
+                       Inventory has become Inventory/Basic (Push) and Inventory/HotelInfo (Push):
+                                        OTA_HotelDescriptiveContentNotifRQ (major changes, one being that empty GuestRooms elements are now allowed by Luca Rainone)
+
+                       Inventory/Basic (Pull) and Inventory/HotelInfo (Pull) added
+ 
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> BookingRules -> ... -> LengthOfStay (added allowed values to attribute MinMaxMessageType)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Supplements -> Supplement (added element PrerequisiteInventory)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Supplements -> Supplement -> Description (major changes)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Offers -> Offer (major changes)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Description (major changes)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> ... -> BaseByGuestAmt (NumberOfGuests and Type are optional now to allow static rates)
+
+                       BaseRates section added
+
+    v. 2015-07b 1.4 - weaken the schema for Inventory (to prepare for upcoming release that will support Inventory deltas):
+
+                      - the RoomAmenityCode attribute becomes optional to allow empty Amenity elements 
+                      - the MultimediaDescription element can be empty
+
+    v. 2015-07b 1.3 - RatePlans > RatePlan > Description > TextFormat can now also be "HTML" (besides "PlainText")
+
+    v. 2015-07b 1.2 - added optional attributes RatePlanID and RatePlanQualifier to RatePlan
+                      for the new OTA_HotelRatePlanNotif_accept_RatePlanJoin capability
+
+    v. 2015-07b 1.1 - added def_invTypeCode_string type (string with up to 8 chars) used for the following attributes that identify room categories:
+
+                      FreeRooms:     OTA_HotelAvailNotifRQ -> AvailStatusMessages -> AvailStatusMessage -> StatusApplicationControl -> InvTypeCode
+                      GuestRequests: OTA_ResRetrieveRS -> ReservationList -> HotelReservation -> RoomStays -> RoomStay -> RoomTypes > RoomType -> RoomTypeCode
+                      Inventory:     OTA_HotelDescriptiveContentNotifRQ -> HotelDescriptiveContents -> HotelDescriptiveContent -> FacilityInfo -> GuestRooms -> GuestRoom -> Code
+                      RatePlan:      OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> BookingRules -> BookingRule -> Code
+                      RatePlan:      OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Rates -> Rate -> InvTypeCode
+
+    v. 2015-07b 1.0 - RatePlans > RatePlan > Rates > Rate > BaseByGuestAmts > AmountAfterTax
+                      must be > 0.0 (was: >= 0.0)
+
+     v. 2015-07 2.8 - Inventory: fixed the checks for the HotelDescriptiveContent attributes
+
+     v. 2015-07 2.7 - Inventory: reconciled with the definitions given in the updated document
+
+     v. 2015-07 2.6 - added section for New Inventory (exact name pending)
+
+     v. 2015-07 2.5 - made sub-elements of HotelReservation > ... > Customer > Address {0,1} optional
+
+     v. 2015-07 2.4 - added a choice of 'Modify' for ResStatusValue
+
+     v. 2015-07 2.3 - added MinCount attribute to Offer>>Guest
+
+     v. 2015-07 2.2 - changes to Supplement: a few attributes are removed and many attributes are made optional
+
+     v. 2015-07 2.1 - RatePlans/Supplements: changed format of description
+
+     v. 2015-07 2.0 - GuestRequests: ResGuests >> Customer: attributes Gender and Language are now optional
+
+     v. 2015-07 1.9 - allow Warnings in OTA_NotifReportRQ messages
+
+     v. 2015-07 1.8 - GuestRequests: use CardNumber -> PlainText instead of the Remark attribute of
+                      PaymentCard under Guarantee; add BasicPropertyInfo element at the end of the 
+                      ResGlobalInfo block for OTA-2015A compatiblity
+
+     v. 2015-07 1.7 - allowed more than one HotelReservationID
+
+     v. 2015-07 1.6 - RatePlans: allow optional PrerequisiteInventory element under Supplement element
+
+     v. 2015-07 1.5 - Inventory: removed Amenities and added optional Room -> RoomTypeCode
+
+     v. 2015-07 1.4 - HotelReservationID -> ResID_Type is not limited to 13 anymore
+
+     v. 2015-07 1.3 - new section in RoomStays: Guarantee -> GuaranteesAccepted -> GuaranteeAccepted -> PaymentCard
+
+     v. 2015-07 1.2 - new section in ResGlobalInfo: Profiles -> ProfileInfo -> Profile -> CompanyInfo
+
+     v. 2015-07 1.1 - HotelReservation > RoomStays > RoomStay > RoomTypes > RoomType is now
+                      mandatory and has a new optional attribute RoomClassificationCode
+
+     v. 2015-07 1.0 - OTA_NotifReportRS besides Success, now also allows Error responses 
+
+     v. 2014-04 1.5 - [fixed] InvCode attribute in Supplement changed from def_int_ge0 to def_nonempty_string
+
+     v. 2014-04 1.4 - [strictness improvement] made BaseByGuestAmt->NumberOfGuests attribute mandatory for
+                      RatePlans and SimplePackages, made BaseByGuestAmt->Type attribute mandatory for RatePlans
+
+     v. 2014-04 1.3 - [improvement] RatePlans: remove RatePlan->Rate attributes that are not allowed
+                      (problem inherited from the xsd version where Rate is shared with SimplePackages
+
+     v. 2014-04 1.2 - [fixed] RatePlans: optional Rate attributes RateTimeUnit and UnitMultiplier added
+
+     v. 2014-04 1.1 - [fixed] GuestRequests: Email->Remark is an optional attribute
+                    - [fixed] GuestRequests: ReservationsList can be empty
+
+     v. 2014-04 1.0 - complete rewrite for 2014-04
+
+-->
+
+<rng:grammar     xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        ns="http://www.opentravel.org/OTA/2003/05"
+           datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+  <rng:start>
+    <rng:choice>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * FreeRooms                                                                     -->
+      <!-- ******************************************************************************* -->
+
+      <!-- FreeRooms: OTA_HotelAvailNotifRQ -->
+
+      <rng:element name="OTA_HotelAvailNotifRQ">
+
+        <!-- UniqueID {0,1} -->
+
+        <rng:optional>
+          <rng:element name="UniqueID">
+
+            <rng:attribute name="Type">
+              <rng:choice>
+                <rng:value type="string">16</rng:value>
+                <rng:value type="string">35</rng:value>
+              </rng:choice>
+            </rng:attribute>
+            <rng:attribute name="ID"/> <!-- an ID is required by OTA, we ignore the value -->
+            <rng:attribute name="Instance">
+              <rng:value type="string">CompleteSet</rng:value>
+            </rng:attribute>
+
+          </rng:element>
+        </rng:optional>
+
+         <!-- AvailStatusMessages {1} -->
+
+        <rng:element name="AvailStatusMessages">
+
+          <rng:oneOrMore>
+            <rng:choice>
+              <rng:attribute name="HotelCode">
+                <rng:ref name="def_nonempty_string"/>
+              </rng:attribute>
+              <rng:attribute name="HotelName">
+                <rng:ref name="def_nonempty_string"/>
+              </rng:attribute>
+            </rng:choice>
+          </rng:oneOrMore>
+
+          <!-- AvailStatusMessages > AvailStatusMessage (1,} -->
+
+          <rng:oneOrMore>
+            <rng:element name="AvailStatusMessage">
+
+              <!-- AvailStatusMessage is either empty or has
+                 attributes BookingLimit, BookingLimitMessageType, BookingThreshold (optional)
+                 and contains one StatusApplicationControl element -->
+
+              <rng:optional>
+
+                <rng:element name="StatusApplicationControl">
+
+                  <rng:attribute name="Start">
+                    <rng:ref name="def_date"/>
+                  </rng:attribute>
+                  <rng:attribute name="End">
+                    <rng:ref name="def_date"/>
+                  </rng:attribute>
+                  <rng:attribute name="InvTypeCode">
+                    <rng:ref name="def_invTypeCode_string"/>
+                  </rng:attribute>
+                  <rng:optional>
+                    <rng:attribute name="InvCode">
+                      <rng:ref name="def_nonempty_string"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                </rng:element>
+
+                <rng:attribute name="BookingLimit">
+                  <rng:ref name="def_int_ge0"/>
+                </rng:attribute>
+                <rng:optional>
+                  <rng:attribute name="BookingThreshold">
+                    <rng:ref name="def_int_ge0"/>
+                  </rng:attribute>
+                </rng:optional>
+                <rng:attribute name="BookingLimitMessageType">
+                  <rng:value type="string">SetLimit</rng:value>
+                </rng:attribute>
+
+              </rng:optional>
+
+            </rng:element>
+          </rng:oneOrMore>
+
+        </rng:element>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- FreeRooms: OTA_HotelAvailNotifRQ -->
+
+      <rng:element name="OTA_HotelAvailNotifRS">
+
+        <rng:ref name="def_generic_response"/>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * GuestRequests                                                                 -->
+      <!-- ******************************************************************************* -->
+
+      <!-- GuestRequests: OTA_ReadRQ -->
+
+      <rng:element name="OTA_ReadRQ">
+
+        <rng:element name="ReadRequests">
+    
+          <rng:element name="HotelReadRequest">
+        
+            <rng:optional>
+              <rng:element name="SelectionCriteria">
+          
+                <rng:attribute name="Start">
+                  <rng:ref name="def_datetime"/>
+                </rng:attribute>
+          
+              </rng:element>
+            </rng:optional>
+
+            <rng:oneOrMore>
+              <rng:choice>
+                <rng:attribute name="HotelCode">
+                  <rng:ref name="def_nonempty_string"/>
+                </rng:attribute>
+                <rng:attribute name="HotelName">
+                  <rng:ref name="def_nonempty_string"/>
+                </rng:attribute>
+              </rng:choice>
+            </rng:oneOrMore>
+
+          </rng:element>
+
+        </rng:element>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+  
+      </rng:element>
+
+      <!-- GuestRequests: OTA_ResRetrieveRS -->
+
+      <rng:element name="OTA_ResRetrieveRS">
+        <rng:choice>
+
+          <!-- choice: Errors {1} -->
+
+          <rng:element name="Errors">
+
+            <!-- Errors > Error {1,} -->
+
+            <rng:oneOrMore>
+              <rng:element name="Error">
+
+                <rng:attribute name="Type">
+                  <rng:value type="string">13</rng:value>
+                </rng:attribute>
+                <rng:attribute name="Code">
+                  <rng:ref name="def_int_ge0"/>
+                </rng:attribute>
+
+                <rng:text/>
+
+              </rng:element>
+
+            </rng:oneOrMore>
+          </rng:element>
+
+          <!-- choice: Success {1} + ReservationsList {1} -->
+
+          <rng:group>
+
+            <rng:element name="Success">
+              <rng:empty/>
+            </rng:element>
+
+            <rng:element name="ReservationsList">
+
+              <!-- HotelReservation {0,} -->
+
+              <rng:zeroOrMore>
+                <rng:element name="HotelReservation">
+
+                  <!-- HotelReservation > UniqueID {1} -->
+
+                  <rng:element name="UniqueID">
+
+                    <rng:attribute name="Type">
+                      <rng:choice>
+                        <rng:value>14</rng:value>
+                        <rng:value>15</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+
+                    <rng:attribute name="ID">
+                      <rng:ref name="def_nonempty_string"/>
+                    </rng:attribute>
+
+                  </rng:element>
+
+                  <!-- HotelReservation > RoomStays {0,1} -->
+
+                  <rng:optional>
+                    <rng:element name="RoomStays">
+
+                      <!-- HotelReservation > RoomStays > RoomStay {1,} -->
+
+                      <rng:oneOrMore>
+                        <rng:element name="RoomStay">
+
+                          <!-- HotelReservation > RoomStays > RoomStay > RoomTypes {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="RoomTypes">
+
+                              <!-- HotelReservation > RoomStays > RoomStay > RoomTypes > RoomType {1} -->
+
+                              <rng:element name="RoomType">
+                                <rng:optional>
+                                  <rng:attribute name="RoomTypeCode">
+                                    <rng:ref name="def_invTypeCode_string"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="RoomClassificationCode">
+                                    <rng:ref name="def_int_ge0"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                              </rng:element>
+                         
+                            </rng:element>
+                          </rng:optional>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > RatePlans {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="RatePlans">
+
+                              <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan {1} -->
+
+                              <rng:element name="RatePlan">
+
+                                <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan > Commission {0,1} -->
+
+                                <rng:optional>
+                                  <rng:element name="Commission">
+                                    <rng:choice>
+
+                                      <!-- Commission has either attribute "Percent" ... -->
+
+                                      <rng:attribute name="Percent">
+                                        <rng:ref name="def_int_ge0"/>
+                                      </rng:attribute>
+
+                                      <!-- ... or subelement "CommissionPayableAmount" -->
+
+                                      <rng:element name="CommissionPayableAmount">
+                                        <rng:attribute name="Amount">
+                                          <rng:ref name="def_decimal_ge0"/>
+                                        </rng:attribute>
+                                        <rng:attribute name="CurrencyCode">
+                                          <rng:choice>
+                                            <rng:value>EUR</rng:value>
+                                          </rng:choice>
+                                        </rng:attribute>
+                                      </rng:element>
+
+                                    </rng:choice>
+                                  </rng:element>
+                                </rng:optional>
+
+                                <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan > MealsIncluded {0,1} -->
+
+                                <rng:optional>
+                                  <rng:element name="MealsIncluded">
+
+                                    <rng:attribute name="MealPlanIndicator">
+                                      <rng:choice>
+                                        <rng:value>1</rng:value>
+                                        <rng:value>true</rng:value>
+                                      </rng:choice>
+                                    </rng:attribute>
+                                    <rng:attribute name="MealPlanCodes">
+                                      <rng:choice>
+                                        <rng:value>1</rng:value>
+                                        <rng:value>3</rng:value>
+                                        <rng:value>10</rng:value>
+                                        <rng:value>12</rng:value>
+                                        <rng:value>14</rng:value>
+                                      </rng:choice>
+                                    </rng:attribute>
+
+                                  </rng:element>
+                                </rng:optional>
+
+                                <rng:optional>
+                                  <rng:attribute name="RatePlanCode">
+                                    <rng:ref name="def_nonempty_string"/>
+                                  </rng:attribute>
+                                </rng:optional>
+
+                              </rng:element>
+
+                            </rng:element>
+
+                          </rng:optional>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > GuestCounts {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="GuestCounts">
+
+                              <!-- HotelReservation > RoomStays > RoomStay > GuestCounts > GuestCount {1,} -->
+
+                              <rng:oneOrMore>
+                                <rng:element name="GuestCount">
+
+                                  <rng:attribute name="Count">
+                                    <rng:ref name="def_int_gt0"/>
+                                  </rng:attribute>
+                                  <rng:optional>
+                                    <rng:attribute name="Age">
+                                      <rng:ref name="def_int_ge0"/>
+                                    </rng:attribute>
+                                  </rng:optional>
+
+                                </rng:element>
+                              </rng:oneOrMore>
+
+                            </rng:element>
+                          </rng:optional>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > TimeSpan {1} -->
+
+                          <rng:element name="TimeSpan">
+
+                            <!-- HotelReservation > RoomStays > RoomStay > TimeSpan > StartDateWindow {0,1} -->
+
+                            <rng:optional>
+                              <rng:element name="StartDateWindow">
+
+                                <rng:attribute name="EarliestDate">
+                                  <rng:ref name="def_date"/>
+                                </rng:attribute>
+                                <rng:attribute name="LatestDate">
+                                  <rng:ref name="def_date"/>
+                                </rng:attribute>
+
+                              </rng:element>
+                            </rng:optional>
+
+                            <rng:optional>
+                              <rng:attribute name="Start">
+                                <rng:ref name="def_date"/>
+                              </rng:attribute>
+                            </rng:optional>
+                            <rng:optional>
+                              <rng:attribute name="End">
+                                <rng:ref name="def_date"/>
+                              </rng:attribute>
+                            </rng:optional>
+                            <rng:optional>
+                              <rng:attribute name="Duration">
+                                <rng:data type="string">
+                                  <rng:param name="pattern">P[0-9]+N</rng:param>
+                                </rng:data>
+                              </rng:attribute>
+                            </rng:optional>
+
+                          </rng:element>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > Guarantee {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="Guarantee">
+                              <rng:element name="GuaranteesAccepted">
+                                <rng:element name="GuaranteeAccepted">
+
+                                  <rng:element name="PaymentCard">
+
+                                    <rng:attribute name="CardCode">
+                                      <rng:data type="string">
+                                        <rng:param name="pattern">[A-Z][A-Z]?</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+                                    <rng:attribute name="ExpireDate">
+                                      <rng:data type="string">
+                                        <rng:param name="pattern">[0-9][0-9][0-9][0-9]</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+
+                                    <rng:element name="CardHolderName">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:element>
+
+                                    <rng:element name="CardNumber">
+
+                                      <rng:choice>
+
+                                        <rng:element name="PlainText">
+                                          <rng:ref name="def_nonempty_string"/>
+                                        </rng:element>
+
+                                        <rng:group>
+                                          <rng:attribute name="EncryptedValue">
+                                            <rng:ref name="def_nonempty_string"/>
+                                          </rng:attribute>
+                                          <rng:attribute name="EncryptionMethod">
+                                            <rng:ref name="def_nonempty_string"/>
+                                          </rng:attribute>
+                                        </rng:group>
+
+                                      </rng:choice>
+
+                                    </rng:element>
+
+                                  </rng:element>
+
+                                </rng:element>
+                              </rng:element>
+                            </rng:element>
+                          </rng:optional>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > Total {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="Total">
+
+                              <rng:attribute name="AmountAfterTax">
+                                <rng:ref name="def_decimal_ge0"/>
+                              </rng:attribute>
+                              <rng:attribute name="CurrencyCode">
+                                <rng:ref name="def_nonempty_string"/>
+                              </rng:attribute>
+
+                            </rng:element>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:oneOrMore>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <!-- HotelReservation > ResGuests {0, 1} -->
+
+                  <rng:optional>
+                    <rng:element name="ResGuests">
+                      <rng:element name="ResGuest">
+                        <rng:element name="Profiles">
+                          <rng:element name="ProfileInfo">
+                            <rng:element name="Profile">
+
+                              <!-- HotelReservation > ... > Customer {1} -->
+
+                              <rng:element name="Customer">
+
+                                <!-- HotelReservation > ... > Customer > PersonName {1} -->
+
+                                <rng:element name="PersonName">
+
+                                  <rng:optional>
+                                    <rng:element name="NamePrefix">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:element>
+                                  </rng:optional>
+                                  <rng:element name="GivenName">
+                                    <rng:ref name="def_nonempty_string"/>
+                                  </rng:element>
+                                  <rng:element name="Surname">
+                                    <rng:ref name="def_nonempty_string"/>
+                                  </rng:element>
+                                  <rng:optional>
+                                    <rng:element name="NameTitle">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:element>
+
+                                  </rng:optional>
+                                </rng:element>
+
+                                <!-- HotelReservation > ... > Customer > Telephone {0,} -->
+
+                                <rng:zeroOrMore>
+                                  <rng:element name="Telephone">
+
+                                    <rng:attribute name="PhoneTechType">
+                                      <rng:data type="string">
+                                        <rng:param name="pattern">(1|3|5)</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+                                    <rng:attribute name="PhoneNumber">
+                                      <rng:data type="string">
+                                        <rng:param name="pattern">\+?[0-9]+</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+
+                                  </rng:element>
+                                </rng:zeroOrMore>
+
+                                <!-- HotelReservation > ... > Customer > Email {0,1} -->
+
+                                <rng:optional>
+                                  <rng:element name="Email">
+                                    <rng:ref name="def_email_string"/>
+                                    <rng:optional>
+                                      <rng:attribute name="Remark">
+                                        <rng:data type="string">
+                                          <rng:param name="pattern">newsletter:(no|yes)</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                    </rng:optional>
+
+                                  </rng:element>
+                                </rng:optional>
+
+                                <!-- HotelReservation > ... > Customer > Address {0,1} -->
+
+                                <rng:optional>
+                                  <rng:element name="Address">
+
+                                    <rng:optional>
+                                      <rng:element name="AddressLine">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                    </rng:optional>
+
+                                    <rng:optional>
+                                      <rng:element name="CityName">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                    </rng:optional>
+
+                                    <rng:optional>
+                                      <rng:element name="PostalCode">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                    </rng:optional>
+
+                                    <rng:optional>
+                                      <rng:element name="CountryName">
+                                        <rng:attribute name="Code">
+                                          <rng:data type="string">
+                                            <rng:param name="pattern">[A-Z][A-Z]</rng:param>
+                                          </rng:data>
+                                        </rng:attribute>
+                                      </rng:element>
+                                    </rng:optional>
+
+                                    <rng:optional>
+                                      <rng:attribute name="Remark">
+                                        <rng:data type="string">
+                                          <rng:param name="pattern">catalog:(no|yes)</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                    </rng:optional>
+
+                                  </rng:element>
+                                </rng:optional>
+
+                                <rng:optional>
+                                  <rng:attribute name="Gender">
+                                    <rng:data type="string">
+                                      <rng:param name="pattern">(Unknown|Male|Female)</rng:param>
+                                    </rng:data>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="BirthDate">
+                                    <rng:ref name="def_date"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Language">
+                                    <rng:data type="language">
+                                      <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                    </rng:data>
+                                  </rng:attribute>
+                                </rng:optional>
+
+                              </rng:element>
+                            </rng:element>
+                          </rng:element>
+                        </rng:element>
+                      </rng:element>
+                    </rng:element>
+                  </rng:optional>
+
+                  <!-- HotelReservation > ResGlobalInfo {0,1} -->
+
+                  <rng:optional>
+                    <rng:element name="ResGlobalInfo">
+
+                      <!-- HotelReservation > ResGlobalInfo > Comments {0,1} -->
+
+                      <rng:optional>
+                        <rng:element name="Comments">
+
+                          <!-- HotelReservation > ResGlobalInfo > Comments {1,} (actually {1,2} but Relax-NG cannot do this) -->
+
+                          <rng:oneOrMore>
+                            <rng:element name="Comment">
+                         
+                              <rng:choice>
+                                <rng:zeroOrMore>
+                         
+                                  <rng:element name="ListItem">
+                                    <rng:ref name="def_nonempty_string"/>
+                                    <rng:attribute name="ListItem">
+                                      <rng:ref name="def_int_ge0"/>
+                                    </rng:attribute>
+                                    <rng:attribute name="Language">
+                                      <rng:data type="language">
+                                        <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+                         
+                                  </rng:element>
+                                </rng:zeroOrMore>
+                         
+                                <rng:optional>
+                                  <rng:element name="Text">
+                                    <rng:ref name="def_nonempty_string"/>
+                                  </rng:element>
+                                </rng:optional>
+                         
+                              </rng:choice>
+                         
+                              <rng:attribute name="Name">
+                                <rng:choice>
+                                  <rng:value>included services</rng:value>
+                                  <rng:value>customer comment</rng:value>
+                                </rng:choice>
+                              </rng:attribute>
+                         
+                            </rng:element>
+                          </rng:oneOrMore>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <!-- HotelReservation > ResGlobalInfo > CancelPenalties {0,1} -->
+
+                      <rng:optional>
+                        <rng:element name="CancelPenalties">
+                          <rng:element name="CancelPenalty">
+                            <rng:element name="PenaltyDescription">
+                              <rng:element name="Text">
+                                <rng:ref name="def_nonempty_string"/>
+                              </rng:element>
+                            </rng:element>
+                          </rng:element>
+                        </rng:element>
+                      </rng:optional>
+
+                      <!-- HotelReservation > ResGlobalInfo > HotelReservationIDs {0,1} -->
+
+                      <rng:optional>
+                        <rng:element name="HotelReservationIDs">
+
+                          <rng:oneOrMore>
+                            <rng:element name="HotelReservationID">
+                          
+                              <rng:attribute name="ResID_Type">
+                                  <rng:ref name="def_int_gt0"/>
+                              </rng:attribute>
+                              <rng:optional>
+                                <rng:attribute name="ResID_Value">
+                                  <rng:ref name="def_nonempty_string"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="ResID_Source">
+                                  <rng:ref name="def_nonempty_string"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="ResID_SourceContext">
+                                  <rng:ref name="def_nonempty_string"/>
+                                </rng:attribute>
+                              </rng:optional>
+                          
+                            </rng:element>
+                          </rng:oneOrMore>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <!-- HotelReservation > ResGlobalInfo > Profiles {0,1} -->
+
+                      <rng:optional>
+                        <rng:element name="Profiles">
+                          <rng:element name="ProfileInfo">
+                            <rng:element name="Profile">
+                          
+                              <rng:attribute name="ProfileType">
+                                <rng:choice>
+                                  <rng:value>4</rng:value>
+                                </rng:choice>
+                              </rng:attribute>
+                          
+                              <rng:element name="CompanyInfo">
+                          
+                                  <rng:element name="CompanyName">
+                                    <rng:ref name="def_nonempty_string"/>
+                                    <rng:attribute name="Code">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:attribute>
+                                    <rng:attribute name="CodeContext">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:attribute>
+                                  </rng:element>
+                          
+                                  <rng:optional>
+                                    <rng:element name="AddressInfo">
+                                      <rng:element name="AddressLine">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                      <rng:element name="CityName">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                      <rng:element name="PostalCode">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                      <rng:element name="CountryName">
+                                        <rng:attribute name="Code">
+                                          <rng:data type="string">
+                                            <rng:param name="pattern">[A-Z][A-Z]</rng:param>
+                                          </rng:data>
+                                        </rng:attribute>
+                                      </rng:element>
+                                    </rng:element>
+                                  </rng:optional>
+                          
+                                  <rng:optional>
+                                    <rng:element name="TelephoneInfo">
+                                      <rng:attribute name="PhoneTechType">
+                                        <rng:data type="string">
+                                          <rng:param name="pattern">(1|3|5)</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                      <rng:attribute name="PhoneNumber">
+                                        <rng:data type="string">
+                                          <rng:param name="pattern">\+?[0-9]+</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                    </rng:element>
+                                  </rng:optional>
+                                  <rng:optional>
+                                    <rng:element name="Email">
+                                      <rng:ref name="def_email_string"/>
+                                    </rng:element>
+                                  </rng:optional>
+                          
+                              </rng:element>
+                          
+                            </rng:element>
+                          </rng:element>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <rng:element name="BasicPropertyInfo">
+                        <rng:empty/>
+                      </rng:element>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:attribute name="CreateDateTime">
+                    <rng:ref name="def_datetime"/>
+                  </rng:attribute>
+                  <rng:attribute name="ResStatus">
+                    <rng:choice>
+                      <rng:value>Requested</rng:value>
+                      <rng:value>Reserved</rng:value>
+                      <rng:value>Cancelled</rng:value>
+                      <rng:value>Modify</rng:value>
+                    </rng:choice>
+                  </rng:attribute>
+
+                </rng:element>
+              </rng:zeroOrMore>
+
+            </rng:element>
+          </rng:group>
+
+        </rng:choice>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- GuestRequests: OTA_NotifReportRQ -->
+
+      <rng:element name="OTA_NotifReportRQ">
+
+        <rng:element name="Success">
+          <rng:empty/>
+        </rng:element>
+
+        <rng:optional>
+          <rng:element name="Warnings">
+        
+            <!-- Warnings > Warning {1,} -->
+
+            <rng:oneOrMore>
+              <rng:element name="Warning">
+          
+                <rng:attribute name="Type">
+                  <rng:ref name="def_int_gt0"/>
+                </rng:attribute>
+
+                <rng:attribute name="Code">
+                  <rng:ref name="def_int_gt0"/>
+                </rng:attribute>
+
+                  <rng:attribute name="RecordID">
+                    <rng:ref name="def_nonempty_string"/>
+                  </rng:attribute>
+
+                <rng:text/>
+          
+              </rng:element>
+            </rng:oneOrMore>
+
+          </rng:element>
+        </rng:optional>
+
+        <rng:optional>
+          <rng:element name="NotifDetails">
+
+            <rng:element name="HotelNotifReport">
+
+              <rng:element name="HotelReservations">
+
+                <rng:oneOrMore>
+                  <rng:element name="HotelReservation">
+
+                    <rng:element name="UniqueID">
+
+                      <rng:attribute name="Type">
+                        <rng:choice>
+                          <rng:value>14</rng:value>
+                          <rng:value>15</rng:value>
+                        </rng:choice>
+                      </rng:attribute>
+                      <rng:attribute name="ID">
+                        <rng:ref name="def_nonempty_string"/>
+                      </rng:attribute>
+
+                    </rng:element>
+
+                  </rng:element>
+                </rng:oneOrMore>
+
+              </rng:element>
+
+            </rng:element>
+
+          </rng:element>
+
+        </rng:optional>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- GuestRequests: OTA_NotifReportRS -->
+
+      <rng:element name="OTA_NotifReportRS">
+
+        <rng:choice>
+
+          <!-- choice: Errors {1} -->
+
+          <rng:element name="Errors">
+
+            <!-- Errors > Error {1,} -->
+
+            <rng:oneOrMore>
+              <rng:element name="Error">
+
+                <rng:attribute name="Type">
+                  <rng:value type="string">13</rng:value>
+                </rng:attribute>
+                <rng:attribute name="Code">
+                  <rng:ref name="def_int_ge0"/>
+                </rng:attribute>
+
+                <rng:text/>
+
+              </rng:element>
+
+            </rng:oneOrMore>
+
+          </rng:element>
+
+          <!-- choice: Success {1} -->
+
+          <rng:element name="Success">
+            <rng:empty/>
+          </rng:element>
+
+        </rng:choice>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+ 
+      </rng:element>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * Inventory/Basic (Push) and Inventory/HotelInfo (Push)                         -->
+      <!-- ******************************************************************************* -->
+
+      <!-- Inventory: OTA_HotelDescriptiveContentNotifRQ -->
+
+      <rng:element name="OTA_HotelDescriptiveContentNotifRQ">
+
+        <rng:ref name="def_hoteldescriptivecontents"/>
+        
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- Inventory: OTA_HotelDescriptiveContentNotifRS -->
+
+      <rng:element name="OTA_HotelDescriptiveContentNotifRS">
+
+        <rng:ref name="def_generic_response"/>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * Inventory/Basic (Pull) and Inventory/HotelInfo (Pull)                         -->
+      <!-- ******************************************************************************* -->
+
+      <!-- Inventory: OTA_HotelDescriptiveInfoRQ -->
+
+      <rng:element name="OTA_HotelDescriptiveInfoRQ">
+
+        <rng:element name="HotelDescriptiveInfos">
+
+          <rng:element name="HotelDescriptiveInfo">
+            <rng:oneOrMore>
+              <rng:choice>
+                <rng:attribute name="HotelCode">
+                  <rng:ref name="def_nonempty_string"/>
+                </rng:attribute>
+                <rng:attribute name="HotelName">
+                  <rng:ref name="def_nonempty_string"/>
+                </rng:attribute>
+              </rng:choice>
+            </rng:oneOrMore>
+          </rng:element>
+
+        </rng:element>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+       
+      <!-- Inventory: OTA_HotelDescriptiveInfoRS -->
+
+      <rng:element name="OTA_HotelDescriptiveInfoRS">
+
+        <rng:choice>
+
+          <!-- choice: Errors {1} -->
+       
+          <rng:element name="Errors">
+        
+            <!-- Errors > Error {1,} -->
+       
+            <rng:oneOrMore>
+              <rng:element name="Error">
+       
+                <rng:attribute name="Type">
+                  <rng:value type="string">13</rng:value>
+                </rng:attribute>
+                <rng:attribute name="Code">
+                  <rng:ref name="def_int_gt0"/>
+                </rng:attribute>
+       
+                <rng:text/>
+       
+              </rng:element>
+            </rng:oneOrMore>
+       
+          </rng:element>
+       
+          <!-- choice: Success {1} + HotelDescriptiveContents {1} -->
+       
+          <rng:group>
+       
+            <rng:element name="Success">
+              <rng:empty/>
+            </rng:element>
+       
+            <rng:ref name="def_hoteldescriptivecontents"/>
+      
+          </rng:group>
+
+        </rng:choice>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+ 
+      <!-- ******************************************************************************* -->
+      <!-- * RatePlans                                                                     -->
+      <!-- ******************************************************************************* -->
+
+      <!-- RatePlans: OTA_HotelRatePlanNotifRQ  --> 
+
+      <rng:element name="OTA_HotelRatePlanNotifRQ">
+
+        <!-- UniqueID {0,1} -->
+
+        <rng:optional>
+          <rng:element name="UniqueID">
+
+            <rng:attribute name="Type">
+              <rng:value type="string">16</rng:value>
+            </rng:attribute>
+            <rng:attribute name="ID"/> <!-- an ID is required by OTA, we ignore the value -->
+            <rng:attribute name="Instance">
+              <rng:value type="string">CompleteSet</rng:value>
+            </rng:attribute>
+
+          </rng:element>
+        </rng:optional>
+
+        <!-- RatePlans {1} -->
+
+        <rng:ref name="def_rateplans"/>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- RatePlans: OTA_HotelRatePlanNotifRS -->
+
+      <rng:element name="OTA_HotelRatePlanNotifRS">
+
+        <rng:ref name="def_generic_response"/>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * BaseRates                                                                     -->
+      <!-- ******************************************************************************* -->
+
+      <!-- BaseRates: OTA_HotelRatePlanRQ --> 
+
+      <rng:element name="OTA_HotelRatePlanRQ">
+
+        <!-- RatePlans {1} -->
+
+        <rng:element name="RatePlans">
+
+          <!-- RatePlans > RatePlan {1} -->
+
+          <rng:element name="RatePlan">
+
+            <rng:oneOrMore>
+              <rng:choice>
+
+                <rng:element name="DateRange">
+                  <rng:optional>
+                    <rng:attribute name="Start">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="End">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+                </rng:element>
+
+                <rng:element name="RatePlanCandidates">
+                  <rng:oneOrMore>
+                    <rng:element name="RatePlanCandidate">
+                      <rng:optional>
+                         <rng:attribute name="RatePlanCode">
+                           <rng:ref name="def_nonempty_string"/>
+                         </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                         <rng:attribute name="RatePlanID">
+                           <rng:ref name="def_nonempty_string"/>
+                         </rng:attribute>
+                      </rng:optional>
+                    </rng:element>
+                  </rng:oneOrMore>
+                </rng:element>
+
+                <rng:element name="HotelRef">
+                  <rng:optional>
+                     <rng:attribute name="HotelCode">
+                       <rng:ref name="def_nonempty_string"/>
+                     </rng:attribute>
+                   </rng:optional>
+                  <rng:optional>
+                     <rng:attribute name="HotelName">
+                       <rng:ref name="def_nonempty_string"/>
+                     </rng:attribute>
+                  </rng:optional>
+                </rng:element>
+
+              </rng:choice>
+            </rng:oneOrMore>
+ 
+          </rng:element> <!-- close RatePlan -->
+
+        </rng:element> <!-- close RatePlans -->
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element> 
+
+      <!-- BaseRates: OTA_HotelRatePlanRS -->
+
+      <rng:element name="OTA_HotelRatePlanRS">
+
+        <rng:choice>
+
+          <!-- choice: Errors {1} -->
+       
+          <rng:element name="Errors">
+        
+            <!-- Errors > Error {1,} -->
+       
+            <rng:oneOrMore>
+              <rng:element name="Error">
+       
+                <rng:attribute name="Type">
+                  <rng:value type="string">13</rng:value>
+                </rng:attribute>
+                <rng:attribute name="Code">
+                  <rng:ref name="def_int_gt0"/>
+                </rng:attribute>
+       
+                <rng:text/>
+       
+              </rng:element>
+            </rng:oneOrMore>
+       
+          </rng:element>
+       
+          <!-- choice: Success {1} + RatePlans {1} -->
+       
+          <rng:group>
+       
+            <rng:element name="Success">
+              <rng:empty/>
+            </rng:element>
+       
+            <rng:ref name="def_rateplans"/>
+      
+          </rng:group>
+
+        </rng:choice>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+ 
+    </rng:choice>
+  </rng:start>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for HotelDescriptiveContents element as used                -->
+  <!-- * in the Inventory types                                                        -->
+  <!-- ******************************************************************************* -->
+
+  <rng:define name="def_hoteldescriptivecontents">
+
+    <rng:element name="HotelDescriptiveContents">
+
+      <rng:element name="HotelDescriptiveContent">
+
+          <!-- HotelInfo -->
+
+          <rng:optional>
+            <rng:element name="HotelInfo">
+              <rng:zeroOrMore>
+                <rng:ref name="def_anything"/>
+              </rng:zeroOrMore>
+              <rng:zeroOrMore>
+                <rng:ref name="def_any_attribute"/>
+              </rng:zeroOrMore>
+            </rng:element>
+          </rng:optional>
+
+          <!-- FacilityInfo --> 
+
+          <rng:optional>
+            <rng:element name="FacilityInfo">
+       
+                <rng:element name="GuestRooms">
+                  
+                  <rng:zeroOrMore>
+                    <rng:choice>
+       
+                      <!-- basic content + basic descriptions + optionally additional description -->
+                      <rng:element name="GuestRoom">
+       
+                        <rng:element name="TypeRoom">
+                          <rng:optional>
+                            <rng:attribute name="StandardOccupancy">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="RoomClassificationCode">
+                              <rng:ref name="def_int_ge0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="RoomID">
+                              <rng:ref name="def_nonempty_string"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Size">
+                              <rng:ref name="def_int_ge0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                        </rng:element>
+       
+                        <rng:optional>
+                          <rng:element name="Amenities">
+                            <rng:oneOrMore>
+                              <rng:element name="Amenity">
+                                  <rng:optional>
+                                    <rng:attribute name="RoomAmenityCode">
+                                      <rng:ref name="def_int_gt0"/>
+                                    </rng:attribute>
+                                  </rng:optional>
+                              </rng:element>
+                            </rng:oneOrMore>
+                          </rng:element>
+                        </rng:optional>
+       
+                        <rng:optional>
+                          <rng:element name="MultimediaDescriptions">
+       
+                            <rng:oneOrMore>
+       
+                              <rng:choice>
+       
+                                <!-- basic description: Long name + Description -->
+                                <rng:element name="MultimediaDescription">
+       
+                                  <rng:optional>
+                                    <rng:element name="TextItems">
+                                      <rng:element name="TextItem">
+                                        <rng:zeroOrMore>
+                                          <rng:element name="Description">
+                                            <rng:ref name="def_nonempty_string"/>
+                                            <rng:attribute name="TextFormat">
+                                              <rng:choice>
+                                                <rng:value>PlainText</rng:value>
+                                              </rng:choice>
+                                            </rng:attribute>
+                                            <rng:attribute name="Language">
+                                              <rng:data type="language">
+                                                <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                              </rng:data>
+                                            </rng:attribute>
+                                          </rng:element>
+                                        </rng:zeroOrMore>
+                                      </rng:element>
+                                    </rng:element>
+                                  </rng:optional>
+       
+                                  <rng:optional>
+                                    <rng:attribute name="InfoCode">
+                                      <rng:choice>
+                                        <rng:value>1</rng:value>
+                                        <rng:value>25</rng:value>
+                                      </rng:choice>
+                                    </rng:attribute>
+                                  </rng:optional>
+       
+                                </rng:element>
+       
+                                <!-- basic description: Pictures -->
+                                <rng:element name="MultimediaDescription">
+       
+                                  <rng:optional>
+                                    <rng:element name="ImageItems">
+
+                                      <rng:oneOrMore>
+                                        <rng:element name="ImageItem">
+                                          <rng:element name="ImageFormat">
+                                            <rng:element name="URL">
+                                              <rng:ref name="def_url_string"/>
+                                            </rng:element>
+                                            <rng:optional>
+                                              <rng:attribute name="CopyrightNotice">
+                                                <rng:ref name="def_nonempty_string"/>
+                                              </rng:attribute>
+                                            </rng:optional>
+                                          </rng:element>
+                                      
+                                          <rng:zeroOrMore>
+                                            <rng:element name="Description">
+                                              <rng:ref name="def_nonempty_string"/>
+                                              <rng:attribute name="TextFormat">
+                                                <rng:choice>
+                                                  <rng:value>PlainText</rng:value>
+                                                </rng:choice>
+                                              </rng:attribute>
+                                              <rng:attribute name="Language">
+                                                <rng:data type="language">
+                                                  <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                                </rng:data>
+                                              </rng:attribute>
+                                            </rng:element>
+                                          </rng:zeroOrMore>
+                                      
+                                          <rng:attribute name="Category">
+                                            <rng:ref name="def_int_gt0"/>
+                                          </rng:attribute>
+
+                                        </rng:element>
+                                      </rng:oneOrMore>
+
+                                    </rng:element>
+                                  </rng:optional>
+       
+                                  <rng:optional>
+                                    <rng:attribute name="InfoCode">
+                                      <rng:choice>
+                                        <rng:value>23</rng:value>
+                                      </rng:choice>
+                                    </rng:attribute>
+                                  </rng:optional>
+       
+                                </rng:element>
+       
+                                <!-- additional description -->
+                                <rng:element name="MultimediaDescription">
+       
+                                  <rng:optional>
+                                    <rng:element name="ImageItems">
+                                  
+                                      <rng:oneOrMore>
+                                        <rng:element name="ImageItem">
+                                          <rng:element name="ImageFormat">
+                                            <rng:element name="URL">
+                                              <rng:ref name="def_url_string"/>
+                                            </rng:element>
+                                            <rng:optional>
+                                              <rng:attribute name="CopyrightNotice">
+                                                <rng:ref name="def_nonempty_string"/>
+                                              </rng:attribute>
+                                            </rng:optional>
+                                          </rng:element>
+                                  
+                                          <rng:zeroOrMore>
+                                            <rng:element name="Description">
+                                              <rng:ref name="def_nonempty_string"/>
+                                              <rng:attribute name="TextFormat">
+                                                <rng:choice>
+                                                  <rng:value>PlainText</rng:value>
+                                                </rng:choice>
+                                              </rng:attribute>
+                                              <rng:attribute name="Language">
+                                                <rng:data type="language">
+                                                  <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                                </rng:data>
+                                              </rng:attribute>
+                                            </rng:element>
+                                          </rng:zeroOrMore>
+                                  
+                                          <rng:attribute name="Category">
+                                            <rng:ref name="def_int_gt0"/>
+                                          </rng:attribute>
+                                        </rng:element>
+                                      </rng:oneOrMore>
+                                  
+                                    </rng:element>
+                                  </rng:optional>
+       
+                                </rng:element>
+       
+                              </rng:choice>
+                            </rng:oneOrMore>
+       
+                          </rng:element>
+                        </rng:optional>
+       
+                        <rng:attribute name="Code">
+                          <rng:ref name="def_invTypeCode_string"/>
+                        </rng:attribute>
+                        <rng:optional>
+                          <rng:attribute name="MaxOccupancy">
+                            <rng:ref name="def_int_gt0"/>
+                          </rng:attribute>
+                        </rng:optional>
+                        <rng:optional>
+                          <rng:attribute name="MinOccupancy">
+                            <rng:ref name="def_int_gt0"/>
+                          </rng:attribute>
+                        </rng:optional>
+                        <rng:optional>
+                          <rng:attribute name="MaxChildOccupancy">
+                            <rng:ref name="def_int_gt0"/>
+                          </rng:attribute>
+                        </rng:optional>
+                        <rng:optional>
+                          <rng:attribute name="ID">
+                            <rng:ref name="def_invTypeCode_string"/>
+                          </rng:attribute>
+                        </rng:optional>
+
+                      </rng:element>
+       
+                      <!-- additional detail only -->
+                      <rng:element name="GuestRoom">
+       
+                        <rng:element name="MultimediaDescriptions">
+                          <rng:element name="MultimediaDescription">
+                            <rng:element name="ImageItems">
+       
+                              <rng:oneOrMore>
+                                <rng:element name="ImageItem">
+                                  <rng:element name="ImageFormat">
+                                    <rng:element name="URL">
+                                      <rng:ref name="def_url_string"/>
+                                    </rng:element>
+                                    <rng:optional>
+                                      <rng:attribute name="CopyrightNotice">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:attribute>
+                                    </rng:optional>
+                                  </rng:element>
+       
+                                  <rng:zeroOrMore>
+                                    <rng:element name="Description">
+                                      <rng:ref name="def_nonempty_string"/>
+                                      <rng:attribute name="TextFormat">
+                                        <rng:choice>
+                                          <rng:value>PlainText</rng:value>
+                                        </rng:choice>
+                                      </rng:attribute>
+                                      <rng:attribute name="Language">
+                                        <rng:data type="language">
+                                          <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                    </rng:element>
+                                  </rng:zeroOrMore>
+       
+                                  <rng:attribute name="Category">
+                                    <rng:ref name="def_int_gt0"/>
+                                  </rng:attribute>
+                                </rng:element>
+                              </rng:oneOrMore>
+       
+                            </rng:element>
+                          </rng:element>
+                        </rng:element>
+       
+                      <rng:attribute name="Code">
+                        <rng:ref name="def_nonempty_string"/>
+                      </rng:attribute>
+                      </rng:element>
+       
+                      <!-- room list -->
+                      <rng:element name="GuestRoom">
+                        <rng:element name="TypeRoom">
+                          <rng:attribute name="RoomID">
+                            <rng:ref name="def_nonempty_string"/>
+                          </rng:attribute>
+                        </rng:element>
+                      <rng:attribute name="Code">
+                        <rng:ref name="def_nonempty_string"/>
+                      </rng:attribute>
+                      </rng:element>
+       
+                    </rng:choice>
+                  </rng:zeroOrMore>
+                  
+                </rng:element>
+            </rng:element>
+          </rng:optional>
+       
+          <!-- Policies -->
+
+          <rng:optional>
+            <rng:element name="Policies">
+              <rng:zeroOrMore>
+                <rng:ref name="def_anything"/>
+              </rng:zeroOrMore>
+              <rng:zeroOrMore>
+                <rng:ref name="def_any_attribute"/>
+              </rng:zeroOrMore>
+            </rng:element>
+          </rng:optional>
+
+          <!-- AffiliationInfo -->
+
+          <rng:optional>
+            <rng:element name="AffiliationInfo">
+              <rng:zeroOrMore>
+                <rng:ref name="def_anything"/>
+              </rng:zeroOrMore>
+              <rng:zeroOrMore>
+                <rng:ref name="def_any_attribute"/>
+              </rng:zeroOrMore>
+            </rng:element>
+          </rng:optional>
+
+
+          <!-- ContactInfos -->
+
+          <rng:optional>
+            <rng:element name="ContactInfos">
+              <rng:zeroOrMore>
+                <rng:ref name="def_anything"/>
+              </rng:zeroOrMore>
+              <rng:zeroOrMore>
+                <rng:ref name="def_any_attribute"/>
+              </rng:zeroOrMore>
+            </rng:element>
+          </rng:optional>
+
+        <rng:oneOrMore>
+          <rng:choice>
+            <rng:attribute name="HotelCode">
+              <rng:ref name="def_nonempty_string"/>
+            </rng:attribute>
+            <rng:attribute name="HotelName">
+              <rng:ref name="def_nonempty_string"/>
+            </rng:attribute>
+            <rng:attribute name="HotelCityCode">
+              <rng:ref name="def_nonempty_string"/>
+            </rng:attribute>
+          </rng:choice>
+        </rng:oneOrMore>
+
+      </rng:element>
+        
+    </rng:element>
+
+  </rng:define>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for RatePlans element as used                               -->
+  <!-- * in RatePlans and BaseRates                                                    -->
+  <!-- ******************************************************************************* -->
+
+  <rng:define name="def_rateplans">
+
+    <rng:element name="RatePlans">
+
+      <!-- RatePlans > RatePlan {1,} -->
+
+      <rng:oneOrMore>
+        <rng:element name="RatePlan">
+
+          <!-- RatePlans > RatePlan > BookingRules {0,1} -->
+
+          <rng:optional>
+            <rng:element name="BookingRules">
+
+              <rng:oneOrMore>
+                <rng:element name="BookingRule">
+
+                  <rng:optional>
+                    <rng:element name="LengthsOfStay">
+
+                      <rng:oneOrMore>
+                        <rng:element name="LengthOfStay">
+
+                          <rng:attribute name="Time">
+                            <rng:ref name="def_decimal_ge0"/>
+                          </rng:attribute>
+                          <rng:attribute name="TimeUnit">
+                            <rng:value type="string">Day</rng:value>
+                          </rng:attribute>
+                          <rng:attribute name="MinMaxMessageType">
+                            <rng:choice>
+                              <rng:value>SetMinLOS</rng:value>
+                              <rng:value>SetForwardMinStay</rng:value>
+                              <rng:value>SetMaxLOS</rng:value>
+                              <rng:value>SetForwardMaxStay</rng:value>
+                            </rng:choice>
+                          </rng:attribute>
+
+                        </rng:element>
+                      </rng:oneOrMore>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:element name="DOW_Restrictions">
+
+                      <rng:optional>
+                        <rng:element name="ArrivalDaysOfWeek">
+
+                          <rng:optional>
+                            <rng:attribute name="Mon">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Tue">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Weds">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Thur">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Fri">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Sat">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Sun">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <rng:optional>
+                        <rng:element name="DepartureDaysOfWeek">
+
+                          <rng:optional>
+                            <rng:attribute name="Mon">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Tue">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Weds">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Thur">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Fri">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Sat">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Sun">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:optional>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:element name="RestrictionStatus">
+
+                      <rng:optional>
+                        <rng:attribute name="Restriction">
+                          <rng:choice>
+                            <rng:value>Master</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="Status">
+                          <rng:choice>
+                            <rng:value>Open</rng:value>
+                            <rng:value>Close</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:optional>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="CodeContext">
+                      <rng:choice>
+                        <rng:value>ROOMTYPE</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="Code">
+                      <rng:ref name="def_invTypeCode_string"/>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="Start">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="End">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+                </rng:element>
+              </rng:oneOrMore>
+
+            </rng:element>
+          </rng:optional>
+
+          <!-- RatePlans > RatePlan > Rates {0,1} -->
+
+          <rng:optional>
+            <rng:element name="Rates">
+
+              <rng:oneOrMore>
+                <rng:element name="Rate">
+
+                  <rng:optional>
+                    <rng:element name="BaseByGuestAmts">
+
+                      <rng:oneOrMore>
+                        <rng:element name="BaseByGuestAmt">
+
+                          <rng:optional>
+                            <rng:attribute name="NumberOfGuests">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="AmountAfterTax">
+                              <rng:ref name="def_decimal_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="CurrencyCode">
+                              <rng:choice>
+                                <rng:value>EUR</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Type">
+                              <rng:choice>
+                                <rng:value>7</rng:value>
+                                <rng:value>25</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="AgeQualifyingCode">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:oneOrMore>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:element name="AdditionalGuestAmounts">
+
+                      <rng:oneOrMore>
+                        <rng:element name="AdditionalGuestAmount">
+
+                          <rng:optional>
+                            <rng:attribute name="Amount">
+                              <rng:ref name="def_decimal_ge0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="AgeQualifyingCode">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="MinAge">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="MaxAge">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:oneOrMore>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:element name="MealsIncluded">
+
+                      <rng:optional>
+                        <rng:attribute name="MealPlanCodes">
+                          <rng:choice>
+                            <rng:value>1</rng:value>
+                            <rng:value>3</rng:value>
+                            <rng:value>10</rng:value>
+                            <rng:value>12</rng:value>
+                            <rng:value>14</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="MealPlanIndicator">
+                          <rng:choice>
+                            <rng:value>1</rng:value>
+                            <rng:value>true</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:optional>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="Start">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="End">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="RateTimeUnit">
+                      <rng:choice>
+                        <rng:value type="string">Day</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="UnitMultiplier">
+                      <rng:ref name="def_int_gt0"/>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="InvTypeCode">
+                      <rng:ref name="def_invTypeCode_string"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                </rng:element>
+              </rng:oneOrMore>
+
+            </rng:element>
+          </rng:optional>
+
+          <!-- RatePlans > RatePlan > Supplements {0,1} -->
+
+          <rng:optional>
+            <rng:element name="Supplements">
+
+              <rng:oneOrMore>
+                <rng:element name="Supplement">
+
+                  <rng:optional>
+                    <rng:choice>
+                      <rng:element name="PrerequisiteInventory">
+                        <rng:attribute name="InvCode">
+                          <rng:data type="string">
+                              <rng:param name="pattern">[01]{7}</rng:param>
+                            </rng:data>
+                        </rng:attribute>
+                        <rng:attribute name="InvType">
+                          <rng:choice>
+                            <rng:value>ALPINEBITSDOW</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:element>
+                      <rng:element name="PrerequisiteInventory">
+                        <rng:attribute name="InvCode">
+                          <rng:ref name="def_invTypeCode_string"/>
+                        </rng:attribute>
+                        <rng:attribute name="InvType">
+                          <rng:choice>
+                            <rng:value>ROOMTYPE</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:element>
+                    </rng:choice>
+                  </rng:optional>
+
+                  <!-- RatePlans > RatePlan > Supplements > Supplement > Description {0,} (actually {0,5} but Relax-NG cannot do this) -->
+           
+                  <rng:zeroOrMore>
+                    <rng:element name="Description">
+           
+                      <rng:oneOrMore>
+                        <rng:choice>
+           
+                          <rng:element name="ListItem">
+                            <rng:ref name="def_nonempty_string"/>
+                          </rng:element>
+                        
+                          <rng:element name="Image">
+                            <rng:ref name="def_url_string"/>
+                          </rng:element>
+           
+                          <rng:element name="Text">
+                            <rng:ref name="def_nonempty_string"/>
+                            <rng:attribute name="TextFormat">
+                              <rng:choice>
+                                <rng:value>PlainText</rng:value>
+                                <rng:value>HTML</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+                            <rng:optional>
+                              <rng:attribute name="Language">
+                                <rng:data type="language">
+                                  <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                </rng:data>
+                              </rng:attribute>
+                            </rng:optional>
+                          </rng:element>
+           
+                          <rng:element name="URL">
+                            <rng:ref name="def_url_string"/>
+                          </rng:element>
+           
+                        </rng:choice>
+                      </rng:oneOrMore>
+           
+                      <rng:attribute name="Name">
+                        <rng:choice>
+                          <rng:value>title</rng:value>
+                          <rng:value>intro</rng:value>
+                          <rng:value>description</rng:value>
+                          <rng:value>gallery</rng:value>
+                          <rng:value>codelist</rng:value>
+                        </rng:choice>
+                      </rng:attribute>
+           
+                    </rng:element>
+                  </rng:zeroOrMore>
+
+                  <rng:optional>
+                    <rng:attribute name="AddToBasicRateIndicator">
+                      <rng:choice>
+                        <rng:value>1</rng:value>
+                        <rng:value>true</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="ChargeTypeCode">
+                      <rng:choice>
+                        <rng:value>1</rng:value>
+                        <rng:value>12</rng:value>
+                        <rng:value>18</rng:value>
+                        <rng:value>19</rng:value>
+                        <rng:value>20</rng:value>
+                        <rng:value>21</rng:value>
+                        <rng:value>24</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+                  </rng:optional>
+               
+                  <rng:optional>
+                    <rng:attribute name="Amount">
+                      <rng:ref name="def_decimal_ge0"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="InvType">
+                      <rng:choice>
+                        <rng:value>EXTRA</rng:value>
+                        <rng:value>ALPINEBITSEXTRA</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="InvCode">
+                      <rng:ref name="def_nonempty_string"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="MandatoryIndicator">
+                      <rng:ref name="def_bool"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="Start">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="End">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                </rng:element>
+              </rng:oneOrMore>
+
+            </rng:element>
+          </rng:optional>
+
+          <!-- RatePlans > RatePlan > Offers {0,1}  -->
+
+          <rng:optional>
+            <rng:element name="Offers">
+
+              <rng:oneOrMore>
+                <rng:element name="Offer">
+
+                  <rng:zeroOrMore>
+                    <rng:element name="OfferRules">
+
+                      <rng:element name="OfferRule">
+
+                        <rng:optional>
+                          <rng:element name="LengthsOfStay">
+                      
+                            <rng:oneOrMore>
+                              <rng:element name="LengthOfStay">
+                      
+                                <rng:attribute name="Time">
+                                  <rng:ref name="def_decimal_ge0"/>
+                                </rng:attribute>
+                                <rng:attribute name="TimeUnit">
+                                  <rng:value type="string">Day</rng:value>
+                                </rng:attribute>
+                                <rng:attribute name="MinMaxMessageType">
+                                  <rng:choice>
+                                    <rng:value>SetMinLOS</rng:value>
+                                    <rng:value>SetMaxLOS</rng:value>
+                                  </rng:choice>
+                                </rng:attribute>
+                      
+                              </rng:element>
+                            </rng:oneOrMore>
+                      
+                          </rng:element>
+                        </rng:optional>
+                      
+                        <rng:optional>
+                          <rng:element name="DOW_Restrictions">
+                      
+                            <rng:optional>
+                              <rng:element name="ArrivalDaysOfWeek">
+                      
+                                <rng:optional>
+                                  <rng:attribute name="Mon">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Tue">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Weds">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Thur">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Fri">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Sat">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Sun">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                      
+                              </rng:element>
+                            </rng:optional>
+                      
+                            <rng:optional>
+                              <rng:element name="DepartureDaysOfWeek">
+                      
+                                <rng:optional>
+                                  <rng:attribute name="Mon">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Tue">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Weds">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Thur">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Fri">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Sat">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Sun">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                      
+                              </rng:element>
+                            </rng:optional>
+                      
+                          </rng:element>
+                        </rng:optional>
+                    
+                        <rng:zeroOrMore>
+                          <rng:element name="Occupancy">
+                      
+                            <rng:attribute name="AgeQualifyingCode">
+                              <rng:choice>
+                                <rng:value>8</rng:value>
+                                <rng:value>10</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+
+                            <rng:optional>
+                              <rng:attribute name="MinAge">
+                                <rng:ref name="def_int_gt0"/>
+                              </rng:attribute>
+                            </rng:optional>
+
+                            <rng:optional>
+                              <rng:attribute name="MaxAge">
+                                <rng:ref name="def_int_gt0"/>
+                              </rng:attribute>
+                            </rng:optional>
+
+                            <rng:optional>
+                              <rng:attribute name="MinOccupancy">
+                                <rng:ref name="def_int_ge0"/>
+                              </rng:attribute>
+                            </rng:optional>
+
+                            <rng:optional>
+                              <rng:attribute name="MaxOccupancy">
+                                <rng:ref name="def_int_gt0"/>
+                              </rng:attribute>
+                            </rng:optional>
+ 
+                          </rng:element>
+                        </rng:zeroOrMore>
+                      
+                        <rng:optional>
+                          <rng:attribute name="MinAdvancedBookingOffset">
+                            <rng:data type="string">
+                              <rng:param name="pattern">P[0-9]+D</rng:param>
+                            </rng:data>
+                          </rng:attribute>
+                        </rng:optional>
+ 
+                        <rng:optional>
+                          <rng:attribute name="MaxAdvancedBookingOffset">
+                            <rng:data type="string">
+                              <rng:param name="pattern">P[0-9]+D</rng:param>
+                            </rng:data>
+                          </rng:attribute>
+                        </rng:optional>
+
+                       </rng:element>
+                    </rng:element>
+                  </rng:zeroOrMore>
+
+                  <rng:optional>
+                    <rng:element name="Discount">
+                
+                      <rng:attribute name="Percent">
+                        <rng:value type="string">100</rng:value>
+                      </rng:attribute>
+                      <rng:optional>
+                        <rng:attribute name="NightsRequired">
+                          <rng:ref name="def_int_gt0"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="NightsDiscounted">
+                          <rng:ref name="def_int_gt0"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="DiscountPattern">
+                          <rng:data type="string">
+                            <rng:param name="pattern">0*1*</rng:param>
+                          </rng:data>
+                        </rng:attribute>
+                      </rng:optional>
+                
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:element name="Guests">
+
+                      <rng:element name="Guest">
+
+                        <rng:attribute name="AgeQualifyingCode">
+                          <rng:ref name="def_int_gt0"/>
+                        </rng:attribute>
+                        <rng:attribute name="MaxAge">
+                          <rng:ref name="def_int_gt0"/>
+                        </rng:attribute>
+                        <rng:attribute name="MinCount">
+                          <rng:ref name="def_int_ge0"/>
+                        </rng:attribute>
+                        <rng:attribute name="FirstQualifyingPosition">
+                          <rng:choice>
+                            <rng:value>1</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                        <rng:attribute name="LastQualifyingPosition">
+                          <rng:ref name="def_int_gt0"/>
+                        </rng:attribute>
+
+                      </rng:element> 
+
+                    </rng:element> 
+                  </rng:optional>
+
+                </rng:element>  <!-- close Offer -->
+              </rng:oneOrMore>
+
+            </rng:element>  <!-- close Offers -->
+          </rng:optional>
+
+          <!-- RatePlans > RatePlan > Description {0,} (actually {0,5} but Relax-NG cannot do this) -->
+
+          <rng:zeroOrMore>
+            <rng:element name="Description">
+
+              <rng:oneOrMore>
+                <rng:choice>
+
+                  <rng:element name="ListItem">
+                    <rng:ref name="def_nonempty_string"/>
+                  </rng:element>
+                
+                  <rng:element name="Image">
+                    <rng:ref name="def_url_string"/>
+                  </rng:element>
+
+                  <rng:element name="Text">
+                    <rng:ref name="def_nonempty_string"/>
+                    <rng:attribute name="TextFormat">
+                      <rng:choice>
+                        <rng:value>PlainText</rng:value>
+                        <rng:value>HTML</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+                    <rng:optional>
+                      <rng:attribute name="Language">
+                        <rng:data type="language">
+                          <rng:param name="pattern">[a-z][a-z]</rng:param>
+                        </rng:data>
+                      </rng:attribute>
+                    </rng:optional>
+                  </rng:element>
+
+                  <rng:element name="URL">
+                    <rng:ref name="def_url_string"/>
+                  </rng:element>
+
+                </rng:choice>
+              </rng:oneOrMore>
+
+              <rng:attribute name="Name">
+                <rng:choice>
+                  <rng:value>title</rng:value>
+                  <rng:value>intro</rng:value>
+                  <rng:value>description</rng:value>
+                  <rng:value>gallery</rng:value>
+                  <rng:value>codelist</rng:value>
+                </rng:choice>
+              </rng:attribute>
+
+            </rng:element>
+          </rng:zeroOrMore>
+ 
+          <rng:optional>
+            <rng:attribute name="RatePlanNotifType">
+              <rng:choice>
+                <rng:value>Overlay</rng:value>
+                <rng:value>New</rng:value>
+                <rng:value>Remove</rng:value>
+              </rng:choice>
+            </rng:attribute>
+          </rng:optional>
+          <rng:optional>
+            <rng:attribute name="CurrencyCode">
+              <rng:choice>
+                <rng:value>EUR</rng:value>
+              </rng:choice>
+            </rng:attribute>
+          </rng:optional>
+          <rng:optional>
+            <rng:attribute name="RatePlanCode">
+              <rng:ref name="def_nonempty_string"/>
+            </rng:attribute>
+          </rng:optional>
+          <rng:optional>
+            <rng:attribute name="RatePlanType">
+              <rng:choice>
+                <rng:value>12</rng:value>
+              </rng:choice>
+            </rng:attribute>
+          </rng:optional>
+          <rng:optional>
+            <rng:attribute name="RatePlanCategory">
+              <rng:ref name="def_nonempty_string"/>
+            </rng:attribute>
+          </rng:optional>
+          <rng:optional>
+            <rng:attribute name="RatePlanID">
+              <rng:ref name="def_nonempty_string"/>
+            </rng:attribute>
+          </rng:optional>
+          <rng:optional>
+            <rng:attribute name="RatePlanQualifier">
+              <rng:ref name="def_bool"/>
+            </rng:attribute>
+          </rng:optional>
+
+        </rng:element>
+      </rng:oneOrMore>
+
+      <rng:oneOrMore>
+        <rng:choice>
+          <rng:attribute name="HotelCode">
+            <rng:ref name="def_nonempty_string"/>
+          </rng:attribute>
+          <rng:attribute name="HotelName">
+            <rng:ref name="def_nonempty_string"/>
+          </rng:attribute>
+        </rng:choice>
+      </rng:oneOrMore>
+
+    </rng:element>
+
+  </rng:define>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for success/advisory/warning/error responses                -->
+  <!-- ******************************************************************************* -->
+
+  <rng:define name="def_generic_response">
+    <rng:choice>
+
+      <!-- choice: Errors {1} -->
+
+      <rng:element name="Errors">
+    
+        <!-- Errors > Error {1,} -->
+
+        <rng:oneOrMore>
+          <rng:element name="Error">
+
+            <rng:attribute name="Type">
+              <rng:value type="string">13</rng:value>
+            </rng:attribute>
+            <rng:attribute name="Code">
+              <rng:ref name="def_int_gt0"/>
+            </rng:attribute>
+
+            <rng:text/>
+
+          </rng:element>
+        </rng:oneOrMore>
+
+      </rng:element>
+
+      <!-- choice: Success {1} + Warnings {0,1} -->
+
+      <rng:group>
+
+        <rng:element name="Success">
+          <rng:empty/>
+        </rng:element>
+
+        <rng:optional>
+          <rng:element name="Warnings">
+        
+            <!-- Warnings > Warning {1,} -->
+
+            <rng:oneOrMore>
+              <rng:element name="Warning">
+          
+                <rng:attribute name="Type">
+                  <rng:ref name="def_int_gt0"/>
+                </rng:attribute>
+
+                <rng:optional>
+                  <rng:attribute name="RecordID">
+                    <rng:ref name="def_nonempty_string"/>
+                  </rng:attribute>
+                </rng:optional>
+
+                <rng:text/>
+          
+              </rng:element>
+            </rng:oneOrMore>
+
+          </rng:element>
+        </rng:optional>
+
+      </rng:group>
+
+    </rng:choice>
+  </rng:define>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for recurring, simple types                                 -->
+  <!-- ******************************************************************************* -->
+
+  <!-- A generic non-empty string type. -->
+
+  <rng:define name="def_nonempty_string">
+    <rng:data type="string">
+      <rng:param name="minLength">1</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic string type containing an @ char, like an email address. -->
+
+  <rng:define name="def_email_string">
+    <rng:data type="string">
+      <rng:param name="pattern">\S+@\S+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic string type starting with http:// or https:// --> 
+
+  <rng:define name="def_url_string">
+    <rng:data type="string">
+      <rng:param name="pattern">https?://.+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- String type defining room category codes (like InvTypeCode)  -->
+
+  <rng:define name="def_invTypeCode_string">
+    <rng:data type="string">
+      <rng:param name="minLength">1</rng:param>
+      <rng:param name="maxLength">8</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic integer > 0 type. -->
+
+  <rng:define name="def_int_gt0">
+    <rng:data type="positiveInteger">
+      <rng:param name="pattern">[0-9]+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic integer >= 0 type. -->
+
+  <rng:define name="def_int_ge0">
+    <rng:data type="nonNegativeInteger">
+      <rng:param name="pattern">[0-9]+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic decimal >= 0 type. -->
+
+  <rng:define name="def_decimal_ge0">
+    <rng:data type="decimal">
+      <rng:param name="minInclusive">0.0</rng:param>
+      <rng:param name="pattern">[0-9]*\.?[0-9]*</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic decimal > 0 type. -->
+
+  <rng:define name="def_decimal_gt0">
+    <rng:data type="decimal">
+      <rng:param name="minExclusive">0.0</rng:param>
+      <rng:param name="pattern">[0-9]*\.?[0-9]*</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic date type. -->
+
+  <rng:define name="def_date">
+    <rng:data type="date">
+      <rng:param name="pattern">\S+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic datetime type. -->
+
+  <rng:define name="def_datetime">
+    <rng:data type="dateTime">
+      <rng:param name="pattern">\S+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic boolean type (1,true,0,false). -->
+
+  <rng:define name="def_bool">
+    <rng:data type="boolean">
+      <rng:param name="pattern">\S+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- Anything. -->
+
+  <rng:define name="def_anything">
+    <rng:interleave>
+      <rng:zeroOrMore>
+        <rng:element>
+          <rng:anyName/>
+          <rng:zeroOrMore>
+            <rng:ref name="def_anything"/>
+          </rng:zeroOrMore>
+          <rng:zeroOrMore>
+            <rng:ref name="def_any_attribute"/>
+          </rng:zeroOrMore>
+        </rng:element>
+      </rng:zeroOrMore>
+    <rng:text/>
+    </rng:interleave>
+  </rng:define>
+
+  <rng:define name="def_any_attribute">
+    <rng:attribute>
+      <rng:anyName/>
+    </rng:attribute>
+  </rng:define>
+
+</rng:grammar>
+

--- a/alpinebits-xml/api/src/main/resources/alpinebits-2017-10.xsd
+++ b/alpinebits-xml/api/src/main/resources/alpinebits-2017-10.xsd
@@ -1,0 +1,2405 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+     AlpineBits 2017-10
+     http://www.alpinebits.org/
+
+     W3C XML Schema file
+
+     changelog:
+
+    v. 2017-10  1.1 -  RatePlans:       RatePlans > RatePlan > Offers: allow only MinLOS and MaxLOS attributes (not the forward ones too)
+
+    v. 2017-10  1.0 -  FreeRooms:       OTA_HotelAvailNotifRQ -> UniqueID (added allowed value to attribute Type, by Luca Rainone)
+                       FreeRooms:       OTA_HotelAvailNotifRQ -> AvailStatusMessages -> ...  -> StatusApplicationControl (added new mandatory attribute BookingThreshold)
+
+                       GuestRequests:   OTA_ResRetrieveRS -> ReservationsList -> ... -> RatePlan (added element Commission)
+                       GuestRequests:   OTA_ResRetrieveRS -> ReservationsList -> ... -> CardNumber (added attributes EncryptedValue and EncryptionMethod) 
+                       GuestRequests:   OTA_ResRetrieveRS -> ReservationsList -> ... -> RoomStay > RoomTypes (made optional)
+
+                       SimplePackages section removed
+
+                       Inventory has become Inventory/Basic (Push) and Inventory/HotelInfo (Push):
+                                        OTA_HotelDescriptiveContentNotifRQ (major changes, one being that empty GuestRooms elements are now allowed by Luca Rainone)
+
+                       Inventory/Basic (Pull) and Inventory/HotelInfo (Pull) added
+ 
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> BookingRules -> ... -> LengthOfStay (added allowed values to attribute MinMaxMessageType)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Supplements -> Supplement (added element PrerequisiteInventory)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Supplements -> Supplement -> Description (major changes)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Offers -> Offer (major changes)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Description (major changes)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> ... -> BaseByGuestAmt (NumberOfGuests and Type are optional now to allow static rates)
+
+                       BaseRates section added
+
+    v. 2015-07b 1.4 - weaken the schema for Inventory (to prepare for upcoming release that will support Inventory deltas):
+
+                      - the RoomAmenityCode attribute becomes optional to allow empty Amenity elements 
+                      - the MultimediaDescription element can be empty
+
+    v. 2015-07b 1.3 - RatePlans > RatePlan > Description > TextFormat can now also be "HTML" (besides "PlainText")
+
+    v. 2015-07b 1.2 - added optional attributes RatePlanID and RatePlanQualifier to RatePlan
+                      for the new OTA_HotelRatePlanNotif_accept_RatePlanJoin capability
+
+    v. 2015-07b 1.1 - added def_invTypeCode_string type (string with up to 8 chars) used for the following attributes that identify room categories:
+
+                      FreeRooms:     OTA_HotelAvailNotifRQ -> AvailStatusMessages -> AvailStatusMessage -> StatusApplicationControl -> InvTypeCode
+                      GuestRequests: OTA_ResRetrieveRS -> ReservationList -> HotelReservation -> RoomStays -> RoomStay -> RoomTypes > RoomType -> RoomTypeCode
+                      Inventory:     OTA_HotelDescriptiveContentNotifRQ -> HotelDescriptiveContents -> HotelDescriptiveContent -> FacilityInfo -> GuestRooms -> GuestRoom -> Code
+                      RatePlan:      OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> BookingRules -> BookingRule -> Code
+                      RatePlan:      OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Rates -> Rate -> InvTypeCode
+
+                      (derived from Lukas Braun's pull request)
+
+    v. 2015-07b 1.0 - RatePlans > RatePlan > Rates > Rate > BaseByGuestAmts > AmountAfterTax
+                      must be > 0.0 (was: >= 0.0)
+
+     v. 2015-07 2.9 - Inventory: added a missing maxOccurs="unbounded" to the ImageItem
+
+     v. 2015-07 2.8 - Inventory: reconciled with the definitions given in the updated document
+
+     v. 2015-07 2.7 - changes to Inventory: removed the old Inventory, added MaxChildOccupancy to GuestRoom,
+                      made some of the attributes mandatory, formating changes
+
+     v. 2015-07 2.6 - made sub-elements of HotelReservation > ... > Customer > Address {0,1} optional
+
+     v. 2015-07 2.5 - added a choice of 'Modify' for ResStatusValue
+
+     v. 2015-07 2.4 - added MinCount attribute to Offer>>Guest
+
+     v. 2015-07 2.3 - changes to Supplement: a few attributes are removed and many attributes are made optional
+
+     v. 2015-07 2.2 - RatePlans/Supplements: changed format of description
+
+     v. 2015-07 2.1 - GuestRequests: ResGuests >> Customer: attributes Gender and Language are now optional
+
+     v. 2015-07 2.0 - allow Warnings in OTA_NotifReportRQ messages
+
+     v. 2015-07 1.9 - GuestRequests: use CardNumber -> PlainText instead of the Remark attribute of
+                      PaymentCard under Guarantee; add BasicPropertyInfo element at the end of the 
+                      ResGlobalInfo block for OTA-2015A compatiblity
+
+     v. 2015-07 1.8 - added section for New Inventory (exact name pending)
+
+     v. 2015-07 1.7 - allowed more than one HotelReservationID
+
+     v. 2015-07 1.6 - RatePlans: allow optional PrerequisiteInventory element under Supplement element
+
+     v. 2015-07 1.5 - Inventory: removed Amenities and added optional Room -> RoomTypeCode
+
+     v. 2015-07 1.4 - HotelReservationID -> ResID_Type is not limited to 13 anymore
+
+     v. 2015-07 1.3 - new section in RoomStays: Guarantee -> GuaranteesAccepted -> GuaranteeAccepted -> PaymentCard
+
+     v. 2015-07 1.2 - new section in ResGlobalInfo: Profiles -> ProfileInfo -> Profile -> CompanyInfo
+
+     v. 2015-07 1.1 - HotelReservation > RoomStays > RoomStay > RoomTypes > RoomType is now
+                      mandatory and has a new optional attribute RoomClassificationCode
+
+     v. 2015-07 1.0 - OTA_NotifReportRS besides Success, now also allows Error responses 
+
+     v. 2014-04 1.6 - [fixed] InvCode attribute in Supplement changed from def_int_ge0 to def_nonempty_string
+
+     v. 2014-04 1.5 - [strictness improvement] made NumberOfGuests attribute mandatory
+
+     v. 2014-04 1.4 - [fixed] RatePlans: optional Rate attributes RateTimeUnit and UnitMultiplier added
+
+     v. 2014-04 1.3 - [fixed] GuestRequests: ReservationsList can be empy
+
+     v. 2014-04 1.2 - follow-up to fix 1.1 that allowed empty AvailStatusMessages elements too
+                      (reverted)
+
+     v. 2014-04 1.1 - empty AvailStatusMessage elements in FreeRooms now allowed
+                      (see https://groups.google.com/d/msg/alpinebits/B-orBE9eJCk/rKyIYbNBFNoJ )
+                    - Version and TimeStamp also added to OTA_NotifReportRS 
+                      (see https://groups.google.com/d/msg/alpinebits/jwaPC3XAafo/yDDYCkpNPYEJ )
+
+     v. 2014-04 1.0 - major rewrite for 2014-04
+
+     previous changelogs:
+
+     v. 2013-04 1.0 - the XML schema is now flattened into this single file;
+                      some improvements by Martin;
+                      added optional RatePlanCode attribute to RatePlan;
+                      removed restrictions on the form of the ID attribute in UniqueID
+
+     W3C XML Schema for OTA_HotelAvailNotifRQ:
+     v. 2013-04 1.0 - added MessageContentCode attribute for delta messages
+     v. 2012-05 1.2 - changed Thu -> Thur and Wed -> Weds for OTA compatibility
+     v. 2012-05 1.1 - added optional TimeStamp attribute for OTA_HotelAvailNotifRQ to be compatible with AlpineBits 2011-11 documents
+     v. 2012-05 1.0
+      
+     W3C XML Schema for OTA_HotelAvailNotifRS:
+     v. 2013-04 1.0 - added warnings
+     v. 2012-05 1.0
+  
+     W3C XML Schema for OTA_ReadRQ:
+     v. 2012-05 1.0
+   
+     W3C XML Schema for OTA_ResRetrieveRS:
+     v. 2013-04 1.0 - simplified the definition of GuestCounts for XSD conformance,
+                      moved UniqueID and RatePlans elements to common to support schema flattening
+     v. 2012-05 1.0
+  
+     W3C XML Schema for OTA_HotelRatePlanNotifRQ:
+     v. 2013-04 1.0 - removed def_plaintext and simplified def_rate_plan to fix an issue with the parsing of the schema,
+                      moved UniqueID and RatePlans elements to common
+     v. 2012-05 1.2 - changed Thu -> Thur and Wed -> Weds for OTA compatibility
+     v. 2012-05 1.0
+  
+     W3C XML Schema for OTA_HotelRatePlanNotifRS:
+     v. 2013-04 1.0 - added warnings
+     v. 2012-05 1.0
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           targetNamespace="http://www.opentravel.org/OTA/2003/05"
+           xmlns="http://www.opentravel.org/OTA/2003/05">
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * FreeRooms                                                                     -->
+  <!-- ******************************************************************************* -->
+
+  <!-- FreeRooms: OTA_HotelAvailNotifRQ -->
+
+  <xs:element name="OTA_HotelAvailNotifRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <!-- UniqueID {0,1} -->
+
+        <xs:element name="UniqueID" minOccurs="0">
+          <xs:complexType>
+            <xs:attribute name="Type" use="required">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="16"/>
+                  <xs:enumeration value="35"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="ID" use="required" type="xs:string"/> <!-- an ID is required by OTA, we ignore the value -->
+            <xs:attribute name="Instance" use="required">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="CompleteSet"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+
+        <!-- AvailStatusMessages {1} -->
+
+        <xs:element name="AvailStatusMessages">
+          <xs:complexType>
+            <xs:sequence>
+
+              <!-- AvailStatusMessages > AvailStatusMessage (1,} -->
+              
+              <xs:element name="AvailStatusMessage" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <!-- AvailStatusMessages > AvailStatusMessage > StatusApplicationControl {0,1} -->
+
+                    <xs:element name="StatusApplicationControl" minOccurs="0">
+                      <xs:complexType>
+                        <xs:attribute name="Start"        use="required" type="def_date"/>
+                        <xs:attribute name="End"          use="required" type="def_date"/>
+                        <xs:attribute name="InvTypeCode"                 type="def_invTypeCode_string"/>
+                        <xs:attribute name="InvCode"                     type="def_nonempty_string"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                  </xs:sequence>
+                  <xs:attribute name="BookingLimitMessageType">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="SetLimit"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="BookingLimit" type="def_int_ge0"/>
+                  <xs:attribute name="BookingThreshold" type="def_int_ge0"/>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+            <xs:attribute name="HotelCode" type="def_nonempty_string"/>
+            <xs:attribute name="HotelName" type="def_nonempty_string"/>
+          </xs:complexType> 
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- FreeRooms: OTA_HotelAvailNotifRS -->
+
+  <xs:element name="OTA_HotelAvailNotifRS">
+    <xs:complexType>
+      <xs:group   ref="def_generic_response"/>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * GuestRequests                                                                 -->
+  <!-- ******************************************************************************* -->
+
+  <!-- GuestRequests: OTA_ReadRQ -->
+
+  <xs:element name="OTA_ReadRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <xs:element name="ReadRequests">
+          <xs:complexType>
+            <xs:sequence>
+
+              <xs:element name="HotelReadRequest">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <xs:element name="SelectionCriteria" minOccurs="0">
+                      <xs:complexType>
+                        <xs:attribute name="Start" use="required" type="def_datetime"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                  </xs:sequence>
+                  <xs:attribute name="HotelCode" type="def_nonempty_string"/> 
+                  <xs:attribute name="HotelName" type="def_nonempty_string"/>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- GuestRequests: OTA_ResRetrieveRS -->
+
+  <xs:element name="OTA_ResRetrieveRS">
+    <xs:complexType>
+
+      <xs:choice>
+
+        <!-- choice: Errors {1} -->
+
+        <xs:element name="Errors">
+          <xs:complexType>
+            <xs:sequence>
+
+              <!-- Errors > Error {1,} -->
+
+              <xs:element name="Error" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type" use="required">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="13"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="Code" use="required" type="def_int_ge0"/>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:sequence>
+
+          <!-- choice: Success {1} + ReservationsList {1} -->
+
+          <xs:element name="Success"/>
+
+          <xs:element name="ReservationsList">
+            <xs:complexType>
+              <xs:sequence>
+
+               <!-- HotelReservation {0,} -->
+ 
+                <xs:element name="HotelReservation" maxOccurs="unbounded" minOccurs="0">
+                  <xs:complexType>
+                    <xs:sequence>
+
+                      <!-- HotelReservation > UniqueID {1} -->
+
+                      <xs:element name="UniqueID">
+                        <xs:complexType>
+                          <xs:attribute name="Type" use="required">
+                            <xs:simpleType>
+                              <xs:restriction base="xs:string">
+                                <xs:enumeration value="14"/>
+                                <xs:enumeration value="15"/>
+                              </xs:restriction>
+                            </xs:simpleType>
+                          </xs:attribute>
+                          <xs:attribute name="ID" use="required" type="def_nonempty_string"/>
+                        </xs:complexType>
+                      </xs:element>
+
+                      <!-- HotelReservation > RoomStays {0,1} -->
+
+                      <xs:element name="RoomStays" minOccurs="0">
+                        <xs:complexType>
+                          <xs:sequence>
+
+                            <!-- HotelReservation > RoomStays > RoomStay {1,} -->
+
+                            <xs:element name="RoomStay" maxOccurs="unbounded">
+                              <xs:complexType>
+                                <xs:sequence>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > RoomTypes {0,1} -->
+
+                                  <xs:element name="RoomTypes" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:sequence>
+
+                                        <!-- HotelReservation > RoomStays > RoomStay > RoomTypes > RoomType {1} -->
+
+                                        <xs:element name="RoomType">
+                                          <xs:complexType>
+                                            <xs:attribute name="RoomTypeCode"           type="def_invTypeCode_string"/>
+                                            <xs:attribute name="RoomClassificationCode" type="def_int_ge0"/>
+                                          </xs:complexType>
+                                        </xs:element>
+
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > RatePlans {0,1} -->
+
+                                  <xs:element name="RatePlans" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:sequence>
+
+                                        <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan {1} -->
+
+                                        <xs:element name="RatePlan">
+                                          <xs:complexType>
+                                            <xs:sequence>
+
+                                              <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan > Commission {0,1} -->
+
+                                              <xs:element name="Commission" minOccurs="0">
+                                                <xs:complexType>
+                                                  <xs:sequence>
+                                                    <xs:element name="CommissionPayableAmount" minOccurs="0">
+                                                      <xs:complexType>
+                                                        <xs:attribute name="Amount" type="def_decimal_ge0"/>
+                                                        <xs:attribute name="CurrencyCode">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:enumeration value="EUR"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                      </xs:complexType>
+                                                    </xs:element>
+                                                  </xs:sequence>
+                                                  <xs:attribute name="Percent" type="def_int_ge0"/>
+                                                </xs:complexType>
+                                              </xs:element>
+
+                                              <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan > MealsIncluded {0,1} -->
+
+                                              <xs:element name="MealsIncluded" minOccurs="0">
+                                                <xs:complexType>
+                                                  <xs:attribute name="MealPlanIndicator" use="required">
+                                                    <xs:simpleType>
+                                                      <xs:restriction base="xs:string">
+                                                        <xs:enumeration value="1"/>
+                                                        <xs:enumeration value="true"/>
+                                                      </xs:restriction>
+                                                    </xs:simpleType>
+                                                  </xs:attribute>
+                                                  <xs:attribute name="MealPlanCodes" use="required">
+                                                    <xs:simpleType>
+                                                      <xs:restriction base="xs:string">
+                                                        <xs:enumeration value="1"/>
+                                                        <xs:enumeration value="3"/>
+                                                        <xs:enumeration value="10"/>
+                                                        <xs:enumeration value="12"/>
+                                                        <xs:enumeration value="14"/>
+                                                      </xs:restriction>
+                                                    </xs:simpleType>
+                                                  </xs:attribute>
+                                                </xs:complexType>
+                                              </xs:element>
+
+                                            </xs:sequence>
+                                            <xs:attribute name="RatePlanCode" type="def_nonempty_string"/>
+                                          </xs:complexType>
+                                        </xs:element>
+
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > GuestCounts {0,1} -->
+
+                                  <xs:element name="GuestCounts" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:sequence>
+
+                                        <!-- HotelReservation > RoomStays > RoomStay > GuestCounts > GuestCount {1,} -->
+
+                                        <xs:element name="GuestCount" maxOccurs="unbounded">
+                                          <xs:complexType>
+                                            <xs:attribute name="Count" use="required" type="def_int_gt0"/>
+                                            <xs:attribute name="Age"                  type="def_int_ge0"/>
+                                          </xs:complexType>
+                                        </xs:element>
+
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > TimeSpan {1} -->
+
+                                  <xs:element name="TimeSpan">
+                                    <xs:complexType>
+                                      <xs:sequence>
+
+                                        <!-- HotelReservation > RoomStays > RoomStay > TimeSpan > StartDateWindow {0,1} -->
+
+                                        <xs:element name="StartDateWindow" minOccurs="0">
+                                          <xs:complexType>
+                                            <xs:attribute name="EarliestDate" use="required" type="def_date"/>
+                                            <xs:attribute name="LatestDate"   use="required" type="def_date"/>
+                                          </xs:complexType>
+                                        </xs:element>
+
+                                      </xs:sequence>
+                                      <xs:attribute name="Start" type="def_date"/>
+                                      <xs:attribute name="End"   type="def_date"/>
+                                      <xs:attribute name="Duration">
+                                        <xs:simpleType>
+                                          <xs:restriction base="xs:string">
+                                            <xs:pattern value="P[0-9]+N"/>
+                                          </xs:restriction>
+                                        </xs:simpleType>
+                                      </xs:attribute>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > Guarantee {0,1} -->
+
+                                  <xs:element name="Guarantee" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="GuaranteesAccepted">
+                                          <xs:complexType>
+                                            <xs:sequence>
+                                              <xs:element name="GuaranteeAccepted">
+                                                <xs:complexType>
+                                                  <xs:sequence>
+                                      
+                                                    <xs:element name="PaymentCard">
+                                                      <xs:complexType>
+                                                        <xs:sequence>
+                                                          <xs:element name="CardHolderName" type="def_nonempty_string"/>
+
+                                                          <xs:element name="CardNumber">
+                                                            <xs:complexType>
+                                                              <xs:sequence>
+                                                                <xs:element name="PlainText" type="def_nonempty_string" minOccurs="0"/>
+                                                              </xs:sequence>
+                                                             <xs:attribute name="EncryptedValue" type="def_nonempty_string"/>
+                                                             <xs:attribute name="EncryptionMethod" type="def_nonempty_string"/>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                        </xs:sequence>
+                                                        <xs:attribute name="CardCode" use="required">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="[A-Z][A-Z]?"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                        <xs:attribute name="ExpireDate" use="required">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="[0-9][0-9][0-9][0-9]"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                      </xs:complexType>
+                                                    </xs:element>
+                                      
+                                                  </xs:sequence>
+                                                </xs:complexType>
+                                              </xs:element>
+                                            </xs:sequence>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > Total {0,1} -->
+
+                                  <xs:element name="Total" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:attribute name="AmountAfterTax" use="required" type="def_decimal_ge0"/>
+                                      <xs:attribute name="CurrencyCode"   use="required" type="def_nonempty_string"/>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+
+                      <!-- HotelReservation > ResGuests {0, 1} -->
+
+                      <xs:element name="ResGuests" minOccurs="0">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="ResGuest">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="Profiles">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="ProfileInfo">
+                                          <xs:complexType>
+                                            <xs:sequence>
+                                              <xs:element name="Profile">
+                                                <xs:complexType>
+                                                  <xs:sequence>
+
+                                                    <!-- HotelReservation > ... > Customer {1} -->
+
+                                                    <xs:element name="Customer">
+                                                      <xs:complexType>
+                                                        <xs:sequence>
+
+                                                          <!-- HotelReservation > ... > Customer > PersonName {1} -->
+
+                                                          <xs:element name="PersonName">
+                                                            <xs:complexType>
+                                                              <xs:sequence>
+                                                                <xs:element name="NamePrefix" minOccurs="0" type="def_nonempty_string"/>
+                                                                <xs:element name="GivenName"                type="def_nonempty_string"/>
+                                                                <xs:element name="Surname"                  type="def_nonempty_string"/>
+                                                                <xs:element name="NameTitle"  minOccurs="0" type="def_nonempty_string"/>
+                                                              </xs:sequence>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                          <!-- HotelReservation > ... > Customer > Telephone {0,} -->
+
+                                                          <xs:element name="Telephone" minOccurs="0" maxOccurs="unbounded">
+                                                            <xs:complexType>
+                                                              <xs:attribute name="PhoneTechType" use="required">
+                                                                <xs:simpleType>
+                                                                  <xs:restriction base="xs:string">
+                                                                    <xs:pattern value="(1|3|5)"/>
+                                                                  </xs:restriction>
+                                                                </xs:simpleType>
+                                                              </xs:attribute>
+                                                              <xs:attribute name="PhoneNumber" use="required">
+                                                                <xs:simpleType>
+                                                                  <xs:restriction base="xs:string">
+                                                                    <xs:pattern value="\+?[0-9]+"/>
+                                                                  </xs:restriction>
+                                                                </xs:simpleType>
+                                                              </xs:attribute>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                          <!-- HotelReservation > ... > Customer > Email {0,1} -->
+
+                                                          <xs:element name="Email" minOccurs="0">
+                                                            <xs:complexType>
+                                                              <xs:simpleContent>
+                                                                <xs:extension base="def_email_string"> 
+                                                                  <xs:attribute name="Remark">
+                                                                    <xs:simpleType>
+                                                                      <xs:restriction base="xs:string">
+                                                                        <xs:pattern value="newsletter:(no|yes)"/>
+                                                                      </xs:restriction>
+                                                                    </xs:simpleType>
+                                                                  </xs:attribute>
+                                                                </xs:extension>
+                                                              </xs:simpleContent>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                          <!-- HotelReservation > ... > Customer > Address {0,1} -->
+
+                                                          <xs:element name="Address" minOccurs="0">
+                                                            <xs:complexType>
+                                                              <xs:sequence>
+                                                                <xs:element name="AddressLine"  type="def_nonempty_string" minOccurs="0"/>
+                                                                <xs:element name="CityName"     type="def_nonempty_string" minOccurs="0"/>
+                                                                <xs:element name="PostalCode"   type="def_nonempty_string" minOccurs="0"/>
+                                                                <xs:element name="CountryName"  minOccurs="0">
+                                                                  <xs:complexType>
+                                                                    <xs:attribute name="Code" use="required">
+                                                                      <xs:simpleType>
+                                                                        <xs:restriction base="xs:string">
+                                                                          <xs:pattern value="[A-Z][A-Z]"/>
+                                                                        </xs:restriction>
+                                                                      </xs:simpleType>
+                                                                    </xs:attribute>
+                                                                  </xs:complexType>
+                                                                </xs:element>
+                                                              </xs:sequence>
+                                                              <xs:attribute name="Remark">
+                                                                <xs:simpleType>
+                                                                  <xs:restriction base="xs:string">
+                                                                    <xs:pattern value="catalog:(no|yes)"/>
+                                                                  </xs:restriction>
+                                                                </xs:simpleType>
+                                                              </xs:attribute>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                        </xs:sequence>
+                                                        <xs:attribute name="Gender">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="(Unknown|Male|Female)"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                        <xs:attribute name="BirthDate" type="def_date"/>
+                                                        <xs:attribute name="Language">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:language">
+                                                              <xs:pattern value="[a-z][a-z]"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                      </xs:complexType>
+                                                    </xs:element>
+
+                                                  </xs:sequence>
+                                                </xs:complexType>
+                                              </xs:element>
+                                            </xs:sequence>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+
+                      <!-- HotelReservation > ResGlobalInfo {0,1} -->
+
+                      <xs:element name="ResGlobalInfo" minOccurs="0">
+                        <xs:complexType>
+                          <xs:sequence>
+
+                            <!-- HotelReservation > ResGlobalInfo > Comments {0,1} -->
+
+                            <xs:element name="Comments" minOccurs="0">
+                              <xs:complexType>
+                                <xs:sequence>
+
+                                 <!-- HotelReservation > ResGlobalInfo > Comments {1,2} -->
+
+                                  <xs:element name="Comment" maxOccurs="2">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:choice>
+
+                                          <xs:element name="ListItem" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                              <xs:simpleContent>
+                                                <xs:extension base="def_nonempty_string">
+                                                  <xs:attribute name="ListItem" use="required" type="def_int_ge0"/>
+                                                  <xs:attribute name="Language" use="required">
+                                                    <xs:simpleType>
+                                                      <xs:restriction base="xs:language">
+                                                        <xs:pattern value="[a-z][a-z]"/>
+                                                      </xs:restriction>
+                                                    </xs:simpleType>
+                                                  </xs:attribute>
+                                                </xs:extension>
+                                              </xs:simpleContent>
+                                            </xs:complexType>
+                                          </xs:element>
+
+                                          <xs:element name="Text" minOccurs="0" type="def_nonempty_string"/>
+
+                                        </xs:choice>
+                                      </xs:sequence>
+                                      <xs:attribute name="Name" use="required">
+                                        <xs:simpleType>
+                                          <xs:restriction base="xs:string">
+                                            <xs:enumeration value="included services"/>
+                                            <xs:enumeration value="customer comment"/>
+                                          </xs:restriction>
+                                        </xs:simpleType>
+                                      </xs:attribute>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+
+                            <!-- HotelReservation > ResGlobalInfo > CancelPenalties {0,1} -->
+
+                            <xs:element name="CancelPenalties" minOccurs="0">
+                              <xs:complexType>        
+                                <xs:sequence>         
+                                  <xs:element name="CancelPenalty">
+                                    <xs:complexType>  
+                                      <xs:sequence>   
+                                        <xs:element name="PenaltyDescription">
+                                          <xs:complexType>
+                                            <xs:sequence>
+                                              <xs:element name="Text" type="def_nonempty_string"/>
+                                            </xs:sequence>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>  
+                                    </xs:complexType> 
+                                  </xs:element>       
+                                </xs:sequence>        
+                              </xs:complexType>       
+                            </xs:element>             
+
+                            <!-- HotelReservation > ResGlobalInfo > HotelReservationIDs {0,1} -->
+
+                            <xs:element name="HotelReservationIDs" minOccurs="0">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="HotelReservationID" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                      <xs:attribute name="ResID_Type" use="required" type="def_int_gt0"/>
+                                      <xs:attribute name="ResID_Value"               type="def_nonempty_string"/>
+                                      <xs:attribute name="ResID_Source"              type="def_nonempty_string"/>
+                                      <xs:attribute name="ResID_SourceContext"       type="def_nonempty_string"/>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+
+                            <!-- HotelReservation > ResGlobalInfo > Profiles {0,1} -->
+
+                            <xs:element name="Profiles" minOccurs="0">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="ProfileInfo">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="Profile">
+                                          <xs:complexType>
+                                            <xs:sequence>
+                                              <xs:element name="CompanyInfo">
+                                                <xs:complexType>
+                                                  <xs:sequence>
+
+                                                    <xs:element name="CompanyName">
+                                                      <xs:complexType>
+                                                        <xs:simpleContent>
+                                                          <xs:extension base="def_nonempty_string"> 
+                                                            <xs:attribute name="Code"        use="required" type="def_nonempty_string"/>
+                                                            <xs:attribute name="CodeContext" use="required" type="def_nonempty_string"/>
+                                                          </xs:extension>
+                                                        </xs:simpleContent>
+                                                      </xs:complexType>
+                                                    </xs:element>
+
+                                                    <xs:element name="AddressInfo" minOccurs="0">
+                                                      <xs:complexType>
+                                                        <xs:sequence>
+                                                          <xs:element name="AddressLine"  type="def_nonempty_string"/>
+                                                          <xs:element name="CityName"     type="def_nonempty_string"/>
+                                                          <xs:element name="PostalCode"   type="def_nonempty_string"/>
+                                                          <xs:element name="CountryName">
+                                                            <xs:complexType>
+                                                              <xs:attribute name="Code" use="required">
+                                                                <xs:simpleType>
+                                                                  <xs:restriction base="xs:string">
+                                                                    <xs:pattern value="[A-Z][A-Z]"/>
+                                                                  </xs:restriction>
+                                                                </xs:simpleType>
+                                                              </xs:attribute>
+                                                            </xs:complexType>
+                                                          </xs:element>
+                                                        </xs:sequence>
+                                                      </xs:complexType>
+                                                    </xs:element>
+
+                                                    <xs:element name="TelephoneInfo" minOccurs="0">
+                                                      <xs:complexType>
+                                                        <xs:attribute name="PhoneTechType" use="required">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="(1|3|5)"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                        <xs:attribute name="PhoneNumber" use="required">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="\+?[0-9]+"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                      </xs:complexType>
+                                                    </xs:element>
+
+                                                    <xs:element name="Email" minOccurs="0" type="def_nonempty_string"/>
+
+                                                  </xs:sequence>
+                                                </xs:complexType>
+                                              </xs:element>
+                                            </xs:sequence>
+                                            <xs:attribute name="ProfileType" use="required">
+                                              <xs:simpleType>
+                                                <xs:restriction base="xs:string">
+                                                  <xs:enumeration value="4"/>
+                                                </xs:restriction>
+                                              </xs:simpleType>
+                                            </xs:attribute>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+
+                            <xs:element name="BasicPropertyInfo"/>
+
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+
+                    </xs:sequence>
+                    <xs:attribute name="CreateDateTime" use="required" type="def_datetime"/>
+                    <xs:attribute name="ResStatus"      use="required">
+                      <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                          <xs:enumeration value="Requested"/>
+                          <xs:enumeration value="Reserved"/>
+                          <xs:enumeration value="Cancelled"/>
+                          <xs:enumeration value="Modify"/>
+                        </xs:restriction>
+                      </xs:simpleType>
+                    </xs:attribute>
+                  </xs:complexType>
+                </xs:element>
+
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+
+        </xs:sequence>
+
+      </xs:choice>
+
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- GuestRequests: OTA_NotifReportRQ -->
+
+  <xs:element name="OTA_NotifReportRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <xs:element name="Success"/>
+
+        <xs:element name="Warnings" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Warning" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type"     use="required" type="def_int_gt0"/>
+                  <xs:attribute name="Code"     use="required" type="def_int_gt0"/>
+                  <xs:attribute name="RecordID" use="required" type="def_nonempty_string"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="NotifDetails" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+
+              <xs:element name="HotelNotifReport">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <xs:element name="HotelReservations">
+                      <xs:complexType>
+                        <xs:sequence>
+
+                          <xs:element name="HotelReservation" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:sequence>
+
+                                <xs:element name="UniqueID">
+                                  <xs:complexType>
+                                    <xs:attribute name="Type" use="required">
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="14"/>
+                                          <xs:enumeration value="15"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:attribute>
+                                    <xs:attribute name="ID" use="required" type="def_nonempty_string"/>
+                                  </xs:complexType>
+                                </xs:element>
+                 
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- GuestRequests: OTA_NotifReportRS -->
+
+  <xs:element name="OTA_NotifReportRS">
+    <xs:complexType>
+
+      <xs:choice>
+
+        <!-- choice: Errors {1} -->
+
+        <xs:element name="Errors">
+          <xs:complexType>
+            <xs:sequence>
+   
+              <!-- Errors > Error {1,} -->
+   
+              <xs:element name="Error" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type" use="required">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="13"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="Code" use="required" type="def_int_ge0"/>
+                </xs:complexType>
+              </xs:element>
+   
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <!-- choice: Success {1} -->
+
+        <xs:sequence>
+          <xs:element name="Success"/>
+        </xs:sequence>
+
+      </xs:choice>
+
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+
+    </xs:complexType>
+  </xs:element>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * Inventory/Basic (Push) and Inventory/HotelInfo (Push)                         -->
+  <!-- ******************************************************************************* -->
+
+  <!-- Inventory: OTA_HotelDescriptiveContentNotifRQ -->
+
+  <xs:element name="OTA_HotelDescriptiveContentNotifRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <xs:group ref="def_hoteldescriptivecontents"/>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required" />
+      <xs:attribute name="TimeStamp" />
+    </xs:complexType>
+  </xs:element>
+
+  <!-- Inventory: OTA_HotelDescriptiveContentNotifRS -->
+  
+  <xs:element name="OTA_HotelDescriptiveContentNotifRS">
+    <xs:complexType>
+      <xs:group ref="def_generic_response"/>
+      <xs:attribute name="Version" use="required" />
+      <xs:attribute name="TimeStamp" />
+    </xs:complexType>
+  </xs:element>
+ 
+
+  <!-- ******************************************************************************* -->
+  <!-- * Inventory/Basic (Pull) and Inventory/HotelInfo (Pull)                         -->
+  <!-- ******************************************************************************* -->
+
+  <!-- Inventory: OTA_HotelDescriptiveInfoRQ -->
+
+  <xs:element name="OTA_HotelDescriptiveInfoRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <xs:element name="HotelDescriptiveInfos" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+
+              <xs:element name="HotelDescriptiveInfo" maxOccurs="1">
+                <xs:complexType>
+                  <xs:attribute name="HotelCode" type="def_nonempty_string"/>
+                  <xs:attribute name="HotelName" type="def_nonempty_string"/>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required" />
+      <xs:attribute name="TimeStamp" />
+    </xs:complexType>
+  </xs:element>
+
+  <!-- Inventory: OTA_HotelDescriptiveInfoRS -->
+  
+  <xs:element name="OTA_HotelDescriptiveInfoRS"> 
+    <xs:complexType>
+
+      <xs:choice>
+
+        <!-- choice: Errors {1} -->
+
+        <xs:element name="Errors">
+          <xs:complexType>
+            <xs:sequence>
+   
+              <!-- Errors > Error {1,} -->
+   
+              <xs:element name="Error" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type" use="required">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="13"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="Code" use="required" type="def_int_ge0"/>
+                </xs:complexType>
+              </xs:element>
+   
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <!-- choice: Success {1} + HotelDescriptiveContents {1} -->
+
+        <xs:sequence>
+          <xs:element name="Success"/>
+          <xs:group ref="def_hoteldescriptivecontents"/>
+        </xs:sequence>
+
+      </xs:choice>
+
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+
+    </xs:complexType>
+  </xs:element>
+
+ 
+  <!-- ******************************************************************************* -->
+  <!-- * RatePlans                                                                     -->
+  <!-- ******************************************************************************* -->
+
+  <!-- RatePlans: OTA_HotelRatePlanNotifRQ -->
+
+  <xs:element name="OTA_HotelRatePlanNotifRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <!-- UniqueID {0,1} -->
+
+        <xs:element name="UniqueID" minOccurs="0">
+          <xs:complexType>
+            <xs:attribute name="Type" use="required">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="16"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="ID" use="required" type="xs:string"/> <!-- an ID is required by OTA, we ignore the value -->
+            <xs:attribute name="Instance" use="required">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="CompleteSet"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+
+        <!-- RatePlans {1} -->
+
+        <xs:group ref="def_rateplans"/>
+ 
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- RatePlans: OTA_HotelRatePlanNotifRS -->
+
+  <xs:element name="OTA_HotelRatePlanNotifRS">
+    <xs:complexType>
+      <xs:group   ref="def_generic_response"/>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * BaseRates                                                                     -->
+  <!-- ******************************************************************************* -->
+
+  <!-- BaseRates: OTA_HotelRatePlanRQ -->
+
+  <xs:element name="OTA_HotelRatePlanRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <!-- RatePlans {1} -->
+ 
+        <xs:element name="RatePlans">
+          <xs:complexType>
+            <xs:sequence>
+
+              <!-- RatePlans > RatePlan {1} -->
+
+              <xs:element name="RatePlan">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <xs:choice maxOccurs="unbounded">
+
+                      <xs:element name="DateRange">
+                        <xs:complexType>
+                          <xs:attribute name="Start" type="def_date"/>
+                          <xs:attribute name="End"   type="def_date"/>
+                        </xs:complexType>
+                      </xs:element>
+
+                      <xs:element name="RatePlanCandidates">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="RatePlanCandidate" maxOccurs="unbounded">
+                              <xs:complexType>
+                                <xs:attribute name="RatePlanCode" type="def_nonempty_string"/>
+                                <xs:attribute name="RatePlanID" type="def_nonempty_string"/>
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+
+                      <xs:element name="HotelRef">
+                        <xs:complexType>
+                          <xs:attribute name="HotelCode" type="def_nonempty_string"/>
+                          <xs:attribute name="HotelName" type="def_nonempty_string"/>
+                        </xs:complexType>
+                      </xs:element>
+
+                    </xs:choice>
+
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+
+    </xs:complexType>
+  </xs:element>
+
+  <!-- BaseRates: OTA_HotelRatePlanRS -->
+
+  <xs:element name="OTA_HotelRatePlanRS">
+    <xs:complexType>
+
+      <xs:choice>
+
+        <!-- choice: Errors {1} -->
+
+        <xs:element name="Errors">
+          <xs:complexType>
+            <xs:sequence>
+   
+              <!-- Errors > Error {1,} -->
+   
+              <xs:element name="Error" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type" use="required">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="13"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="Code" use="required" type="def_int_ge0"/>
+                </xs:complexType>
+              </xs:element>
+   
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <!-- choice: Success {1} + RatePlans {1} -->
+
+        <xs:sequence>
+          <xs:element name="Success"/>
+          <xs:group ref="def_rateplans"/>
+        </xs:sequence>
+
+      </xs:choice>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+
+    </xs:complexType>
+  </xs:element>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for HotelDescriptiveContents element as used                -->
+  <!-- * in the Inventory types                                                        -->
+  <!-- ******************************************************************************* -->
+
+  <xs:group name="def_hoteldescriptivecontents">
+    <xs:sequence>
+
+        <xs:element name="HotelDescriptiveContents" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+
+              <xs:element name="HotelDescriptiveContent" maxOccurs="1">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <!-- HotelInfo -->
+                    <xs:element name="HotelInfo" minOccurs="0" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                        <xs:anyAttribute processContents="lax"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                    <!-- FacilityInfo -->
+                    <xs:element name="FacilityInfo" minOccurs="0" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+
+                          <xs:element name="GuestRooms" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:sequence>
+
+                                <xs:element name="GuestRoom" minOccurs="0" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:sequence>
+
+                                      <xs:element name="TypeRoom" minOccurs="0">
+                                        <xs:complexType>
+                                          <xs:attribute name="StandardOccupancy"      type="def_int_gt0" />
+                                          <xs:attribute name="RoomClassificationCode" type="def_int_ge0" />
+                                          <xs:attribute name="RoomID"                 type="def_nonempty_string" />
+                                          <xs:attribute name="Size"                   type="def_int_ge0" />
+                                        </xs:complexType>
+                                      </xs:element>
+
+                                      <xs:element name="Amenities" minOccurs="0">
+                                        <xs:complexType>
+                                          <xs:sequence>
+
+                                            <xs:element name="Amenity" maxOccurs="unbounded">
+                                              <xs:complexType>
+                                                <xs:attribute name="RoomAmenityCode" type="def_int_gt0"/>
+                                              </xs:complexType>
+                                            </xs:element>
+
+                                          </xs:sequence>
+                                        </xs:complexType>
+                                      </xs:element>
+
+                                      <xs:element name="MultimediaDescriptions" minOccurs="0">
+                                        <xs:complexType>
+                                          <xs:sequence>
+
+                                            <xs:element name="MultimediaDescription" maxOccurs="unbounded" minOccurs="0">
+                                              <xs:complexType>
+                                                <xs:choice>
+
+                                                  <xs:element name="TextItems" minOccurs="0">
+                                                    <xs:complexType>
+                                                      <xs:sequence>
+
+                                                        <xs:element name="TextItem">
+                                                          <xs:complexType>
+                                                            <xs:sequence>
+
+                                                              <xs:element name="Description" maxOccurs="unbounded">
+                                                                <xs:complexType>
+                                                                  <xs:simpleContent>
+                                                                    <xs:extension base="def_nonempty_string">
+                                                                      <xs:attribute name="TextFormat" use="required">
+                                                                        <xs:simpleType>
+                                                                          <xs:restriction base="xs:string">
+                                                                            <xs:enumeration value="PlainText"/>
+                                                                          </xs:restriction>
+                                                                        </xs:simpleType>
+                                                                      </xs:attribute>
+                                                                      <xs:attribute name="Language" use="required">
+                                                                        <xs:simpleType>
+                                                                          <xs:restriction base="xs:language">
+                                                                            <xs:pattern value="[a-z][a-z]"/>
+                                                                          </xs:restriction>
+                                                                        </xs:simpleType>
+                                                                      </xs:attribute>
+                                                                    </xs:extension>
+                                                                  </xs:simpleContent>
+                                                                </xs:complexType>
+                                                              </xs:element>
+
+                                                            </xs:sequence>
+                                                          </xs:complexType>
+                                                        </xs:element>
+
+                                                      </xs:sequence>
+                                                    </xs:complexType>
+                                                  </xs:element>
+
+                                                  <xs:element name="ImageItems" minOccurs="0">
+                                                    <xs:complexType>
+                                                      <xs:sequence>
+
+                                                        <xs:element name="ImageItem" maxOccurs="unbounded">
+                                                          <xs:complexType>
+                                                            <xs:sequence>
+
+                                                              <xs:element name="ImageFormat">
+                                                                <xs:complexType>
+                                                                  <xs:sequence>
+                                                                    <xs:element name="URL" type="def_url_string" />
+                                                                  </xs:sequence>
+                                                                  <xs:attribute name="CopyrightNotice" type="def_nonempty_string" />
+                                                                </xs:complexType>
+                                                              </xs:element>
+
+                                                              <xs:element name="Description" minOccurs="0" maxOccurs="unbounded">
+                                                                <xs:complexType>
+                                                                  <xs:simpleContent>
+                                                                    <xs:extension base="def_nonempty_string">
+                                                                      <xs:attribute name="TextFormat" use="required">
+                                                                        <xs:simpleType>
+                                                                          <xs:restriction base="xs:string">
+                                                                            <xs:enumeration value="PlainText"/>
+                                                                          </xs:restriction>
+                                                                        </xs:simpleType>
+                                                                      </xs:attribute>
+                                                                      <xs:attribute name="Language" use="required">
+                                                                        <xs:simpleType>
+                                                                          <xs:restriction base="xs:language">
+                                                                            <xs:pattern value="[a-z][a-z]"/>
+                                                                          </xs:restriction>
+                                                                        </xs:simpleType>
+                                                                      </xs:attribute>
+                                                                    </xs:extension>
+                                                                  </xs:simpleContent>
+                                                                </xs:complexType>
+                                                              </xs:element>
+
+                                                            </xs:sequence>
+                                                            <xs:attribute name="Category" use="required" type="def_int_gt0" />
+                                                          </xs:complexType>
+                                                        </xs:element>
+
+                                                      </xs:sequence>
+                                                    </xs:complexType>
+                                                  </xs:element>
+
+                                                </xs:choice>
+                                                <xs:attribute name="InfoCode">
+                                                  <xs:simpleType>
+                                                    <xs:restriction base="def_int_gt0">
+                                                      <xs:enumeration value="1"/>
+                                                      <xs:enumeration value="23"/>
+                                                      <xs:enumeration value="25"/>
+                                                    </xs:restriction>
+                                                  </xs:simpleType>
+                                                </xs:attribute>
+                                              </xs:complexType>
+                                            </xs:element>
+
+                                          </xs:sequence>
+                                        </xs:complexType>
+                                      </xs:element>
+
+                                    </xs:sequence>
+                                    <xs:attribute name="Code"              use="required" type="def_invTypeCode_string" />
+                                    <xs:attribute name="MaxOccupancy"                     type="def_int_gt0" />
+                                    <xs:attribute name="MinOccupancy"                     type="def_int_gt0" />
+                                    <xs:attribute name="MaxChildOccupancy"                type="def_int_gt0" />
+                                    <xs:attribute name="ID"                               type="def_invTypeCode_string" />
+                                  </xs:complexType>
+                                </xs:element>
+
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+
+                    <!-- Policies -->
+                    <xs:element name="Policies" minOccurs="0" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                        <xs:anyAttribute processContents="lax"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                    <!-- AffiliationInfo -->
+                    <xs:element name="AffiliationInfo" minOccurs="0" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                        <xs:anyAttribute processContents="lax"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                    <!-- ContactInfos -->
+                    <xs:element name="ContactInfos" minOccurs="0" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                        <xs:anyAttribute processContents="lax"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                  </xs:sequence>
+                  <xs:attribute name="HotelCityCode" type="def_nonempty_string" />
+                  <xs:attribute name="HotelCode" type="def_nonempty_string" />
+                  <xs:attribute name="HotelName" type="def_nonempty_string" />
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+    </xs:sequence>
+  </xs:group>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for RatePlans element as used                               -->
+  <!-- * in RatePlans and BaseRates                                                    -->
+  <!-- ******************************************************************************* -->
+
+  <xs:group name="def_rateplans">
+
+    <xs:sequence>
+      <xs:element name="RatePlans">
+        <xs:complexType>
+          <xs:sequence>
+
+            <!-- RatePlans > RatePlan {1,} -->
+
+            <xs:element name="RatePlan" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+
+                  <!-- RatePlans > RatePlan > BookingRules {0,1} -->
+
+                  <xs:element name="BookingRules" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+
+                        <xs:element name="BookingRule" maxOccurs="unbounded">
+                          <xs:complexType>
+                            <xs:sequence>
+
+                              <xs:element name="LengthsOfStay" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+
+                                    <xs:element name="LengthOfStay" maxOccurs="unbounded">
+                                      <xs:complexType>
+                                        <xs:attribute name="Time" use="required" type="def_decimal_ge0"/>
+                                        <xs:attribute name="TimeUnit" use="required">
+                                          <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                              <xs:enumeration value="Day"/>
+                                            </xs:restriction>
+                                          </xs:simpleType>
+                                        </xs:attribute>
+                                        <xs:attribute name="MinMaxMessageType" use="required">
+                                          <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                              <xs:enumeration value="SetMinLOS"/>
+                                              <xs:enumeration value="SetForwardMinStay"/>
+                                              <xs:enumeration value="SetMaxLOS"/>
+                                              <xs:enumeration value="SetForwardMaxStay"/>
+                                            </xs:restriction>
+                                          </xs:simpleType>
+                                        </xs:attribute>
+                                      </xs:complexType>
+                                    </xs:element>
+
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="DOW_Restrictions" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ArrivalDaysOfWeek" minOccurs="0">
+                                      <xs:complexType>
+                                        <xs:attribute name="Mon"  type="def_bool"/>
+                                        <xs:attribute name="Tue"  type="def_bool"/>
+                                        <xs:attribute name="Weds" type="def_bool"/>
+                                        <xs:attribute name="Thur" type="def_bool"/>
+                                        <xs:attribute name="Fri"  type="def_bool"/>
+                                        <xs:attribute name="Sat"  type="def_bool"/>
+                                        <xs:attribute name="Sun"  type="def_bool"/>
+                                      </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="DepartureDaysOfWeek" minOccurs="0">
+                                      <xs:complexType>
+                                        <xs:attribute name="Mon"  type="def_bool"/>
+                                        <xs:attribute name="Tue"  type="def_bool"/>
+                                        <xs:attribute name="Weds" type="def_bool"/>
+                                        <xs:attribute name="Thur" type="def_bool"/>
+                                        <xs:attribute name="Fri"  type="def_bool"/>
+                                        <xs:attribute name="Sat"  type="def_bool"/>
+                                        <xs:attribute name="Sun"  type="def_bool"/>
+                                      </xs:complexType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="RestrictionStatus" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:attribute name="Restriction">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="Master"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                  <xs:attribute name="Status">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="Open"/>
+                                        <xs:enumeration value="Close"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                </xs:complexType>
+                              </xs:element>
+
+                            </xs:sequence>
+                            <xs:attribute name="CodeContext">
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:enumeration value="ROOMTYPE"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:attribute>
+                            <xs:attribute name="Code"  type="def_invTypeCode_string"/>
+                            <xs:attribute name="Start" type="def_date"/>
+                            <xs:attribute name="End"   type="def_date"/>
+                          </xs:complexType>
+                        </xs:element>
+
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+
+                  <!-- RatePlans > RatePlan > Rates {0,1} -->
+
+                  <xs:element name="Rates" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+
+                        <xs:element name="Rate" maxOccurs="unbounded">
+                          <xs:complexType>
+                            <xs:sequence>
+
+                              <xs:element name="BaseByGuestAmts" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+
+                                    <xs:element name="BaseByGuestAmt" maxOccurs="unbounded">
+                                      <xs:complexType>
+                                        <xs:attribute name="NumberOfGuests" type="def_int_gt0"/>
+                                        <xs:attribute name="AmountAfterTax" type="def_decimal_gt0"/>
+                                        <xs:attribute name="CurrencyCode">
+                                          <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                              <xs:enumeration value="EUR"/>
+                                            </xs:restriction>
+                                          </xs:simpleType>
+                                        </xs:attribute>
+                                        <xs:attribute name="Type">
+                                          <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                              <xs:enumeration value="7"/>
+                                              <xs:enumeration value="25"/>
+                                            </xs:restriction>
+                                          </xs:simpleType>
+                                        </xs:attribute>
+                                        <xs:attribute name="AgeQualifyingCode" type="def_int_gt0"/>
+                                      </xs:complexType>
+                                    </xs:element>
+
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="AdditionalGuestAmounts" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+
+                                    <xs:element name="AdditionalGuestAmount" maxOccurs="unbounded">
+                                      <xs:complexType>
+                                        <xs:attribute name="Amount"            type="def_decimal_ge0"/>
+                                        <xs:attribute name="AgeQualifyingCode" type="def_int_gt0"/>
+                                        <xs:attribute name="MinAge"            type="def_int_gt0"/>
+                                        <xs:attribute name="MaxAge"            type="def_int_gt0"/>
+                                      </xs:complexType>
+                                    </xs:element>
+
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="RateDescription" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+
+                                    <xs:element name="ListItem" maxOccurs="unbounded">
+                                      <xs:complexType>                    
+                                         <xs:simpleContent>                
+                                           <xs:extension base="def_nonempty_string">
+                                             <xs:attribute name="ListItem" use="required" type="def_int_ge0"/>
+                                             <xs:attribute name="Language" use="required">
+                                               <xs:simpleType>             
+                                                 <xs:restriction base="xs:language">
+                                                   <xs:pattern value="[a-z][a-z]"/>
+                                                 </xs:restriction>         
+                                               </xs:simpleType>            
+                                             </xs:attribute>               
+                                           </xs:extension>                 
+                                         </xs:simpleContent>               
+                                       </xs:complexType>                   
+                                    </xs:element>
+     
+                                  </xs:sequence>
+                                    <xs:attribute name="Name" use="required">
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="included services"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:attribute>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="MealsIncluded" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:attribute name="Breakfast" type="def_bool"/>
+                                  <xs:attribute name="Lunch"     type="def_bool"/>
+                                  <xs:attribute name="Dinner"    type="def_bool"/>
+                                  <xs:attribute name="MealPlanCodes">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="1"/>
+                                        <xs:enumeration value="3"/>
+                                        <xs:enumeration value="10"/>
+                                        <xs:enumeration value="12"/>
+                                        <xs:enumeration value="14"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                  <xs:attribute name="MealPlanIndicator">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="1"/>
+                                        <xs:enumeration value="true"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                </xs:complexType>
+                              </xs:element>
+                      
+                            </xs:sequence>
+                            <xs:attribute name="MinGuestApplicable" type="def_int_gt0"/>
+                            <xs:attribute name="Start"              type="def_date"/>
+                            <xs:attribute name="End"                type="def_date"/>
+                            <xs:attribute name="RateTimeUnit">
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:enumeration value="Day"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:attribute>
+                            <xs:attribute name="UnitMultiplier"     type="def_int_gt0"/>
+                            <xs:attribute name="Mon"                type="def_bool"/>
+                            <xs:attribute name="Tue"                type="def_bool"/>
+                            <xs:attribute name="Weds"               type="def_bool"/>
+                            <xs:attribute name="Thur"               type="def_bool"/>
+                            <xs:attribute name="Fri"                type="def_bool"/>
+                            <xs:attribute name="Sat"                type="def_bool"/>
+                            <xs:attribute name="Sun"                type="def_bool"/>
+                            <xs:attribute name="Duration">
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:pattern value="P[0-9]+N"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:attribute>
+                            <xs:attribute name="InvTypeCode" type="def_invTypeCode_string"/>
+
+                          </xs:complexType>
+                        </xs:element>
+                      
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+
+                  <!-- RatePlans > RatePlan > Supplements {0,1} -->
+
+                  <xs:element name="Supplements" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+
+                        <xs:element name="Supplement" maxOccurs="unbounded">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:choice>
+                                <xs:element name="PrerequisiteInventory" minOccurs="0" maxOccurs="1">
+                                  <xs:complexType>
+                                      <xs:attribute name="InvCode" use="required" type="def_nonempty_string"/>
+                                      <xs:attribute name="InvType" use="required">
+                                        <xs:simpleType>
+                                          <xs:restriction base="xs:string">
+                                            <xs:enumeration value="ALPINEBITSDOW"/>
+                                            <xs:enumeration value="ROOMTYPE"/>
+                                          </xs:restriction>
+                                        </xs:simpleType>
+                                      </xs:attribute>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:choice>
+                              <!-- RatePlans > RatePlan > Supplements > Supplement > Description {0,5} -->
+                      
+                              <xs:element name="Description" minOccurs="0" maxOccurs="5">
+                                <xs:complexType>
+                                  <xs:sequence>
+                      
+                                    <xs:choice maxOccurs="unbounded">
+                      
+                                      <xs:element name="ListItem" type="def_nonempty_string"/>
+                      
+                                      <xs:element name="Image" type="def_url_string"/>
+                      
+                                      <xs:element name="Text">
+                                        <xs:complexType>                    
+                                           <xs:simpleContent>                
+                                             <xs:extension base="def_nonempty_string">
+                                               <xs:attribute name="TextFormat" use="required">
+                                                 <xs:simpleType>             
+                                                   <xs:restriction base="xs:string">
+                                                     <xs:enumeration value="PlainText"/>
+                                                     <xs:enumeration value="HTML"/> 
+                                                   </xs:restriction>         
+                                                 </xs:simpleType>            
+                                               </xs:attribute>               
+                                               <xs:attribute name="Language">
+                                                 <xs:simpleType>             
+                                                   <xs:restriction base="xs:language">
+                                                     <xs:pattern value="[a-z][a-z]"/>
+                                                   </xs:restriction>         
+                                                 </xs:simpleType>            
+                                               </xs:attribute>               
+                                             </xs:extension>                 
+                                           </xs:simpleContent>               
+                                         </xs:complexType>                   
+                                      </xs:element>
+                                  
+                                      <xs:element name="URL" type="def_url_string"/>
+                      
+                                    </xs:choice>
+                      
+                                  </xs:sequence>
+                      
+                                  <xs:attribute name="Name" use="required">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="title"/>
+                                        <xs:enumeration value="intro"/>
+                                        <xs:enumeration value="description"/>
+                                        <xs:enumeration value="gallery"/>
+                                        <xs:enumeration value="codelist"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                </xs:complexType>
+                              </xs:element>
+
+                            </xs:sequence>
+
+                            <xs:attribute name="AddToBasicRateIndicator">
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:enumeration value="1"/>
+                                  <xs:enumeration value="true"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:attribute>
+
+                            <xs:attribute name="ChargeTypeCode">
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:enumeration value="1"/>
+                                  <xs:enumeration value="12"/>
+                                  <xs:enumeration value="18"/>
+                                  <xs:enumeration value="19"/>
+                                  <xs:enumeration value="20"/>
+                                  <xs:enumeration value="21"/>
+                                  <xs:enumeration value="24"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:attribute>
+
+                            <xs:attribute name="Amount" type="def_decimal_ge0"/>
+
+                            <xs:attribute name="InvType" use="required">
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:enumeration value="EXTRA"/>
+                                  <xs:enumeration value="ALPINEBITSEXTRA"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:attribute>
+
+                            <xs:attribute name="InvCode" type="def_nonempty_string" use="required"/>
+
+                            <xs:attribute name="MandatoryIndicator" type="def_bool"/>
+
+                            <xs:attribute name="Start" type="def_date"/>
+                            <xs:attribute name="End"   type="def_date"/>
+
+                          </xs:complexType>
+                        </xs:element>  <!-- close Supplement -->
+
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+
+                  <!-- RatePlans > RatePlan > Offers {0,1} -->
+
+                  <xs:element name="Offers" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+
+                        <xs:element name="Offer" maxOccurs="3">
+                          <xs:complexType>
+                            <xs:sequence>
+
+                              <xs:element name="OfferRules" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+
+                                    <xs:element name="OfferRule" minOccurs="0">
+                                      <xs:complexType>
+                                        <xs:sequence>
+                                  
+                                          <xs:element name="LengthsOfStay" minOccurs="0">
+                                            <xs:complexType>
+                                              <xs:sequence>
+                                  
+                                                <xs:element name="LengthOfStay" maxOccurs="unbounded">
+                                                  <xs:complexType>
+                                                    <xs:attribute name="Time" use="required" type="def_decimal_ge0"/>
+                                                    <xs:attribute name="TimeUnit" use="required">
+                                                      <xs:simpleType>
+                                                        <xs:restriction base="xs:string">
+                                                          <xs:enumeration value="Day"/>
+                                                        </xs:restriction>
+                                                      </xs:simpleType>
+                                                    </xs:attribute>
+                                                    <xs:attribute name="MinMaxMessageType" use="required">
+                                                      <xs:simpleType>
+                                                        <xs:restriction base="xs:string">
+                                                          <xs:enumeration value="SetMinLOS"/>
+                                                          <xs:enumeration value="SetMaxLOS"/>
+                                                          <xs:enumeration value=""/>
+                                                        </xs:restriction>
+                                                      </xs:simpleType>
+                                                    </xs:attribute>
+                                                  </xs:complexType>
+                                                </xs:element>
+                                  
+                                              </xs:sequence>
+                                            </xs:complexType>
+                                          </xs:element>
+                                  
+                                          <xs:element name="DOW_Restrictions" minOccurs="0">
+                                            <xs:complexType>
+                                              <xs:sequence>
+                                                <xs:element name="ArrivalDaysOfWeek" minOccurs="0">
+                                                  <xs:complexType>
+                                                    <xs:attribute name="Mon"  type="def_bool"/>
+                                                    <xs:attribute name="Tue"  type="def_bool"/>
+                                                    <xs:attribute name="Weds" type="def_bool"/>
+                                                    <xs:attribute name="Thur" type="def_bool"/>
+                                                    <xs:attribute name="Fri"  type="def_bool"/>
+                                                    <xs:attribute name="Sat"  type="def_bool"/>
+                                                    <xs:attribute name="Sun"  type="def_bool"/>
+                                                  </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="DepartureDaysOfWeek" minOccurs="0">
+                                                  <xs:complexType>
+                                                    <xs:attribute name="Mon"  type="def_bool"/>
+                                                    <xs:attribute name="Tue"  type="def_bool"/>
+                                                    <xs:attribute name="Weds" type="def_bool"/>
+                                                    <xs:attribute name="Thur" type="def_bool"/>
+                                                    <xs:attribute name="Fri"  type="def_bool"/>
+                                                    <xs:attribute name="Sat"  type="def_bool"/>
+                                                    <xs:attribute name="Sun"  type="def_bool"/>
+                                                  </xs:complexType>
+                                                </xs:element>
+                                              </xs:sequence>
+                                            </xs:complexType>
+                                          </xs:element>
+                                  
+                                          <xs:element name="Occupancy" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                              <xs:attribute name="AgeQualifyingCode" use="required">
+                                                <xs:simpleType>
+                                                  <xs:restriction base="xs:string">
+                                                    <xs:enumeration value="8"/>
+                                                    <xs:enumeration value="10"/>
+                                                  </xs:restriction>
+                                                </xs:simpleType>
+                                              </xs:attribute>
+                                              <xs:attribute name="MinAge" type="def_int_gt0"/>
+                                              <xs:attribute name="MaxAge" type="def_int_gt0"/>
+                                              <xs:attribute name="MinOccupancy" type="def_int_ge0"/>
+                                              <xs:attribute name="MaxOccupancy" type="def_int_gt0"/>
+                                            </xs:complexType>
+                                          </xs:element>
+                                  
+                                        </xs:sequence>
+                                  
+                                        <xs:attribute name="MinAdvancedBookingOffset">
+                                          <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                              <xs:pattern value="P[0-9]+D"/>
+                                            </xs:restriction>
+                                          </xs:simpleType>
+                                        </xs:attribute>
+                                        <xs:attribute name="MaxAdvancedBookingOffset">
+                                          <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                              <xs:pattern value="P[0-9]+D"/>
+                                            </xs:restriction>
+                                          </xs:simpleType>
+                                        </xs:attribute>
+                                  
+                                      </xs:complexType>
+                                    </xs:element>
+
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="Discount" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:attribute name="Percent" use="required">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="100"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                  <xs:attribute name="NightsRequired"   type="def_int_gt0"/>
+                                  <xs:attribute name="NightsDiscounted" type="def_int_gt0"/>
+                                  <xs:attribute name="DiscountPattern">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:pattern value="0*1*"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="Guests" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+
+                                    <xs:element name="Guest">
+                                      <xs:complexType>
+                                        <xs:attribute name="AgeQualifyingCode" use="required" type="def_int_gt0"/>
+                                        <xs:attribute name="MaxAge"            use="required" type="def_int_gt0"/>
+                                        <xs:attribute name="MinCount"          use="required" type="def_int_ge0"/>
+                                          <xs:attribute name="FirstQualifyingPosition" use="required">
+                                            <xs:simpleType>
+                                              <xs:restriction base="xs:string">
+                                                <xs:enumeration value="1"/>
+                                              </xs:restriction>
+                                            </xs:simpleType>
+                                          </xs:attribute>
+                                          <xs:attribute name="LastQualifyingPosition" use="required" type="def_int_gt0"/>
+                                      </xs:complexType>
+                                    </xs:element>
+
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+
+                  <!-- RatePlans > RatePlan > Description {0,5} -->
+
+                  <xs:element name="Description" minOccurs="0" maxOccurs="5">
+                    <xs:complexType>
+                      <xs:sequence>
+
+                        <xs:choice maxOccurs="unbounded">
+
+                          <xs:element name="ListItem" type="def_nonempty_string"/>
+
+                          <xs:element name="Image" type="def_url_string"/>
+
+                          <xs:element name="Text">
+                            <xs:complexType>                    
+                               <xs:simpleContent>                
+                                 <xs:extension base="def_nonempty_string">
+                                   <xs:attribute name="TextFormat" use="required">
+                                     <xs:simpleType>             
+                                       <xs:restriction base="xs:string">
+                                         <xs:enumeration value="PlainText"/>
+                                         <xs:enumeration value="HTML"/> 
+                                       </xs:restriction>         
+                                     </xs:simpleType>            
+                                   </xs:attribute>               
+                                   <xs:attribute name="Language">
+                                     <xs:simpleType>             
+                                       <xs:restriction base="xs:language">
+                                         <xs:pattern value="[a-z][a-z]"/>
+                                       </xs:restriction>         
+                                     </xs:simpleType>            
+                                   </xs:attribute>               
+                                 </xs:extension>                 
+                               </xs:simpleContent>               
+                             </xs:complexType>                   
+                          </xs:element>
+                      
+                          <xs:element name="URL" type="def_url_string"/>
+
+                        </xs:choice>
+
+                      </xs:sequence>
+
+                      <xs:attribute name="Name" use="required">
+                        <xs:simpleType>
+                          <xs:restriction base="xs:string">
+                            <xs:enumeration value="title"/>
+                            <xs:enumeration value="intro"/>
+                            <xs:enumeration value="description"/>
+                            <xs:enumeration value="gallery"/>
+                            <xs:enumeration value="codelist"/>
+                          </xs:restriction>
+                        </xs:simpleType>
+                      </xs:attribute>
+                    </xs:complexType>
+                  </xs:element>
+
+                </xs:sequence>
+                <xs:attribute name="Start" type="def_date"/>
+                <xs:attribute name="End"   type="def_date"/>
+                <xs:attribute name="RatePlanNotifType">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                      <xs:enumeration value="Overlay"/>
+                      <xs:enumeration value="New"/>
+                      <xs:enumeration value="Remove"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="CurrencyCode">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                      <xs:enumeration value="EUR"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="RatePlanCode" type="def_nonempty_string"/>
+                <xs:attribute name="RatePlanType">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                      <xs:enumeration value="12"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:attribute>                
+                <xs:attribute name="RatePlanCategory" type="def_nonempty_string"/>
+                <xs:attribute name="RatePlanID" type="def_nonempty_string"/>
+                <xs:attribute name="RatePlanQualifier" type="def_bool"/>
+              </xs:complexType>
+            </xs:element> <!-- close RatePlan -->
+
+          </xs:sequence>
+          <xs:attribute name="HotelCode" type="def_nonempty_string"/>
+          <xs:attribute name="HotelName" type="def_nonempty_string"/>
+        </xs:complexType>
+
+      </xs:element>
+
+    </xs:sequence>
+
+  </xs:group>
+
+   
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for success/advisory/warning/error responses                -->
+  <!-- ******************************************************************************* -->
+
+  <xs:group name="def_generic_response">
+    <xs:choice>
+
+      <!-- choice: Errors {1} -->
+
+      <xs:element name="Errors">
+        <xs:complexType>
+          <xs:sequence>
+
+            <!-- Errors > Error {1,} -->
+
+            <xs:element name="Error" maxOccurs="unbounded">
+              <xs:complexType mixed="true">
+                <xs:attribute name="Type" use="required">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                      <xs:enumeration value="13"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="Code" use="required" type="def_int_gt0"/>
+              </xs:complexType>
+            </xs:element>
+
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+      <!-- choice: Success {1} + Warnings {0,1} -->
+
+      <xs:sequence>
+
+        <xs:element name="Success"/>
+
+        <xs:element name="Warnings" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+
+            <!-- Warnings > Warning {1,} -->
+
+              <xs:element name="Warning" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type"     use="required" type="def_int_gt0"/>
+                  <xs:attribute name="RecordID"                type="def_nonempty_string"/>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+
+    </xs:choice>
+  </xs:group>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for recurring, simple types                                 -->
+  <!-- ******************************************************************************* -->
+
+  <!-- A generic non-empty string type. -->
+
+  <xs:simpleType name="def_nonempty_string">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic string type containing an @ char, like an email address -->
+
+  <xs:simpleType name="def_email_string">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\S+@\S+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- String type defining room category codes (like InvTypeCode)  -->
+
+  <xs:simpleType name="def_invTypeCode_string">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+      <xs:maxLength value="8"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic string type starting with http:// or https:// -->
+
+  <xs:simpleType name="def_url_string">
+    <xs:restriction base="xs:anyURI">
+      <xs:pattern value="https?://.+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+  <!-- A generic integer > 0 type. -->
+
+  <xs:simpleType name="def_int_gt0">
+    <xs:restriction base="xs:positiveInteger">
+      <xs:pattern value="[0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic integer >= 0 type. -->
+
+  <xs:simpleType name="def_int_ge0">
+    <xs:restriction base="xs:nonNegativeInteger">
+      <xs:pattern value="[0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic decimal >= 0 type. -->
+
+  <xs:simpleType name="def_decimal_ge0">
+    <xs:restriction base="xs:decimal">
+      <xs:minInclusive value="0.0"/>
+      <xs:pattern value="[0-9]*\.?[0-9]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic decimal > 0 type. -->
+
+  <xs:simpleType name="def_decimal_gt0">
+    <xs:restriction base="xs:decimal">
+      <xs:minExclusive value="0.0"/>
+      <xs:pattern value="[0-9]*\.?[0-9]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic date type. -->
+
+  <xs:simpleType name="def_date">
+    <xs:restriction base="xs:date">
+      <xs:pattern value="\S+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic datetime type. -->
+
+  <xs:simpleType name="def_datetime">
+    <xs:restriction base="xs:dateTime">
+      <xs:pattern value="\S+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic boolean type (1,true,0,false). -->
+
+  <xs:simpleType name="def_bool">
+    <xs:restriction base="xs:boolean">
+      <xs:pattern value="\S+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+</xs:schema>

--- a/alpinebits-xml/api/src/main/resources/alpinebits2015-07b.rng
+++ b/alpinebits-xml/api/src/main/resources/alpinebits2015-07b.rng
@@ -1,0 +1,2432 @@
+<?xml version="1.0"?>
+
+<!-- 
+     AlpineBits 2015-07b
+     http://www.alpinebits.org/
+
+     Relax-NG grammar file
+
+     changelog:
+
+
+    v. 2015-07b 1.4 - weaken the schema for Inventory (to prepare for upcoming release that will support Inventory deltas):
+
+                      - the RoomAmenityCode attribute becomes optional to allow empty Amenity elements 
+                      - the MultimediaDescription element can be empty
+
+    v. 2015-07b 1.3 - RatePlans > RatePlan > Description > TextFormat can now also be "HTML" (besides "PlainText")
+
+    v. 2015-07b 1.2 - added optional attributes RatePlanID and RatePlanQualifier to RatePlan
+                      for the new OTA_HotelRatePlanNotif_accept_RatePlanJoin capability
+
+    v. 2015-07b 1.1 - added def_invTypeCode_string type (string with up to 8 chars) used for the following attributes that identify room categories:
+
+                      FreeRooms:     OTA_HotelAvailNotifRQ -> AvailStatusMessages -> AvailStatusMessage -> StatusApplicationControl -> InvTypeCode
+                      GuestRequests: OTA_ResRetrieveRS -> ReservationList -> HotelReservation -> RoomStays -> RoomStay -> RoomTypes > RoomType -> RoomTypeCode
+                      Inventory:     OTA_HotelDescriptiveContentNotifRQ -> HotelDescriptiveContents -> HotelDescriptiveContent -> FacilityInfo -> GuestRooms -> GuestRoom -> Code
+                      RatePlan:      OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> BookingRules -> BookingRules -> Code
+                      RatePlan:      OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Rates -> Rate -> InvTypeCode
+
+    v. 2015-07b 1.0 - RatePlans > RatePlan > Rates > Rate > BaseByGuestAmts > AmountAfterTax
+                      must be > 0.0 (was: >= 0.0)
+
+     v. 2015-07 2.8 - Inventory: fixed the checks for the HotelDescriptiveContent attributes
+
+     v. 2015-07 2.7 - Inventory: reconciled with the definitions given in the updated document
+
+     v. 2015-07 2.6 - added section for New Inventory (exact name pending)
+
+     v. 2015-07 2.5 - made sub-elements of HotelReservation > ... > Customer > Address {0,1} optional
+
+     v. 2015-07 2.4 - added a choice of 'Modify' for ResStatus
+
+     v. 2015-07 2.3 - added MinCount attribute to Offer>>Guest
+
+     v. 2015-07 2.2 - changes to Supplement: a few attributes are removed and many attributes are made optional
+
+     v. 2015-07 2.1 - RatePlans/Supplements: changed format of description
+
+     v. 2015-07 2.0 - GuestRequests: ResGuests >> Customer: attributes Gender and Language are now optional
+
+     v. 2015-07 1.9 - allow Warnings in OTA_NotifReportRQ messages
+
+     v. 2015-07 1.8 - GuestRequests: use CardNumber -> PlainText instead of the Remark attribute of
+                      PaymentCard under Guarantee; add BasicPropertyInfo element at the end of the 
+                      ResGlobalInfo block for OTA-2015A compatiblity
+
+     v. 2015-07 1.7 - allowed more than one HotelReservationID
+
+     v. 2015-07 1.6 - RatePlans: allow optional PrerequisiteInventory element under Supplement element
+
+     v. 2015-07 1.5 - Inventory: removed Amenities and added optional Room -> RoomTypeCode
+
+     v. 2015-07 1.4 - HotelReservationID -> ResID_Type is not limited to 13 anymore
+
+     v. 2015-07 1.3 - new section in RoomStays: Guarantee -> GuaranteesAccepted -> GuaranteeAccepted -> PaymentCard
+
+     v. 2015-07 1.2 - new section in ResGlobalInfo: Profiles -> ProfileInfo -> Profile -> CompanyInfo
+
+     v. 2015-07 1.1 - HotelReservation > RoomStays > RoomStay > RoomTypes > RoomType is now
+                      mandatory and has a new optional attribute RoomClassificationCode
+
+     v. 2015-07 1.0 - OTA_NotifReportRS besides Success, now also allows Error responses 
+
+     v. 2014-04 1.5 - [fixed] InvCode attribute in Supplement changed from def_int_ge0 to def_nonempty_string
+
+     v. 2014-04 1.4 - [strictness improvement] made BaseByGuestAmt->NumberOfGuests attribute mandatory for
+                      RatePlans and SimplePackages, made BaseByGuestAmt->Type attribute mandatory for RatePlans
+
+     v. 2014-04 1.3 - [improvement] RatePlans: remove RatePlan->Rate attributes that are not allowed
+                      (problem inherited from the xsd version where Rate is shared with SimplePackages
+
+     v. 2014-04 1.2 - [fixed] RatePlans: optional Rate attributes RateTimeUnit and UnitMultiplier added
+
+     v. 2014-04 1.1 - [fixed] GuestRequests: Email->Remark is an optional attribute
+                    - [fixed] GuestRequests: ReservationsList can be empty
+
+     v. 2014-04 1.0 - complete rewrite for 2014-04
+
+-->
+
+<rng:grammar     xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        ns="http://www.opentravel.org/OTA/2003/05"
+           datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+  <rng:start>
+    <rng:choice>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * FreeRooms                                                                     -->
+      <!-- ******************************************************************************* -->
+
+      <!-- FreeRooms: OTA_HotelAvailNotifRQ -->
+
+      <rng:element name="OTA_HotelAvailNotifRQ">
+
+        <!-- UniqueID {0,1} -->
+
+        <rng:optional>
+          <rng:element name="UniqueID">
+
+            <rng:attribute name="Type">
+              <rng:value type="string">16</rng:value>
+            </rng:attribute>
+            <rng:attribute name="ID"/> <!-- an ID is required by OTA, we ignore the value -->
+            <rng:attribute name="Instance">
+              <rng:value type="string">CompleteSet</rng:value>
+            </rng:attribute>
+
+          </rng:element>
+        </rng:optional>
+
+         <!-- AvailStatusMessages {1} -->
+
+        <rng:element name="AvailStatusMessages">
+
+          <rng:oneOrMore>
+            <rng:choice>
+              <rng:attribute name="HotelCode">
+                <rng:ref name="def_nonempty_string"/>
+              </rng:attribute>
+              <rng:attribute name="HotelName">
+                <rng:ref name="def_nonempty_string"/>
+              </rng:attribute>
+            </rng:choice>
+          </rng:oneOrMore>
+
+          <!-- AvailStatusMessages > AvailStatusMessage (1,} -->
+
+          <rng:oneOrMore>
+            <rng:element name="AvailStatusMessage">
+
+              <!-- AvailStatusMessage is either empty or has
+                 attributes BookingLimit and BookingLimitMessageType
+                 and contains one StatusApplicationControl element -->
+
+              <rng:optional>
+
+                <rng:element name="StatusApplicationControl">
+
+                  <rng:attribute name="Start">
+                    <rng:ref name="def_date"/>
+                  </rng:attribute>
+                  <rng:attribute name="End">
+                    <rng:ref name="def_date"/>
+                  </rng:attribute>
+                  <rng:attribute name="InvTypeCode">
+                    <rng:ref name="def_invTypeCode_string"/>
+                  </rng:attribute>
+                  <rng:optional>
+                    <rng:attribute name="InvCode">
+                      <rng:ref name="def_nonempty_string"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                </rng:element>
+
+                <rng:attribute name="BookingLimit">
+                  <rng:ref name="def_int_ge0"/>
+                </rng:attribute>
+                <rng:attribute name="BookingLimitMessageType">
+                  <rng:value type="string">SetLimit</rng:value>
+                </rng:attribute>
+
+              </rng:optional>
+
+            </rng:element>
+          </rng:oneOrMore>
+
+        </rng:element>
+
+        <rng:attribute name="xsi:schemaLocation"/>
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- FreeRooms: OTA_HotelAvailNotifRQ -->
+
+      <rng:element name="OTA_HotelAvailNotifRS">
+
+        <rng:ref name="def_generic_response"/>
+
+        <rng:attribute name="xsi:schemaLocation"/>
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+
+
+      </rng:element>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * GuestRequests                                                                 -->
+      <!-- ******************************************************************************* -->
+
+      <!-- GuestRequests: OTA_ReadRQ -->
+
+      <rng:element name="OTA_ReadRQ">
+
+        <rng:element name="ReadRequests">
+    
+          <rng:element name="HotelReadRequest">
+        
+            <rng:optional>
+              <rng:element name="SelectionCriteria">
+          
+                <rng:attribute name="Start">
+                  <rng:ref name="def_datetime"/>
+                </rng:attribute>
+          
+              </rng:element>
+            </rng:optional>
+
+            <rng:oneOrMore>
+              <rng:choice>
+                <rng:attribute name="HotelCode">
+                  <rng:ref name="def_nonempty_string"/>
+                </rng:attribute>
+                <rng:attribute name="HotelName">
+                  <rng:ref name="def_nonempty_string"/>
+                </rng:attribute>
+              </rng:choice>
+            </rng:oneOrMore>
+
+          </rng:element>
+
+        </rng:element>
+
+        <rng:attribute name="xsi:schemaLocation"/>
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+  
+      </rng:element>
+
+      <!-- GuestRequests: OTA_ResRetrieveRS -->
+
+      <rng:element name="OTA_ResRetrieveRS">
+        <rng:choice>
+
+          <!-- choice: Errors {1} -->
+
+          <rng:element name="Errors">
+
+            <!-- Errors > Error {1,} -->
+
+            <rng:oneOrMore>
+              <rng:element name="Error">
+
+                <rng:attribute name="Type">
+                  <rng:value type="string">13</rng:value>
+                </rng:attribute>
+                <rng:attribute name="Code">
+                  <rng:ref name="def_int_ge0"/>
+                </rng:attribute>
+
+                <rng:text/>
+
+              </rng:element>
+
+            </rng:oneOrMore>
+          </rng:element>
+
+          <!-- choice: Success {1} + ReservationsList {1} -->
+
+          <rng:group>
+
+            <rng:element name="Success">
+              <rng:empty/>
+            </rng:element>
+
+            <rng:element name="ReservationsList">
+
+              <!-- HotelReservation {0,} -->
+
+              <rng:zeroOrMore>
+                <rng:element name="HotelReservation">
+
+                  <!-- HotelReservation > UniqueID {1} -->
+
+                  <rng:element name="UniqueID">
+
+                    <rng:attribute name="Type">
+                      <rng:choice>
+                        <rng:value>14</rng:value>
+                        <rng:value>15</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+
+                    <rng:attribute name="ID">
+                      <rng:ref name="def_nonempty_string"/>
+                    </rng:attribute>
+
+                  </rng:element>
+
+                  <!-- HotelReservation > RoomStays {0,1} -->
+
+                  <rng:optional>
+                    <rng:element name="RoomStays">
+
+                      <!-- HotelReservation > RoomStays > RoomStay {1,} -->
+
+                      <rng:oneOrMore>
+                        <rng:element name="RoomStay">
+
+                          <!-- HotelReservation > RoomStays > RoomStay > RoomTypes {0,1} -->
+
+                          <rng:element name="RoomTypes">
+
+                            <!-- HotelReservation > RoomStays > RoomStay > RoomTypes > RoomType {1} -->
+
+                            <rng:element name="RoomType">
+                              <rng:optional>
+                                <rng:attribute name="RoomTypeCode">
+                                  <rng:ref name="def_invTypeCode_string"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="RoomClassificationCode">
+                                  <rng:ref name="def_int_ge0"/>
+                                </rng:attribute>
+                              </rng:optional>
+                            </rng:element>
+
+                          </rng:element>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > RatePlans {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="RatePlans">
+
+                              <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan {1} -->
+
+                              <rng:element name="RatePlan">
+
+                                <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan > MealsIncluded {0,1} -->
+
+                                <rng:optional>
+                                  <rng:element name="MealsIncluded">
+
+                                    <rng:attribute name="MealPlanIndicator">
+                                      <rng:choice>
+                                        <rng:value>1</rng:value>
+                                        <rng:value>true</rng:value>
+                                      </rng:choice>
+                                    </rng:attribute>
+                                    <rng:attribute name="MealPlanCodes">
+                                      <rng:choice>
+                                        <rng:value>1</rng:value>
+                                        <rng:value>3</rng:value>
+                                        <rng:value>10</rng:value>
+                                        <rng:value>12</rng:value>
+                                        <rng:value>14</rng:value>
+                                      </rng:choice>
+                                    </rng:attribute>
+
+                                  </rng:element>
+                                </rng:optional>
+
+                                <rng:optional>
+                                  <rng:attribute name="RatePlanCode">
+                                    <rng:ref name="def_nonempty_string"/>
+                                  </rng:attribute>
+                                </rng:optional>
+
+                              </rng:element>
+
+                            </rng:element>
+
+                          </rng:optional>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > GuestCounts {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="GuestCounts">
+
+                              <!-- HotelReservation > RoomStays > RoomStay > GuestCounts > GuestCount {1,} -->
+
+                              <rng:oneOrMore>
+                                <rng:element name="GuestCount">
+
+                                  <rng:attribute name="Count">
+                                    <rng:ref name="def_int_gt0"/>
+                                  </rng:attribute>
+                                  <rng:optional>
+                                    <rng:attribute name="Age">
+                                      <rng:ref name="def_int_ge0"/>
+                                    </rng:attribute>
+                                  </rng:optional>
+
+                                </rng:element>
+                              </rng:oneOrMore>
+
+                            </rng:element>
+                          </rng:optional>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > TimeSpan {1} -->
+
+                          <rng:element name="TimeSpan">
+
+                            <!-- HotelReservation > RoomStays > RoomStay > TimeSpan > StartDateWindow {0,1} -->
+
+                            <rng:optional>
+                              <rng:element name="StartDateWindow">
+
+                                <rng:attribute name="EarliestDate">
+                                  <rng:ref name="def_date"/>
+                                </rng:attribute>
+                                <rng:attribute name="LatestDate">
+                                  <rng:ref name="def_date"/>
+                                </rng:attribute>
+
+                              </rng:element>
+                            </rng:optional>
+
+                            <rng:optional>
+                              <rng:attribute name="Start">
+                                <rng:ref name="def_date"/>
+                              </rng:attribute>
+                            </rng:optional>
+                            <rng:optional>
+                              <rng:attribute name="End">
+                                <rng:ref name="def_date"/>
+                              </rng:attribute>
+                            </rng:optional>
+                            <rng:optional>
+                              <rng:attribute name="Duration">
+                                <rng:data type="string">
+                                  <rng:param name="pattern">P[0-9]+N</rng:param>
+                                </rng:data>
+                              </rng:attribute>
+                            </rng:optional>
+
+                          </rng:element>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > Guarantee {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="Guarantee">
+                              <rng:element name="GuaranteesAccepted">
+                                <rng:element name="GuaranteeAccepted">
+
+                                  <rng:element name="PaymentCard">
+
+                                    <rng:attribute name="CardCode">
+                                      <rng:data type="string">
+                                        <rng:param name="pattern">[A-Z][A-Z]?</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+                                    <rng:attribute name="ExpireDate">
+                                      <rng:data type="string">
+                                        <rng:param name="pattern">[0-9][0-9][0-9][0-9]</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+
+                                    <rng:element name="CardHolderName">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:element>
+
+                                    <rng:element name="CardNumber">
+                                      <rng:element name="PlainText">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                    </rng:element>
+
+                                  </rng:element>
+
+                                </rng:element>
+                              </rng:element>
+                            </rng:element>
+                          </rng:optional>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > Total {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="Total">
+
+                              <rng:attribute name="AmountAfterTax">
+                                <rng:ref name="def_decimal_ge0"/>
+                              </rng:attribute>
+                              <rng:attribute name="CurrencyCode">
+                                <rng:ref name="def_nonempty_string"/>
+                              </rng:attribute>
+
+                            </rng:element>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:oneOrMore>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <!-- HotelReservation > ResGuests {0, 1} -->
+
+                  <rng:optional>
+                    <rng:element name="ResGuests">
+                      <rng:element name="ResGuest">
+                        <rng:element name="Profiles">
+                          <rng:element name="ProfileInfo">
+                            <rng:element name="Profile">
+
+                              <!-- HotelReservation > ... > Customer {1} -->
+
+                              <rng:element name="Customer">
+
+                                <!-- HotelReservation > ... > Customer > PersonName {1} -->
+
+                                <rng:element name="PersonName">
+
+                                  <rng:optional>
+                                    <rng:element name="NamePrefix">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:element>
+                                  </rng:optional>
+                                  <rng:element name="GivenName">
+                                    <rng:ref name="def_nonempty_string"/>
+                                  </rng:element>
+                                  <rng:element name="Surname">
+                                    <rng:ref name="def_nonempty_string"/>
+                                  </rng:element>
+                                  <rng:optional>
+                                    <rng:element name="NameTitle">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:element>
+
+                                  </rng:optional>
+                                </rng:element>
+
+                                <!-- HotelReservation > ... > Customer > Telephone {0,} -->
+
+                                <rng:zeroOrMore>
+                                  <rng:element name="Telephone">
+
+                                    <rng:attribute name="PhoneTechType">
+                                      <rng:data type="string">
+                                        <rng:param name="pattern">(1|3|5)</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+                                    <rng:attribute name="PhoneNumber">
+                                      <rng:data type="string">
+                                        <rng:param name="pattern">\+?[0-9]+</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+
+                                  </rng:element>
+                                </rng:zeroOrMore>
+
+                                <!-- HotelReservation > ... > Customer > Email {0,1} -->
+
+                                <rng:optional>
+                                  <rng:element name="Email">
+                                    <rng:ref name="def_email_string"/>
+                                    <rng:optional>
+                                      <rng:attribute name="Remark">
+                                        <rng:data type="string">
+                                          <rng:param name="pattern">newsletter:(no|yes)</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                    </rng:optional>
+
+                                  </rng:element>
+                                </rng:optional>
+
+                                <!-- HotelReservation > ... > Customer > Address {0,1} -->
+
+                                <rng:optional>
+                                  <rng:element name="Address">
+
+                                    <rng:optional>
+                                      <rng:element name="AddressLine">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                    </rng:optional>
+
+                                    <rng:optional>
+                                      <rng:element name="CityName">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                    </rng:optional>
+
+                                    <rng:optional>
+                                      <rng:element name="PostalCode">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                    </rng:optional>
+
+                                    <rng:optional>
+                                      <rng:element name="CountryName">
+                                        <rng:attribute name="Code">
+                                          <rng:data type="string">
+                                            <rng:param name="pattern">[A-Z][A-Z]</rng:param>
+                                          </rng:data>
+                                        </rng:attribute>
+                                      </rng:element>
+                                    </rng:optional>
+
+                                    <rng:optional>
+                                      <rng:attribute name="Remark">
+                                        <rng:data type="string">
+                                          <rng:param name="pattern">catalog:(no|yes)</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                    </rng:optional>
+
+                                  </rng:element>
+                                </rng:optional>
+
+                                <rng:optional>
+                                  <rng:attribute name="Gender">
+                                    <rng:data type="string">
+                                      <rng:param name="pattern">(Unknown|Male|Female)</rng:param>
+                                    </rng:data>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="BirthDate">
+                                    <rng:ref name="def_date"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Language">
+                                    <rng:data type="language">
+                                      <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                    </rng:data>
+                                  </rng:attribute>
+                                </rng:optional>
+
+                              </rng:element>
+                            </rng:element>
+                          </rng:element>
+                        </rng:element>
+                      </rng:element>
+                    </rng:element>
+                  </rng:optional>
+
+                  <!-- HotelReservation > ResGlobalInfo {0,1} -->
+
+                  <rng:optional>
+                    <rng:element name="ResGlobalInfo">
+
+                      <!-- HotelReservation > ResGlobalInfo > Comments {0,1} -->
+
+                      <rng:optional>
+                        <rng:element name="Comments">
+
+                          <!-- HotelReservation > ResGlobalInfo > Comments {1,} (actually {1,2} but Relax-NG cannot do this) -->
+
+                          <rng:oneOrMore>
+                            <rng:element name="Comment">
+                         
+                              <rng:choice>
+                                <rng:zeroOrMore>
+                         
+                                  <rng:element name="ListItem">
+                                    <rng:ref name="def_nonempty_string"/>
+                                    <rng:attribute name="ListItem">
+                                      <rng:ref name="def_int_ge0"/>
+                                    </rng:attribute>
+                                    <rng:attribute name="Language">
+                                      <rng:data type="language">
+                                        <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+                         
+                                  </rng:element>
+                                </rng:zeroOrMore>
+                         
+                                <rng:optional>
+                                  <rng:element name="Text">
+                                    <rng:ref name="def_nonempty_string"/>
+                                  </rng:element>
+                                </rng:optional>
+                         
+                              </rng:choice>
+                         
+                              <rng:attribute name="Name">
+                                <rng:choice>
+                                  <rng:value>included services</rng:value>
+                                  <rng:value>customer comment</rng:value>
+                                </rng:choice>
+                              </rng:attribute>
+                         
+                            </rng:element>
+                          </rng:oneOrMore>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <!-- HotelReservation > ResGlobalInfo > CancelPenalties {0,1} -->
+
+                      <rng:optional>
+                        <rng:element name="CancelPenalties">
+                          <rng:element name="CancelPenalty">
+                            <rng:element name="PenaltyDescription">
+                              <rng:element name="Text">
+                                <rng:ref name="def_nonempty_string"/>
+                              </rng:element>
+                            </rng:element>
+                          </rng:element>
+                        </rng:element>
+                      </rng:optional>
+
+                      <!-- HotelReservation > ResGlobalInfo > HotelReservationIDs {0,1} -->
+
+                      <rng:optional>
+                        <rng:element name="HotelReservationIDs">
+
+                          <rng:oneOrMore>
+                            <rng:element name="HotelReservationID">
+                          
+                              <rng:attribute name="ResID_Type">
+                                  <rng:ref name="def_int_gt0"/>
+                              </rng:attribute>
+                              <rng:optional>
+                                <rng:attribute name="ResID_Value">
+                                  <rng:ref name="def_nonempty_string"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="ResID_Source">
+                                  <rng:ref name="def_nonempty_string"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="ResID_SourceContext">
+                                  <rng:ref name="def_nonempty_string"/>
+                                </rng:attribute>
+                              </rng:optional>
+                          
+                            </rng:element>
+                          </rng:oneOrMore>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <!-- HotelReservation > ResGlobalInfo > Profiles {0,1} -->
+
+                      <rng:optional>
+                        <rng:element name="Profiles">
+                          <rng:element name="ProfileInfo">
+                            <rng:element name="Profile">
+                          
+                              <rng:attribute name="ProfileType">
+                                <rng:choice>
+                                  <rng:value>4</rng:value>
+                                </rng:choice>
+                              </rng:attribute>
+                          
+                              <rng:element name="CompanyInfo">
+                          
+                                  <rng:element name="CompanyName">
+                                    <rng:ref name="def_nonempty_string"/>
+                                    <rng:attribute name="Code">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:attribute>
+                                    <rng:attribute name="CodeContext">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:attribute>
+                                  </rng:element>
+                          
+                                  <rng:optional>
+                                    <rng:element name="AddressInfo">
+                                      <rng:element name="AddressLine">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                      <rng:element name="CityName">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                      <rng:element name="PostalCode">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                      <rng:element name="CountryName">
+                                        <rng:attribute name="Code">
+                                          <rng:data type="string">
+                                            <rng:param name="pattern">[A-Z][A-Z]</rng:param>
+                                          </rng:data>
+                                        </rng:attribute>
+                                      </rng:element>
+                                    </rng:element>
+                                  </rng:optional>
+                          
+                                  <rng:optional>
+                                    <rng:element name="TelephoneInfo">
+                                      <rng:attribute name="PhoneTechType">
+                                        <rng:data type="string">
+                                          <rng:param name="pattern">(1|3|5)</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                      <rng:attribute name="PhoneNumber">
+                                        <rng:data type="string">
+                                          <rng:param name="pattern">\+?[0-9]+</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                    </rng:element>
+                                  </rng:optional>
+                                  <rng:optional>
+                                    <rng:element name="Email">
+                                      <rng:ref name="def_email_string"/>
+                                    </rng:element>
+                                  </rng:optional>
+                          
+                              </rng:element>
+                          
+                            </rng:element>
+                          </rng:element>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <rng:element name="BasicPropertyInfo">
+                        <rng:empty/>
+                      </rng:element>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:attribute name="CreateDateTime">
+                    <rng:ref name="def_datetime"/>
+                  </rng:attribute>
+                  <rng:attribute name="ResStatus">
+                    <rng:choice>
+                      <rng:value>Requested</rng:value>
+                      <rng:value>Reserved</rng:value>
+                      <rng:value>Cancelled</rng:value>
+                      <rng:value>Modify</rng:value>
+                    </rng:choice>
+                  </rng:attribute>
+
+                </rng:element>
+              </rng:zeroOrMore>
+
+            </rng:element>
+          </rng:group>
+
+        </rng:choice>
+
+        <rng:attribute name="xsi:schemaLocation"/>
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- GuestRequests: OTA_NotifReportRQ -->
+
+      <rng:element name="OTA_NotifReportRQ">
+
+        <rng:element name="Success">
+          <rng:empty/>
+        </rng:element>
+
+        <rng:optional>
+          <rng:element name="Warnings">
+        
+            <!-- Warnings > Warning {1,} -->
+
+            <rng:oneOrMore>
+              <rng:element name="Warning">
+          
+                <rng:attribute name="Type">
+                  <rng:ref name="def_int_gt0"/>
+                </rng:attribute>
+
+                <rng:attribute name="Code">
+                  <rng:ref name="def_int_gt0"/>
+                </rng:attribute>
+
+                  <rng:attribute name="RecordID">
+                    <rng:ref name="def_nonempty_string"/>
+                  </rng:attribute>
+
+                <rng:text/>
+          
+              </rng:element>
+            </rng:oneOrMore>
+
+          </rng:element>
+        </rng:optional>
+
+        <rng:optional>
+          <rng:element name="NotifDetails">
+
+            <rng:element name="HotelNotifReport">
+
+              <rng:element name="HotelReservations">
+
+                <rng:oneOrMore>
+                  <rng:element name="HotelReservation">
+
+                    <rng:element name="UniqueID">
+
+                      <rng:attribute name="Type">
+                        <rng:choice>
+                          <rng:value>14</rng:value>
+                          <rng:value>15</rng:value>
+                        </rng:choice>
+                      </rng:attribute>
+                      <rng:attribute name="ID">
+                        <rng:ref name="def_nonempty_string"/>
+                      </rng:attribute>
+
+                    </rng:element>
+
+                  </rng:element>
+                </rng:oneOrMore>
+
+              </rng:element>
+
+            </rng:element>
+
+          </rng:element>
+
+        </rng:optional>
+
+        <rng:attribute name="xsi:schemaLocation"/>
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- GuestRequests: OTA_NotifReportRS -->
+
+      <rng:element name="OTA_NotifReportRS">
+
+        <rng:choice>
+
+          <!-- choice: Errors {1} -->
+
+          <rng:element name="Errors">
+
+            <!-- Errors > Error {1,} -->
+
+            <rng:oneOrMore>
+              <rng:element name="Error">
+
+                <rng:attribute name="Type">
+                  <rng:value type="string">13</rng:value>
+                </rng:attribute>
+                <rng:attribute name="Code">
+                  <rng:ref name="def_int_ge0"/>
+                </rng:attribute>
+
+                <rng:text/>
+
+              </rng:element>
+
+            </rng:oneOrMore>
+
+          </rng:element>
+
+          <!-- choice: Success {1} -->
+
+          <rng:element name="Success">
+            <rng:empty/>
+          </rng:element>
+
+        </rng:choice>
+
+        <rng:attribute name="xsi:schemaLocation"/>
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+ 
+      </rng:element>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * SimplePackages                                                                -->
+      <!-- ******************************************************************************* -->
+
+      <!-- SimplePackages: OTA_HotelRatePlanNotifRQ
+           (note that the same root element is also used by RatePlans -
+           Relax-NG can do this, XML Schema can not) -->
+
+      <rng:element name="OTA_HotelRatePlanNotifRQ">
+
+        <!-- RatePlans {1} -->
+
+        <rng:element name="RatePlans">
+
+          <!-- RatePlans > RatePlan {1,} -->
+
+          <rng:oneOrMore>
+            <rng:element name="RatePlan">
+
+              <!-- RatePlans > RatePlan > Rates {0,1} -->
+
+              <rng:optional>
+                <rng:element name="Rates">
+
+                  <rng:oneOrMore>
+                    <rng:element name="Rate">
+
+                      <rng:optional>
+                        <rng:element name="BaseByGuestAmts">
+
+                          <rng:oneOrMore>
+                            <rng:element name="BaseByGuestAmt">
+
+                              <rng:attribute name="NumberOfGuests">
+                                <rng:ref name="def_int_gt0"/>
+                              </rng:attribute>
+                              <rng:optional>
+                                <rng:attribute name="AmountAfterTax">
+                                  <rng:ref name="def_decimal_ge0"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="CurrencyCode">
+                                  <rng:choice>
+                                    <rng:value>EUR</rng:value>
+                                  </rng:choice>
+                                </rng:attribute>
+                              </rng:optional>
+                            </rng:element>
+                          </rng:oneOrMore>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <rng:optional>
+                        <rng:element name="RateDescription">
+
+                          <rng:oneOrMore>
+                            <rng:element name="ListItem">
+
+                              <rng:ref name="def_nonempty_string"/>
+                              <rng:attribute name="ListItem">
+                                <rng:ref name="def_int_ge0"/>
+                              </rng:attribute>
+                              <rng:attribute name="Language">
+                                <rng:data type="language">
+                                  <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                </rng:data>
+                              </rng:attribute>
+
+                            </rng:element>
+                          </rng:oneOrMore>
+
+                          <rng:attribute name="Name">
+                            <rng:choice>
+                              <rng:value type="string">included services</rng:value>
+                            </rng:choice>
+                          </rng:attribute>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <rng:optional>
+                        <rng:element name="MealsIncluded">
+
+                          <rng:optional>
+                            <rng:attribute name="Breakfast">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Lunch">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Dinner">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="MealPlanCodes">
+                              <rng:choice>
+                                <rng:value>1</rng:value>
+                                <rng:value>3</rng:value>
+                                <rng:value>10</rng:value>
+                                <rng:value>12</rng:value>
+                                <rng:value>14</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="MealPlanIndicator">
+                              <rng:choice>
+                                <rng:value>1</rng:value>
+                                <rng:value>true</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <rng:optional>
+                        <rng:attribute name="MinGuestApplicable">
+                          <rng:ref name="def_int_gt0"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="Start">
+                          <rng:ref name="def_date"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="End">
+                          <rng:ref name="def_date"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="Mon">
+                          <rng:ref name="def_bool"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="Tue">
+                          <rng:ref name="def_bool"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="Weds">
+                          <rng:ref name="def_bool"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="Thur">
+                          <rng:ref name="def_bool"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="Fri">
+                          <rng:ref name="def_bool"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="Sat">
+                          <rng:ref name="def_bool"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="Sun">
+                          <rng:ref name="def_bool"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="Duration">
+                          <rng:data type="string">
+                            <rng:param name="pattern">P[0-9]+N</rng:param>
+                          </rng:data>
+                        </rng:attribute>
+                      </rng:optional>
+
+                    </rng:element>
+                  </rng:oneOrMore>
+
+                </rng:element>
+              </rng:optional>
+
+              <!-- RatePlans > RatePlan > Description {1,} (actually {1,4} but Relax-NG cannot do this) -->
+
+              <rng:zeroOrMore>
+                <rng:element name="Description">
+
+                  <rng:oneOrMore>
+                    <rng:choice>
+
+                      <rng:element name="Text">
+
+                        <rng:ref name="def_nonempty_string"/>
+                        <rng:attribute name="TextFormat">
+                          <rng:choice>
+                            <rng:value>PlainText</rng:value>
+                            <rng:value>HTML</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                        <rng:attribute name="Language">
+                          <rng:data type="language">
+                            <rng:param name="pattern">[a-z][a-z]</rng:param>
+                          </rng:data>
+                        </rng:attribute>
+
+                      </rng:element>
+
+                      <rng:element name="ListItem">
+
+                        <rng:ref name="def_nonempty_string"/>
+                        <rng:attribute name="ListItem">
+                          <rng:ref name="def_int_ge0"/>
+                        </rng:attribute>
+                        <rng:attribute name="Language">
+                          <rng:data type="language">
+                            <rng:param name="pattern">[a-z][a-z]</rng:param>
+                          </rng:data>
+                        </rng:attribute>
+
+                      </rng:element>
+
+                      <rng:element name="Image">
+
+                        <rng:ref name="def_url_string"/>
+                      </rng:element>
+                      <rng:element name="URL">
+                        <rng:ref name="def_url_string"/>
+
+                      </rng:element>
+
+                    </rng:choice>
+                  </rng:oneOrMore>
+
+                  <rng:attribute name="Name">
+                    <rng:choice>
+                      <rng:value>title</rng:value>
+                      <rng:value>intro</rng:value>
+                      <rng:value>gallery</rng:value>
+                      <rng:value>details</rng:value>
+                    </rng:choice>
+                  </rng:attribute>
+
+                </rng:element>
+              </rng:zeroOrMore>
+
+              <!-- RatePlans > RatePlan > UniqueID {1} -->
+
+              <rng:element name="UniqueID">
+
+                <rng:attribute name="Type">
+                  <rng:choice>
+                    <rng:value>18</rng:value>
+                  </rng:choice>
+                </rng:attribute>
+                <rng:attribute name="ID">
+                  <rng:ref name="def_nonempty_string"/>
+                </rng:attribute>
+
+              </rng:element>
+
+              <!-- RatePlans > RatePlan > HotelRef {0,1} -->
+
+              <rng:optional>      
+                <rng:element name="HotelRef">
+             
+                  <rng:oneOrMore>
+                    <rng:choice>
+                      <rng:attribute name="HotelCode">
+                        <rng:ref name="def_nonempty_string"/>
+                      </rng:attribute>
+                      <rng:attribute name="HotelName">
+                        <rng:ref name="def_nonempty_string"/>
+                      </rng:attribute>
+                    </rng:choice>
+                  </rng:oneOrMore>
+             
+                </rng:element>
+              </rng:optional>      
+
+              <rng:optional>
+                <rng:attribute name="Start">
+                  <rng:ref name="def_date"/>
+                </rng:attribute>
+              </rng:optional>
+              <rng:optional>
+                <rng:attribute name="End">
+                  <rng:ref name="def_date"/>
+                </rng:attribute>
+              </rng:optional>
+            </rng:element>
+          </rng:oneOrMore>
+
+        </rng:element>
+
+        <rng:attribute name="xsi:schemaLocation"/>
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- SimplePackages: OTA_HotelRatePlanNotifRS
+           (note that the same root element is also used by RatePlans -
+           Relax-NG can do this, XML Schema can not)-->
+
+      <rng:element name="OTA_HotelRatePlanNotifRS">
+
+        <rng:ref name="def_generic_response"/>
+
+        <rng:attribute name="xsi:schemaLocation"/>
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+
+      </rng:element>
+      
+      <!-- ******************************************************************************* -->
+      <!-- * Inventory                                                                     -->
+      <!-- ******************************************************************************* -->
+
+      <!-- Inventory: OTA_HotelDescriptiveContentNotifRQ -->
+
+      <rng:element name="OTA_HotelDescriptiveContentNotifRQ">
+
+        <rng:element name="HotelDescriptiveContents">
+
+            <rng:element name="HotelDescriptiveContent">
+
+                <rng:element name="FacilityInfo">
+
+                    <rng:element name="GuestRooms">
+                      
+                      <rng:oneOrMore>
+                        <rng:choice>
+
+                          <!-- basic content + basic descriptions + optionally additional description -->
+                          <rng:element name="GuestRoom">
+                            <rng:element name="TypeRoom">
+                              <rng:attribute name="StandardOccupancy">
+                                <rng:ref name="def_int_gt0"/>
+                              </rng:attribute>
+                              <rng:attribute name="RoomClassificationCode">
+                                <rng:ref name="def_int_ge0"/>
+                              </rng:attribute>
+                            </rng:element>
+
+                            <rng:optional>
+                              <rng:element name="Amenities">
+                                <rng:oneOrMore>
+                                  <rng:element name="Amenity">
+                                      <rng:optional>
+                                        <rng:attribute name="RoomAmenityCode">
+                                          <rng:ref name="def_int_gt0"/>
+                                        </rng:attribute>
+                                      </rng:optional>
+                                  </rng:element>
+                                </rng:oneOrMore>
+                              </rng:element>
+                            </rng:optional>
+
+                              <rng:element name="MultimediaDescriptions">
+
+                                <rng:oneOrMore>
+
+                                  <rng:choice>
+
+                                    <!-- basic description: Long name + Description -->
+                                    <rng:element name="MultimediaDescription">
+
+                                      <rng:optional>
+                                        <rng:element name="TextItems">
+                                          <rng:element name="TextItem">
+                                            <rng:zeroOrMore>
+                                              <rng:element name="Description">
+                                                <rng:ref name="def_nonempty_string"/>
+                                                <rng:attribute name="TextFormat">
+                                                  <rng:choice>
+                                                    <rng:value>PlainText</rng:value>
+                                                  </rng:choice>
+                                                </rng:attribute>
+                                                <rng:attribute name="Language">
+                                                  <rng:data type="language">
+                                                    <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                                  </rng:data>
+                                                </rng:attribute>
+                                              </rng:element>
+                                            </rng:zeroOrMore>
+                                          </rng:element>
+                                        </rng:element>
+                                      </rng:optional>
+
+                                      <rng:optional>
+                                        <rng:attribute name="InfoCode">
+                                          <rng:choice>
+                                            <rng:value>1</rng:value>
+                                            <rng:value>25</rng:value>
+                                          </rng:choice>
+                                        </rng:attribute>
+                                      </rng:optional>
+
+                                    </rng:element>
+
+                                    <!-- basic description: Pictures -->
+                                    <rng:element name="MultimediaDescription">
+
+                                      <rng:optional>
+                                        <rng:element name="ImageItems">
+                                          <rng:element name="ImageItem">
+                                            <rng:element name="ImageFormat">
+                                              <rng:element name="URL">
+                                                <rng:ref name="def_url_string"/>
+                                              </rng:element>
+                                              <rng:optional>
+                                                <rng:attribute name="CopyrightNotice">
+                                                  <rng:ref name="def_nonempty_string"/>
+                                                </rng:attribute>
+                                              </rng:optional>
+                                            </rng:element>
+                                    
+                                            <rng:zeroOrMore>
+                                              <rng:element name="Description">
+                                                <rng:ref name="def_nonempty_string"/>
+                                                <rng:attribute name="TextFormat">
+                                                  <rng:choice>
+                                                    <rng:value>PlainText</rng:value>
+                                                  </rng:choice>
+                                                </rng:attribute>
+                                                <rng:attribute name="Language">
+                                                  <rng:data type="language">
+                                                    <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                                  </rng:data>
+                                                </rng:attribute>
+                                              </rng:element>
+                                            </rng:zeroOrMore>
+                                    
+                                            <rng:attribute name="Category">
+                                              <rng:ref name="def_int_gt0"/>
+                                            </rng:attribute>
+                                    
+                                          </rng:element>
+                                        </rng:element>
+                                      </rng:optional>
+
+                                      <rng:optional>
+                                        <rng:attribute name="InfoCode">
+                                          <rng:choice>
+                                            <rng:value>23</rng:value>
+                                          </rng:choice>
+                                        </rng:attribute>
+                                      </rng:optional>
+
+                                    </rng:element>
+
+                                    <!-- additional description -->
+                                    <rng:element name="MultimediaDescription">
+
+                                      <rng:optional>
+                                        <rng:element name="ImageItems">
+                                      
+                                          <rng:oneOrMore>
+                                            <rng:element name="ImageItem">
+                                              <rng:element name="ImageFormat">
+                                                <rng:element name="URL">
+                                                  <rng:ref name="def_url_string"/>
+                                                </rng:element>
+                                                <rng:optional>
+                                                  <rng:attribute name="CopyrightNotice">
+                                                    <rng:ref name="def_nonempty_string"/>
+                                                  </rng:attribute>
+                                                </rng:optional>
+                                              </rng:element>
+                                      
+                                              <rng:zeroOrMore>
+                                                <rng:element name="Description">
+                                                  <rng:ref name="def_nonempty_string"/>
+                                                  <rng:attribute name="TextFormat">
+                                                    <rng:choice>
+                                                      <rng:value>PlainText</rng:value>
+                                                    </rng:choice>
+                                                  </rng:attribute>
+                                                  <rng:attribute name="Language">
+                                                    <rng:data type="language">
+                                                      <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                                    </rng:data>
+                                                  </rng:attribute>
+                                                </rng:element>
+                                              </rng:zeroOrMore>
+                                      
+                                              <rng:attribute name="Category">
+                                                <rng:ref name="def_int_gt0"/>
+                                              </rng:attribute>
+                                            </rng:element>
+                                          </rng:oneOrMore>
+                                      
+                                        </rng:element>
+                                      </rng:optional>
+
+                                    </rng:element>
+
+                                  </rng:choice>
+                                </rng:oneOrMore>
+
+                              </rng:element>
+ 
+                          <rng:attribute name="Code">
+                            <rng:ref name="def_invTypeCode_string"/>
+                          </rng:attribute>
+                          <rng:attribute name="MaxOccupancy">
+                            <rng:ref name="def_int_gt0"/>
+                          </rng:attribute>
+                          <rng:attribute name="MinOccupancy">
+                            <rng:ref name="def_int_gt0"/>
+                          </rng:attribute>
+                          <rng:optional>
+                            <rng:attribute name="MaxChildOccupancy">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          
+                          </rng:element>
+
+                          <!-- additional detail only -->
+                          <rng:element name="GuestRoom">
+
+                            <rng:element name="MultimediaDescriptions">
+                              <rng:element name="MultimediaDescription">
+                                <rng:element name="ImageItems">
+
+                                  <rng:oneOrMore>
+                                    <rng:element name="ImageItem">
+                                      <rng:element name="ImageFormat">
+                                        <rng:element name="URL">
+                                          <rng:ref name="def_url_string"/>
+                                        </rng:element>
+                                        <rng:optional>
+                                          <rng:attribute name="CopyrightNotice">
+                                            <rng:ref name="def_nonempty_string"/>
+                                          </rng:attribute>
+                                        </rng:optional>
+                                      </rng:element>
+
+                                      <rng:zeroOrMore>
+                                        <rng:element name="Description">
+                                          <rng:ref name="def_nonempty_string"/>
+                                          <rng:attribute name="TextFormat">
+                                            <rng:choice>
+                                              <rng:value>PlainText</rng:value>
+                                            </rng:choice>
+                                          </rng:attribute>
+                                          <rng:attribute name="Language">
+                                            <rng:data type="language">
+                                              <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                            </rng:data>
+                                          </rng:attribute>
+                                        </rng:element>
+                                      </rng:zeroOrMore>
+ 
+                                      <rng:attribute name="Category">
+                                        <rng:ref name="def_int_gt0"/>
+                                      </rng:attribute>
+                                    </rng:element>
+                                  </rng:oneOrMore>
+
+                                </rng:element>
+                              </rng:element>
+                            </rng:element>
+
+                          <rng:attribute name="Code">
+                            <rng:ref name="def_nonempty_string"/>
+                          </rng:attribute>
+                          </rng:element>
+
+                          <!-- room list -->
+                          <rng:element name="GuestRoom">
+                            <rng:element name="TypeRoom">
+                              <rng:attribute name="RoomID">
+                                <rng:ref name="def_nonempty_string"/>
+                              </rng:attribute>
+                            </rng:element>
+                          <rng:attribute name="Code">
+                            <rng:ref name="def_nonempty_string"/>
+                          </rng:attribute>
+                          </rng:element>
+
+                        </rng:choice>
+                      </rng:oneOrMore>
+                      
+                    </rng:element>
+                </rng:element>
+              
+              <rng:oneOrMore>
+                <rng:choice>
+                  <rng:attribute name="HotelCode">
+                    <rng:ref name="def_nonempty_string"/>
+                  </rng:attribute>
+                  <rng:attribute name="HotelName">
+                    <rng:ref name="def_nonempty_string"/>
+                  </rng:attribute>
+                </rng:choice>
+              </rng:oneOrMore>
+
+            </rng:element>
+            
+        </rng:element>
+        
+        <rng:attribute name="xsi:schemaLocation"/>
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- Inventory: OTA_HotelDescriptiveContentNotifRQ -->
+      
+      
+      <!-- Inventory: OTA_HotelDescriptiveContentNotifRS -->
+
+      <rng:element name="OTA_HotelDescriptiveContentNotifRS">
+
+        <rng:ref name="def_generic_response"/>
+
+        <rng:attribute name="xsi:schemaLocation"/>
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+
+      </rng:element>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * RatePlans                                                                     -->
+      <!-- ******************************************************************************* -->
+
+      <!-- RatePlans: OTA_HotelRatePlanNotifRQ 
+           (note that the same root element is also used by SimplePackages -
+           Relax-NG can do this, XML Schema can not) -->
+
+      <rng:element name="OTA_HotelRatePlanNotifRQ">
+
+        <!-- UniqueID {0,1} -->
+
+        <rng:optional>
+          <rng:element name="UniqueID">
+
+            <rng:attribute name="Type">
+              <rng:value type="string">16</rng:value>
+            </rng:attribute>
+            <rng:attribute name="ID"/> <!-- an ID is required by OTA, we ignore the value -->
+            <rng:attribute name="Instance">
+              <rng:value type="string">CompleteSet</rng:value>
+            </rng:attribute>
+
+          </rng:element>
+        </rng:optional>
+
+        <!-- RatePlans {1} -->
+
+        <rng:element name="RatePlans">
+
+          <!-- RatePlans > RatePlan {1,} -->
+
+          <rng:oneOrMore>
+            <rng:element name="RatePlan">
+
+              <!-- RatePlans > RatePlan > BookingRules {0,1} -->
+
+              <rng:optional>
+                <rng:element name="BookingRules">
+
+                  <rng:oneOrMore>
+                    <rng:element name="BookingRule">
+
+                      <rng:optional>
+                        <rng:element name="LengthsOfStay">
+
+                          <rng:oneOrMore>
+                            <rng:element name="LengthOfStay">
+
+                              <rng:attribute name="Time">
+                                <rng:ref name="def_decimal_ge0"/>
+                              </rng:attribute>
+                              <rng:attribute name="TimeUnit">
+                                <rng:value type="string">Day</rng:value>
+                              </rng:attribute>
+                              <rng:attribute name="MinMaxMessageType">
+                                <rng:choice>
+                                  <rng:value>SetMinLOS</rng:value>
+                                  <rng:value>SetMaxLOS</rng:value>
+                                </rng:choice>
+                              </rng:attribute>
+
+                            </rng:element>
+                          </rng:oneOrMore>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <rng:optional>
+                        <rng:element name="DOW_Restrictions">
+
+                          <rng:optional>
+                            <rng:element name="ArrivalDaysOfWeek">
+
+                              <rng:optional>
+                                <rng:attribute name="Mon">
+                                  <rng:ref name="def_bool"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="Tue">
+                                  <rng:ref name="def_bool"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="Weds">
+                                  <rng:ref name="def_bool"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="Thur">
+                                  <rng:ref name="def_bool"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="Fri">
+                                  <rng:ref name="def_bool"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="Sat">
+                                  <rng:ref name="def_bool"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="Sun">
+                                  <rng:ref name="def_bool"/>
+                                </rng:attribute>
+                              </rng:optional>
+
+                            </rng:element>
+                          </rng:optional>
+
+                          <rng:optional>
+                            <rng:element name="DepartureDaysOfWeek">
+
+                              <rng:optional>
+                                <rng:attribute name="Mon">
+                                  <rng:ref name="def_bool"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="Tue">
+                                  <rng:ref name="def_bool"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="Weds">
+                                  <rng:ref name="def_bool"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="Thur">
+                                  <rng:ref name="def_bool"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="Fri">
+                                  <rng:ref name="def_bool"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="Sat">
+                                  <rng:ref name="def_bool"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="Sun">
+                                  <rng:ref name="def_bool"/>
+                                </rng:attribute>
+                              </rng:optional>
+
+                            </rng:element>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <rng:optional>
+                        <rng:element name="RestrictionStatus">
+
+                          <rng:optional>
+                            <rng:attribute name="Restriction">
+                              <rng:choice>
+                                <rng:value>Master</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Status">
+                              <rng:choice>
+                                <rng:value>Open</rng:value>
+                                <rng:value>Close</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <rng:optional>
+                        <rng:attribute name="CodeContext">
+                          <rng:choice>
+                            <rng:value>ROOMTYPE</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="Code">
+                          <rng:ref name="def_invTypeCode_string"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="Start">
+                          <rng:ref name="def_date"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="End">
+                          <rng:ref name="def_date"/>
+                        </rng:attribute>
+                      </rng:optional>
+                    </rng:element>
+                  </rng:oneOrMore>
+
+                </rng:element>
+              </rng:optional>
+
+              <!-- RatePlans > RatePlan > Rates {0,1} -->
+
+              <rng:optional>
+                <rng:element name="Rates">
+
+                  <rng:oneOrMore>
+                    <rng:element name="Rate">
+
+                      <rng:optional>
+                        <rng:element name="BaseByGuestAmts">
+
+                          <rng:oneOrMore>
+                            <rng:element name="BaseByGuestAmt">
+
+                              <rng:attribute name="NumberOfGuests">
+                                <rng:ref name="def_int_gt0"/>
+                              </rng:attribute>
+                              <rng:optional>
+                                <rng:attribute name="AmountAfterTax">
+                                  <rng:ref name="def_decimal_gt0"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="CurrencyCode">
+                                  <rng:choice>
+                                    <rng:value>EUR</rng:value>
+                                  </rng:choice>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:attribute name="Type">
+                                <rng:choice>
+                                  <rng:value>7</rng:value>
+                                  <rng:value>25</rng:value>
+                                </rng:choice>
+                              </rng:attribute>
+                              <rng:optional>
+                                <rng:attribute name="AgeQualifyingCode">
+                                  <rng:ref name="def_int_gt0"/>
+                                </rng:attribute>
+                              </rng:optional>
+
+                            </rng:element>
+                          </rng:oneOrMore>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <rng:optional>
+                        <rng:element name="AdditionalGuestAmounts">
+
+                          <rng:oneOrMore>
+                            <rng:element name="AdditionalGuestAmount">
+
+                              <rng:optional>
+                                <rng:attribute name="Amount">
+                                  <rng:ref name="def_decimal_ge0"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="AgeQualifyingCode">
+                                  <rng:ref name="def_int_gt0"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="MinAge">
+                                  <rng:ref name="def_int_gt0"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="MaxAge">
+                                  <rng:ref name="def_int_gt0"/>
+                                </rng:attribute>
+                              </rng:optional>
+
+                            </rng:element>
+                          </rng:oneOrMore>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <rng:optional>
+                        <rng:element name="MealsIncluded">
+
+                          <rng:optional>
+                            <rng:attribute name="MealPlanCodes">
+                              <rng:choice>
+                                <rng:value>1</rng:value>
+                                <rng:value>3</rng:value>
+                                <rng:value>10</rng:value>
+                                <rng:value>12</rng:value>
+                                <rng:value>14</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="MealPlanIndicator">
+                              <rng:choice>
+                                <rng:value>1</rng:value>
+                                <rng:value>true</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <rng:optional>
+                        <rng:attribute name="Start">
+                          <rng:ref name="def_date"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="End">
+                          <rng:ref name="def_date"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="RateTimeUnit">
+                          <rng:choice>
+                            <rng:value type="string">Day</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="UnitMultiplier">
+                          <rng:ref name="def_int_gt0"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="InvTypeCode">
+                          <rng:ref name="def_invTypeCode_string"/>
+                        </rng:attribute>
+                      </rng:optional>
+
+                    </rng:element>
+                  </rng:oneOrMore>
+
+                </rng:element>
+              </rng:optional>
+
+              <!-- RatePlans > RatePlan > Supplements {0,1} -->
+
+              <rng:optional>
+                <rng:element name="Supplements">
+
+                  <rng:oneOrMore>
+                    <rng:element name="Supplement">
+
+                      <rng:zeroOrMore>
+                        <rng:element name="Description">
+
+                          <rng:oneOrMore>
+                            <rng:choice>
+
+                              <rng:element name="Text">
+                                <rng:attribute name="TextFormat">
+                                  <rng:choice>
+                                    <rng:value>PlainText</rng:value>
+                                  </rng:choice>
+                                </rng:attribute>
+                                <rng:ref name="def_nonempty_string"/>
+                                <rng:attribute name="Language">
+                                  <rng:data type="language">
+                                    <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                  </rng:data>
+                                </rng:attribute>
+
+                              </rng:element>
+
+                            </rng:choice>
+                          </rng:oneOrMore>
+
+                          <rng:attribute name="Name">
+                            <rng:choice>
+                              <rng:value>title</rng:value>
+                              <rng:value>intro</rng:value>
+                            </rng:choice>
+                          </rng:attribute>
+
+                        </rng:element>
+                      </rng:zeroOrMore>
+
+                      <rng:optional>
+                        <rng:attribute name="AddToBasicRateIndicator">
+                          <rng:choice>
+                            <rng:value>1</rng:value>
+                            <rng:value>true</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:optional>
+
+                      <rng:optional>
+                        <rng:attribute name="ChargeTypeCode">
+                          <rng:choice>
+                            <rng:value>1</rng:value>
+                            <rng:value>12</rng:value>
+                            <rng:value>18</rng:value>
+                            <rng:value>19</rng:value>
+                            <rng:value>20</rng:value>
+                            <rng:value>21</rng:value>
+                            <rng:value>24</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:optional>
+                   
+                      <rng:optional>
+                        <rng:attribute name="Amount">
+                          <rng:ref name="def_decimal_ge0"/>
+                        </rng:attribute>
+                      </rng:optional>
+
+                      <rng:optional>
+                        <rng:attribute name="InvType">
+                          <rng:choice>
+                            <rng:value>EXTRA</rng:value>
+                            <rng:value>ALPINEBITSEXTRA</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:optional>
+
+                      <rng:optional>
+                        <rng:attribute name="InvCode">
+                          <rng:ref name="def_nonempty_string"/>
+                        </rng:attribute>
+                      </rng:optional>
+
+                      <rng:optional>
+                        <rng:attribute name="MandatoryIndicator">
+                          <rng:ref name="def_bool"/>
+                        </rng:attribute>
+                      </rng:optional>
+
+                      <rng:optional>
+                        <rng:attribute name="Start">
+                          <rng:ref name="def_date"/>
+                        </rng:attribute>
+                      </rng:optional>
+
+                      <rng:optional>
+                        <rng:attribute name="End">
+                          <rng:ref name="def_date"/>
+                        </rng:attribute>
+                      </rng:optional>
+
+                    </rng:element>
+                  </rng:oneOrMore>
+
+                </rng:element>
+              </rng:optional>
+
+              <!-- RatePlans > RatePlan > Offers {0,1}  -->
+
+              <rng:optional>
+                <rng:element name="Offers">
+
+                  <rng:oneOrMore>
+                    <rng:element name="Offer">
+
+                      <rng:element name="Discount">
+
+                        <rng:attribute name="Percent">
+                          <rng:value type="string">100</rng:value>
+                        </rng:attribute>
+                        <rng:optional>
+                          <rng:attribute name="NightsRequired">
+                            <rng:ref name="def_int_gt0"/>
+                          </rng:attribute>
+                        </rng:optional>
+                        <rng:optional>
+                          <rng:attribute name="NightsDiscounted">
+                            <rng:ref name="def_int_gt0"/>
+                          </rng:attribute>
+                        </rng:optional>
+                        <rng:optional>
+                          <rng:attribute name="DiscountPattern">
+                            <rng:data type="string">
+                              <rng:param name="pattern">0*1*</rng:param>
+                            </rng:data>
+                          </rng:attribute>
+                        </rng:optional>
+
+                      </rng:element>
+
+                      <rng:optional>
+                        <rng:element name="Guests">
+
+                          <rng:element name="Guest">
+
+                            <rng:attribute name="AgeQualifyingCode">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                            <rng:attribute name="MaxAge">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                            <rng:attribute name="MinCount">
+                              <rng:ref name="def_int_ge0"/>
+                            </rng:attribute>
+                            <rng:attribute name="FirstQualifyingPosition">
+                              <rng:choice>
+                                <rng:value>1</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+                            <rng:attribute name="LastQualifyingPosition">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+
+                          </rng:element>
+
+                        </rng:element>
+                      </rng:optional>
+
+                    </rng:element>
+                  </rng:oneOrMore>
+
+                </rng:element>
+              </rng:optional>
+
+              <!-- RatePlans > RatePlan > Description {0,} (actually {0,2} but Relax-NG cannot do this) -->
+
+              <rng:zeroOrMore>
+                <rng:element name="Description">
+
+                  <rng:oneOrMore>
+                    <rng:choice>
+
+                      <rng:element name="Text">
+
+                        <rng:ref name="def_nonempty_string"/>
+                        <rng:attribute name="TextFormat">
+                          <rng:choice>
+                            <rng:value>PlainText</rng:value>
+                            <rng:value>HTML</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                        <rng:attribute name="Language">
+                          <rng:data type="language">
+                            <rng:param name="pattern">[a-z][a-z]</rng:param>
+                          </rng:data>
+                        </rng:attribute>
+
+                      </rng:element>
+
+                    </rng:choice>
+                  </rng:oneOrMore>
+
+                  <rng:attribute name="Name">
+                    <rng:choice>
+                      <rng:value>title</rng:value>
+                      <rng:value>intro</rng:value>
+                      <rng:value>gallery</rng:value>
+                      <rng:value>details</rng:value>
+                    </rng:choice>
+                  </rng:attribute>
+
+                </rng:element>
+              </rng:zeroOrMore>
+
+              <rng:optional>
+                <rng:attribute name="RatePlanNotifType">
+                  <rng:choice>
+                    <rng:value>Overlay</rng:value>
+                    <rng:value>New</rng:value>
+                    <rng:value>Remove</rng:value>
+                  </rng:choice>
+                </rng:attribute>
+              </rng:optional>
+              <rng:optional>
+                <rng:attribute name="CurrencyCode">
+                  <rng:choice>
+                    <rng:value>EUR</rng:value>
+                  </rng:choice>
+                </rng:attribute>
+              </rng:optional>
+              <rng:optional>
+                <rng:attribute name="RatePlanCode">
+                  <rng:ref name="def_nonempty_string"/>
+                </rng:attribute>
+              </rng:optional>
+              <rng:optional>
+                <rng:attribute name="RatePlanType">
+                  <rng:choice>
+                    <rng:value>12</rng:value>
+                  </rng:choice>
+                </rng:attribute>
+              </rng:optional>
+              <rng:optional>
+                <rng:attribute name="RatePlanCategory">
+                  <rng:ref name="def_nonempty_string"/>
+                </rng:attribute>
+              </rng:optional>
+              <rng:optional>
+                <rng:attribute name="RatePlanID">
+                  <rng:ref name="def_nonempty_string"/>
+                </rng:attribute>
+              </rng:optional>
+              <rng:optional>
+                <rng:attribute name="RatePlanQualifier">
+                  <rng:ref name="def_bool"/>
+                </rng:attribute>
+              </rng:optional>
+
+            </rng:element>
+          </rng:oneOrMore>
+
+          <rng:oneOrMore>
+            <rng:choice>
+              <rng:attribute name="HotelCode">
+                <rng:ref name="def_nonempty_string"/>
+              </rng:attribute>
+              <rng:attribute name="HotelName">
+                <rng:ref name="def_nonempty_string"/>
+              </rng:attribute>
+            </rng:choice>
+          </rng:oneOrMore>
+
+        </rng:element>
+
+        <rng:attribute name="xsi:schemaLocation"/>
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- RatePlans: OTA_HotelRatePlanNotifRS -
+           see the identical definition for SimplePackages -->
+
+    </rng:choice>
+  </rng:start>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for success/advisory/warning/error responses                -->
+  <!-- ******************************************************************************* -->
+
+  <rng:define name="def_generic_response">
+    <rng:choice>
+
+      <!-- choice: Errors {1} -->
+
+      <rng:element name="Errors">
+    
+        <!-- Errors > Error {1,} -->
+
+        <rng:oneOrMore>
+          <rng:element name="Error">
+
+            <rng:attribute name="Type">
+              <rng:value type="string">13</rng:value>
+            </rng:attribute>
+            <rng:attribute name="Code">
+              <rng:ref name="def_int_gt0"/>
+            </rng:attribute>
+
+            <rng:text/>
+
+          </rng:element>
+        </rng:oneOrMore>
+
+      </rng:element>
+
+      <!-- choice: Success {1} + Warnings {0,1} -->
+
+      <rng:group>
+
+        <rng:element name="Success">
+          <rng:empty/>
+        </rng:element>
+
+        <rng:optional>
+          <rng:element name="Warnings">
+        
+            <!-- Warnings > Warning {1,} -->
+
+            <rng:oneOrMore>
+              <rng:element name="Warning">
+          
+                <rng:attribute name="Type">
+                  <rng:ref name="def_int_gt0"/>
+                </rng:attribute>
+
+                <rng:optional>
+                  <rng:attribute name="RecordID">
+                    <rng:ref name="def_nonempty_string"/>
+                  </rng:attribute>
+                </rng:optional>
+
+                <rng:text/>
+          
+              </rng:element>
+            </rng:oneOrMore>
+
+          </rng:element>
+        </rng:optional>
+
+      </rng:group>
+
+    </rng:choice>
+  </rng:define>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for recurring, simple types                                 -->
+  <!-- ******************************************************************************* -->
+
+  <!-- A generic non-empty string type. -->
+
+  <rng:define name="def_nonempty_string">
+    <rng:data type="string">
+      <rng:param name="minLength">1</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic string type containing an @ char, like an email address. -->
+
+  <rng:define name="def_email_string">
+    <rng:data type="string">
+      <rng:param name="pattern">\S+@\S+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic string type starting with http:// or https:// --> 
+
+  <rng:define name="def_url_string">
+    <rng:data type="string">
+      <rng:param name="pattern">https?://.+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- String type defining room category codes (like InvTypeCode)  -->
+
+  <rng:define name="def_invTypeCode_string">
+    <rng:data type="string">
+      <rng:param name="minLength">1</rng:param>
+      <rng:param name="maxLength">8</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic integer > 0 type. -->
+
+  <rng:define name="def_int_gt0">
+    <rng:data type="positiveInteger">
+      <rng:param name="pattern">[0-9]+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic integer >= 0 type. -->
+
+  <rng:define name="def_int_ge0">
+    <rng:data type="nonNegativeInteger">
+      <rng:param name="pattern">[0-9]+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic decimal >= 0 type. -->
+
+  <rng:define name="def_decimal_ge0">
+    <rng:data type="decimal">
+      <rng:param name="minInclusive">0.0</rng:param>
+      <rng:param name="pattern">[0-9]*\.?[0-9]*</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic decimal > 0 type. -->
+
+  <rng:define name="def_decimal_gt0">
+    <rng:data type="decimal">
+      <rng:param name="minExclusive">0.0</rng:param>
+      <rng:param name="pattern">[0-9]*\.?[0-9]*</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic date type. -->
+
+  <rng:define name="def_date">
+    <rng:data type="date">
+      <rng:param name="pattern">\S+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic datetime type. -->
+
+  <rng:define name="def_datetime">
+    <rng:data type="dateTime">
+      <rng:param name="pattern">\S+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic boolean type (1,true,0,false). -->
+
+  <rng:define name="def_bool">
+    <rng:data type="boolean">
+      <rng:param name="pattern">\S+</rng:param>
+    </rng:data>
+  </rng:define>
+
+</rng:grammar>
+

--- a/alpinebits-xml/api/src/main/resources/global.xjb
+++ b/alpinebits-xml/api/src/main/resources/global.xjb
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<jaxb:bindings version="2.0" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+               xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+               xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               jaxb:extensionBindingPrefixes="xjc">
+
+    <jaxb:globalBindings>
+        <xjc:simple/>
+        <xjc:javaType name="java.time.LocalDate" xmlType="xs:date"
+                      adapter="it.bz.idm.alpinebits.xml.xmladapter.LocalDateAdapter"/>
+        <xjc:javaType name="java.time.ZonedDateTime" xmlType="xs:dateTime"
+                      adapter="it.bz.idm.alpinebits.xml.xmladapter.ZonedDateTimeAdapter"/>
+    </jaxb:globalBindings>
+</jaxb:bindings>

--- a/alpinebits-xml/api/src/test/java/it/bz/idm/alpinebits/xml/xmladapter/LocalDateAdapterTest.java
+++ b/alpinebits-xml/api/src/test/java/it/bz/idm/alpinebits/xml/xmladapter/LocalDateAdapterTest.java
@@ -1,0 +1,44 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.xmladapter;
+
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+/**
+ * Test cases for {@link LocalDateAdapter} class.
+ */
+public class LocalDateAdapterTest {
+
+    @Test
+    public void testUnmarshal() throws Exception {
+        LocalDate localDate = LocalDate.now();
+        LocalDateAdapter localDateAdapter = new LocalDateAdapter();
+        LocalDate unmarshalledLocalDate = localDateAdapter.unmarshal(localDate.toString());
+        assertEquals(unmarshalledLocalDate, localDate);
+
+    }
+
+    @Test
+    public void testMarshal() throws Exception {
+        LocalDate localDate = LocalDate.now();
+        LocalDateAdapter localDateAdapter = new LocalDateAdapter();
+        String date = localDateAdapter.marshal(localDate);
+        assertEquals(date, localDate.toString());
+    }
+
+    @Test
+    public void testMarshal_LocalDateIsNull() throws Exception {
+        LocalDateAdapter localDateAdapter = new LocalDateAdapter();
+        String date = localDateAdapter.marshal(null);
+        assertNull(date);
+    }
+}

--- a/alpinebits-xml/api/src/test/java/it/bz/idm/alpinebits/xml/xmladapter/ZonedDateTimeAdapterTest.java
+++ b/alpinebits-xml/api/src/test/java/it/bz/idm/alpinebits/xml/xmladapter/ZonedDateTimeAdapterTest.java
@@ -1,0 +1,44 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.xmladapter;
+
+import org.testng.annotations.Test;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+/**
+ * Test cases for {@link ZonedDateTimeAdapter} class.
+ */
+public class ZonedDateTimeAdapterTest {
+
+    @Test
+    public void testUnmarshal() {
+        ZonedDateTime dateTime = ZonedDateTime.now();
+        ZonedDateTimeAdapter zonedDateTimeAdapter = new ZonedDateTimeAdapter();
+        ZonedDateTime unmarshalledLocalDateTime = zonedDateTimeAdapter.unmarshal(dateTime.format(DateTimeFormatter.ISO_ZONED_DATE_TIME));
+        assertEquals(unmarshalledLocalDateTime, dateTime);
+    }
+
+    @Test
+    public void testMarshal() {
+        ZonedDateTime zonedDateTime = ZonedDateTime.now();
+        ZonedDateTimeAdapter zonedDateTimeAdapter = new ZonedDateTimeAdapter();
+        String dateTime = zonedDateTimeAdapter.marshal(zonedDateTime);
+        assertEquals(dateTime, zonedDateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+    }
+
+    @Test
+    public void testMarshal_ZonedDateTimeIsNull() {
+        ZonedDateTimeAdapter zonedDateTimeAdapter = new ZonedDateTimeAdapter();
+        String dateTime = zonedDateTimeAdapter.marshal(null);
+        assertNull(dateTime);
+    }
+}

--- a/alpinebits-xml/impl/pom.xml
+++ b/alpinebits-xml/impl/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>it.bz.idm.alpinebits</groupId>
+        <artifactId>alpinebits-xml</artifactId>
+        <version>0.0.9</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>alpinebits-xml-impl</artifactId>
+    <version>0.0.9</version>
+
+    <name>IDM AlpineBits XML impl</name>
+
+    <properties>
+        <jing.version>20091111</jing.version>
+        <xmlunit.version>2.6.2</xmlunit.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>it.bz.idm.alpinebits</groupId>
+            <artifactId>alpinebits-common-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>it.bz.idm.alpinebits</groupId>
+            <artifactId>alpinebits-middleware-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>it.bz.idm.alpinebits</groupId>
+            <artifactId>alpinebits-xml-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.thaiopensource</groupId>
+            <artifactId>jing</artifactId>
+            <version>${jing.version}</version>
+        </dependency>
+
+        <!-- testing -->
+        <dependency>
+            <groupId>it.bz.idm.alpinebits</groupId>
+            <artifactId>alpinebits-middleware-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>it.bz.idm.alpinebits</groupId>
+            <artifactId>alpinebits-servlet-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testng</groupId>
+            <artifactId>arquillian-testng-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-core</artifactId>
+            <version>${xmlunit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId>
+            <artifactId>xmlunit-matchers</artifactId>
+            <version>${xmlunit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!--
+            Arquilllian needs this additional dependency
+            to work in combination with jing
+        -->
+        <dependency>
+            <groupId>net.sf.saxon</groupId>
+            <artifactId>saxon-dom</artifactId>
+            <version>8.7</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/alpinebits-xml/impl/src/main/java/it/bz/idm/alpinebits/xml/JAXBObjectToXmlConverter.java
+++ b/alpinebits-xml/impl/src/main/java/it/bz/idm/alpinebits/xml/JAXBObjectToXmlConverter.java
@@ -1,0 +1,98 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import javax.xml.validation.Schema;
+import java.io.OutputStream;
+
+/**
+ * This class provides methods to convert Java objects to XML.
+ *
+ * @param <T> object type
+ */
+public final class JAXBObjectToXmlConverter<T> implements ObjectToXmlConverter<T> {
+
+    private Marshaller marshaller;
+
+    private JAXBObjectToXmlConverter() {
+        // Empty
+    }
+
+    @Override
+    public void toXml(T objectToConvert, OutputStream os) {
+        try {
+            this.marshaller.marshal(objectToConvert, os);
+        } catch (JAXBException e) {
+            throw new XmlConversionException("Object-to-XML conversion error", e);
+        }
+    }
+
+    /**
+     * Builder to create instances of {@link JAXBObjectToXmlConverter}.
+     *
+     * @param <T> target type when converting XML to object
+     */
+    public static class Builder<T> {
+
+        private final Class<T> classToBeBound;
+
+        private Schema schema;
+        private boolean doPrettyPrintXml;
+
+        public Builder(Class<T> classToBeBound) {
+            this.classToBeBound = classToBeBound;
+        }
+
+        /**
+         * The {@link Schema} is used for XML validation.
+         * <p>
+         * If the schema is null (default: null), no validation will
+         * be performed.
+         *
+         * @param schema the {@link Schema} used for XML validation
+         * @return the current Builder
+         */
+        public Builder schema(Schema schema) {
+            this.schema = schema;
+            return this;
+        }
+
+        /**
+         * Configure, if the resulting XML should be pretty printed
+         * (default: false).
+         *
+         * @param doPrettyPrintXml if <code>true</code>, the resuling
+         *                         XML will be pretty printed
+         * @return the current Builder
+         */
+        public Builder prettyPrint(boolean doPrettyPrintXml) {
+            this.doPrettyPrintXml = doPrettyPrintXml;
+            return this;
+        }
+
+        /**
+         * Build an instance of {@link JAXBObjectToXmlConverter} with
+         * the current configuration.
+         *
+         * @return instance of {@link JAXBObjectToXmlConverter}
+         * @throws JAXBException if there went something wrong during
+         *                       the creation of the {@link JAXBObjectToXmlConverter} instance
+         */
+        public JAXBObjectToXmlConverter<T> build() throws JAXBException {
+            JAXBContext jaxbContext = JAXBContext.newInstance(classToBeBound);
+            JAXBObjectToXmlConverter<T> converter = new JAXBObjectToXmlConverter<>();
+            converter.marshaller = jaxbContext.createMarshaller();
+            converter.marshaller.setSchema(this.schema);
+            converter.marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, this.doPrettyPrintXml);
+
+            return converter;
+        }
+    }
+}

--- a/alpinebits-xml/impl/src/main/java/it/bz/idm/alpinebits/xml/JAXBXmlToObjectConverter.java
+++ b/alpinebits-xml/impl/src/main/java/it/bz/idm/alpinebits/xml/JAXBXmlToObjectConverter.java
@@ -1,0 +1,83 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.validation.Schema;
+import java.io.InputStream;
+
+/**
+ * This class provides methods to convert XML to Java objects.
+ *
+ * @param <T> converted object type
+ */
+public final class JAXBXmlToObjectConverter<T> implements XmlToObjectConverter {
+
+    private Unmarshaller unmarshaller;
+
+    private JAXBXmlToObjectConverter() {
+        // Empty
+    }
+
+    @Override
+    public T toObject(InputStream is) {
+        try {
+            return (T) this.unmarshaller.unmarshal(is);
+        } catch (JAXBException e) {
+            throw new XmlConversionException("XML-to-object conversion error", 400, e);
+        }
+    }
+
+    /**
+     * Builder to create instances of {@link JAXBObjectToXmlConverter}.
+     *
+     * @param <T> target type when converting XML to object
+     */
+    public static class Builder<T> {
+
+        private final Class<T> classToBeBound;
+
+        private Schema schema;
+
+        public Builder(Class<T> classToBeBound) {
+            this.classToBeBound = classToBeBound;
+        }
+
+        /**
+         * The {@link Schema} is used for XML validation.
+         * <p>
+         * If the schema is null (default: null), no validation will
+         * be performed.
+         *
+         * @param schema the {@link Schema} used for XML validation
+         * @return the current Builder
+         */
+        public Builder schema(Schema schema) {
+            this.schema = schema;
+            return this;
+        }
+
+        /**
+         * Build an instance of {@link JAXBObjectToXmlConverter} with
+         * the current configuration.
+         *
+         * @return instance of {@link JAXBObjectToXmlConverter}
+         * @throws JAXBException if there went something wrong during
+         *                       the creation of the {@link JAXBObjectToXmlConverter} instance
+         */
+        public JAXBXmlToObjectConverter<T> build() throws JAXBException {
+            JAXBContext jaxbContext = JAXBContext.newInstance(classToBeBound);
+            JAXBXmlToObjectConverter<T> converter = new JAXBXmlToObjectConverter<>();
+            converter.unmarshaller = jaxbContext.createUnmarshaller();
+            converter.unmarshaller.setSchema(schema);
+            return converter;
+        }
+    }
+
+}

--- a/alpinebits-xml/impl/src/main/java/it/bz/idm/alpinebits/xml/XmlValidationSchemaProvider.java
+++ b/alpinebits-xml/impl/src/main/java/it/bz/idm/alpinebits/xml/XmlValidationSchemaProvider.java
@@ -1,0 +1,130 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml;
+
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import java.net.URL;
+
+/**
+ * This class provides builder methods to create {@link Schema}
+ * instances for XML validation.
+ */
+public final class XmlValidationSchemaProvider {
+
+    private XmlValidationSchemaProvider() {
+        // Empty
+    }
+
+    /**
+     * Build and return a RNG schema for the specified AlpineBits version.
+     * <p>
+     * This method assumes, that the RNG schema file is loadable from the
+     * classpath and that the filename corresponds to the following pattern:
+     * <p>
+     * <code>alpinebits-VERSION.rng</code>
+     * <p>
+     * where <code>VERSION</code> denotes a valid AlpineBits version (e.g. 2017-10).
+     * <p>
+     * If no valid RNG file could be found a {@link InvalidSchemaException}
+     * will be thrown.
+     *
+     * @param version build RNG schema for this AlpineBits version
+     * @return a {@link Schema} that can be used for XML validation
+     * @throws InvalidSchemaException if the file could not be found
+     *                                or it wasn't a valid RNG file.
+     */
+    public static Schema buildRngSchemaForAlpineBitsVersion(String version) {
+        return XmlValidationSchemaProvider.buildRngSchema("alpinebits-" + version + ".rng");
+    }
+
+    /**
+     * Build and return a RNG schema from the file specified by <code>filename</code>.
+     * <p>
+     * This method assumes, that the RNG schema file is loadable from the
+     * classpath.
+     * <p>
+     * If no valid RNG file could be found a {@link InvalidSchemaException}
+     * will be thrown.
+     *
+     * @param filename name of the RNG file in the classpath
+     * @return a {@link Schema} that can be used for XML validation
+     * @throws InvalidSchemaException if the file could not be found
+     *                                or it wasn't a valid RNG file.
+     */
+    @SuppressWarnings("checkstyle:illegalcatch")
+    public static Schema buildRngSchema(String filename) {
+        System.setProperty(
+                SchemaFactory.class.getName() + ":" + XMLConstants.RELAXNG_NS_URI,
+                "com.thaiopensource.relaxng.jaxp.XMLSyntaxSchemaFactory"
+        );
+        try {
+            return XmlValidationSchemaProvider.buildKnownSchema(filename, XMLConstants.RELAXNG_NS_URI);
+        } catch (Exception e) {
+            throw XmlValidationSchemaProvider.buildValidationException(filename, "RNG", e);
+        }
+    }
+
+    /**
+     * Build and return a XSD schema for the specified AlpineBits version.
+     * <p>
+     * This method assumes, that the XSD schema file is loadable from the
+     * classpath and that the filename corresponds to the following pattern:
+     * <p>
+     * <code>alpinebits-VERSION.xsd</code>
+     * <p>
+     * where <code>VERSION</code> denotes a valid AlpineBits version (e.g. 2017-10).
+     * <p>
+     * If no valid XSD file could be found a {@link InvalidSchemaException}
+     * will be thrown.
+     *
+     * @param version build XSD schema for this AlpineBits version
+     * @return a {@link Schema} that can be used for XML validation
+     * @throws InvalidSchemaException if the file could not be found
+     *                                or it wasn't a valid XSD file.
+     */
+    public static Schema buildXsdSchemaForAlpineBitsVersion(String version) {
+        return XmlValidationSchemaProvider.buildXsdSchema("alpinebits-" + version + ".xsd");
+    }
+
+    /**
+     * Build and return a XSD schema from the file specified by <code>filename</code>.
+     * <p>
+     * This method assumes, that the XSD schema file is loadable from the
+     * classpath.
+     * <p>
+     * If no valid XSD file could be found a {@link InvalidSchemaException}
+     * will be thrown.
+     *
+     * @param filename name of the XSD file in the classpath
+     * @return a {@link Schema} that can be used for XML validation
+     * @throws InvalidSchemaException if the file could not be found
+     *                                or it wasn't a valid XSD file.
+     */
+    @SuppressWarnings("checkstyle:illegalcatch")
+    public static Schema buildXsdSchema(String filename) {
+        try {
+            return XmlValidationSchemaProvider.buildKnownSchema(filename, XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        } catch (Exception e) {
+            throw XmlValidationSchemaProvider.buildValidationException(filename, "XSD", e);
+        }
+    }
+
+    private static Schema buildKnownSchema(String filename, String schemaLanguage) throws SAXException {
+        URL xsdUrl = XmlValidationSchemaProvider.class.getClassLoader().getResource(filename);
+        SchemaFactory sf = SchemaFactory.newInstance(schemaLanguage);
+        return sf.newSchema(xsdUrl);
+    }
+
+    private static InvalidSchemaException buildValidationException(String filename, String validationType, Throwable e) {
+        return new InvalidSchemaException("Error while building " + validationType + " schema from file " + filename, e);
+    }
+
+}

--- a/alpinebits-xml/impl/src/main/java/it/bz/idm/alpinebits/xml/middleware/XmlRequestMappingMiddleware.java
+++ b/alpinebits-xml/impl/src/main/java/it/bz/idm/alpinebits/xml/middleware/XmlRequestMappingMiddleware.java
@@ -1,0 +1,58 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.middleware;
+
+import it.bz.idm.alpinebits.common.context.RequestContextKey;
+import it.bz.idm.alpinebits.middleware.Context;
+import it.bz.idm.alpinebits.middleware.Key;
+import it.bz.idm.alpinebits.middleware.Middleware;
+import it.bz.idm.alpinebits.middleware.MiddlewareChain;
+import it.bz.idm.alpinebits.xml.XmlToObjectConverter;
+
+import java.io.InputStream;
+
+/**
+ * This middleware uses the {@link RequestContextKey#REQUEST_CONTENT_STREAM}, taken
+ * from {@link Context}, and tries to convert the contained XML to a POJO.
+ * <p>
+ * The converter as well as the context key used as identifier for the resulting POJO
+ * inside the context, are defined by the constructor.
+ *
+ * @param <T> request data type
+ */
+public class XmlRequestMappingMiddleware<T> implements Middleware {
+
+    private final XmlToObjectConverter<T> converter;
+    private final Key<T> requestDataCtxKey;
+
+    public XmlRequestMappingMiddleware(
+            XmlToObjectConverter<T> converter,
+            Key<T> requestDataCtxKey
+    ) {
+        if (converter == null) {
+            throw new IllegalArgumentException("The XML-to-object converter must not be null");
+        }
+        if (requestDataCtxKey == null) {
+            throw new IllegalArgumentException("The request data context key must not be null");
+        }
+
+        this.converter = converter;
+        this.requestDataCtxKey = requestDataCtxKey;
+    }
+
+    @Override
+    public void handleContext(Context ctx, MiddlewareChain chain) {
+        InputStream is = ctx.getOrThrow(RequestContextKey.REQUEST_CONTENT_STREAM);
+
+        T requestData = this.converter.toObject(is);
+
+        ctx.put(this.requestDataCtxKey, requestData);
+
+        chain.next();
+    }
+
+}

--- a/alpinebits-xml/impl/src/main/java/it/bz/idm/alpinebits/xml/middleware/XmlResponseMappingMiddleware.java
+++ b/alpinebits-xml/impl/src/main/java/it/bz/idm/alpinebits/xml/middleware/XmlResponseMappingMiddleware.java
@@ -1,0 +1,58 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.middleware;
+
+import it.bz.idm.alpinebits.common.context.ResponseContextKeys;
+import it.bz.idm.alpinebits.middleware.Context;
+import it.bz.idm.alpinebits.middleware.Key;
+import it.bz.idm.alpinebits.middleware.Middleware;
+import it.bz.idm.alpinebits.middleware.MiddlewareChain;
+import it.bz.idm.alpinebits.xml.ObjectToXmlConverter;
+
+import java.io.OutputStream;
+
+/**
+ * This middleware converts the response data from the {@link Context} into
+ * XML and writes the resulting XML to the {@link OutputStream}, defined
+ * by {@link ResponseContextKeys#RESPONSE_CONTENT_STREAM} context key.
+ * <p>
+ * The converter as well as the context key used as identifier for the POJO
+ * inside the context, are defined by the constructor.
+ *
+ * @param <T> response data type
+ */
+public class XmlResponseMappingMiddleware<T> implements Middleware {
+
+    private final ObjectToXmlConverter<T> converter;
+    private final Key<T> responseDataCtxKey;
+
+    public XmlResponseMappingMiddleware(
+            ObjectToXmlConverter<T> converter,
+            Key<T> responseDataCtxKey
+    ) {
+        if (converter == null) {
+            throw new IllegalArgumentException("The object-to-XML converter must not be null");
+        }
+        if (responseDataCtxKey == null) {
+            throw new IllegalArgumentException("The response data context key must not be null");
+        }
+
+        this.converter = converter;
+        this.responseDataCtxKey = responseDataCtxKey;
+    }
+
+    @Override
+    public void handleContext(Context ctx, MiddlewareChain chain) {
+        chain.next();
+
+        T responseData = ctx.getOrThrow(this.responseDataCtxKey);
+        OutputStream os = ctx.getOrThrow(ResponseContextKeys.RESPONSE_CONTENT_STREAM);
+
+        this.converter.toXml(responseData, os);
+    }
+
+}

--- a/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/JAXBObjectToXmlConverterTest.java
+++ b/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/JAXBObjectToXmlConverterTest.java
@@ -1,0 +1,53 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml;
+
+import it.bz.idm.alpinebits.xml.entity.TestEntity;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test cases for {@link JAXBObjectToXmlConverter} class.
+ */
+public class JAXBObjectToXmlConverterTest {
+
+    @Test(expectedExceptions = XmlConversionException.class)
+    public void testToXml_Error() throws Exception {
+        TestEntity testEntity = new TestEntity();
+        testEntity.setName("John Doe");
+        testEntity.setAge(23);
+
+        OutputStream os = new OutputStream() {
+            @Override
+            public void write(int b) throws IOException {
+                throw new IOException("Throw error while writing");
+            }
+        };
+
+        ObjectToXmlConverter<TestEntity> converter = new JAXBObjectToXmlConverter.Builder(TestEntity.class).prettyPrint(true).build();
+        converter.toXml(testEntity, os);
+    }
+
+    @Test
+    public void testToXml_Ok() throws Exception {
+        TestEntity testEntity = new TestEntity();
+        testEntity.setName("John Doe");
+        testEntity.setAge(23);
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+        ObjectToXmlConverter<TestEntity> converter = new JAXBObjectToXmlConverter.Builder(TestEntity.class).prettyPrint(true).build();
+        converter.toXml(testEntity, os);
+
+        assertTrue(os.size() > 0);
+    }
+}

--- a/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/JAXBXmlToObjectConverterTest.java
+++ b/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/JAXBXmlToObjectConverterTest.java
@@ -1,0 +1,44 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml;
+
+import it.bz.idm.alpinebits.xml.entity.TestEntity;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAReadRQ;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Test cases for {@link JAXBXmlToObjectConverter} class.
+ */
+public class JAXBXmlToObjectConverterTest {
+
+    @Test(expectedExceptions = XmlConversionException.class)
+    public void testToObject_Error() throws Exception {
+        InputStream is = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                throw new IOException("Throw error while reading");
+            }
+        };
+
+        XmlToObjectConverter<TestEntity> converter = new JAXBXmlToObjectConverter.Builder(TestEntity.class).build();
+        converter.toObject(is);
+    }
+
+    @Test
+    public void testToObject_Ok() throws Exception {
+        InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples/v_2017_10/GuestRequests-OTA_ReadRQ.xml");
+        XmlToObjectConverter<OTAReadRQ> converter = new JAXBXmlToObjectConverter.Builder(OTAReadRQ.class).build();
+        OTAReadRQ otaReadRQ = converter.toObject(is);
+
+        assertNotNull(otaReadRQ);
+    }
+}

--- a/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/XmlValidationSchemaProviderTest.java
+++ b/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/XmlValidationSchemaProviderTest.java
@@ -1,0 +1,53 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml;
+
+import org.testng.annotations.Test;
+
+import javax.xml.validation.Schema;
+
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Test cases for {@link XmlValidationSchemaProvider} class.
+ */
+public class XmlValidationSchemaProviderTest {
+
+    private static final String UNKNOWN_FILENAME = "unknown-filename";
+
+    @Test(expectedExceptions = InvalidSchemaException.class)
+    public void testBuildRngSchema_FileNotFound() {
+        XmlValidationSchemaProvider.buildRngSchema(UNKNOWN_FILENAME);
+    }
+
+    @Test(expectedExceptions = InvalidSchemaException.class)
+    public void testBuildRngSchema_InvalidSchema() {
+        XmlValidationSchemaProvider.buildRngSchema("schema/alpinebits-2017-10-invalid.rng");
+    }
+
+    @Test
+    public void testBuildRngSchema_ValidSchema() {
+        Schema schema = XmlValidationSchemaProvider.buildRngSchema("alpinebits-2017-10.rng");
+        assertNotNull(schema);
+    }
+
+    @Test(expectedExceptions = InvalidSchemaException.class)
+    public void testBuildXsdSchema_FileNotFound() {
+        XmlValidationSchemaProvider.buildXsdSchema(UNKNOWN_FILENAME);
+    }
+
+    @Test(expectedExceptions = InvalidSchemaException.class)
+    public void testBuildXsdSchema_InvalidSchema() {
+        XmlValidationSchemaProvider.buildXsdSchema("schema/alpinebits-2017-10-invalid.xsd");
+    }
+
+    @Test
+    public void testBuildXsdSchema_ValidSchema() {
+        Schema schema = XmlValidationSchemaProvider.buildXsdSchema("alpinebits-2017-10.xsd");
+        assertNotNull(schema);
+    }
+}

--- a/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/entity/TestEntity.java
+++ b/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/entity/TestEntity.java
@@ -1,0 +1,43 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.entity;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * Entity used for tests.
+ */
+@XmlRootElement
+public class TestEntity {
+
+    private String name;
+    private int age;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    @Override
+    public String toString() {
+        return "TestEntity{" +
+                "name='" + name + '\'' +
+                ", age=" + age +
+                '}';
+    }
+}

--- a/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/FullXmlConversion.java
+++ b/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/FullXmlConversion.java
@@ -1,0 +1,157 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.middleware;
+
+import it.bz.idm.alpinebits.common.context.RequestContextKey;
+import it.bz.idm.alpinebits.common.context.ResponseContextKeys;
+import it.bz.idm.alpinebits.middleware.Context;
+import it.bz.idm.alpinebits.middleware.Key;
+import it.bz.idm.alpinebits.middleware.impl.SimpleContext;
+import it.bz.idm.alpinebits.xml.JAXBObjectToXmlConverter;
+import it.bz.idm.alpinebits.xml.JAXBXmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.ObjectToXmlConverter;
+import it.bz.idm.alpinebits.xml.XmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.XmlValidationSchemaProvider;
+import it.bz.idm.alpinebits.xml.middleware.utils.UnitTestDifferenceEvaluator;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAHotelAvailNotifRQ;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAHotelAvailNotifRS;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAHotelDescriptiveContentNotifRQ;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAHotelDescriptiveContentNotifRS;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAHotelDescriptiveInfoRQ;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAHotelDescriptiveInfoRS;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAHotelRatePlanNotifRQ;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAHotelRatePlanNotifRS;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAHotelRatePlanRQ;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAHotelRatePlanRS;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTANotifReportRQ;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAReadRQ;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAResRetrieveRS;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.diff.Diff;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.validation.Schema;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import static org.testng.Assert.assertFalse;
+
+/**
+ * This test does a full conversion of XML-to-object
+ * and object-to-XML, using {@link XmlRequestMappingMiddleware}
+ * and {@link XmlResponseMappingMiddleware}. Each test
+ * asserts that the original XML and the result XML
+ * are similar.
+ */
+public class FullXmlConversion {
+
+    @DataProvider(name = "xmlValid")
+    public static Object[][] badBasicAuthentication() {
+        return new Object[][]{
+                {"BaseRates-OTA_HotelRatePlanRQ.xml", OTAHotelRatePlanRQ.class},
+                {"BaseRates-OTA_HotelRatePlanRS.xml", OTAHotelRatePlanRS.class},
+                {"FreeRooms-OTA_HotelAvailNotifRQ.xml", OTAHotelAvailNotifRQ.class},
+                {"FreeRooms-OTA_HotelAvailNotifRQ-empty.xml", OTAHotelAvailNotifRQ.class},
+                {"FreeRooms-OTA_HotelAvailNotifRS-advisory.xml", OTAHotelAvailNotifRS.class},
+                {"FreeRooms-OTA_HotelAvailNotifRS-error.xml", OTAHotelAvailNotifRS.class},
+                {"FreeRooms-OTA_HotelAvailNotifRS-success.xml", OTAHotelAvailNotifRS.class},
+                {"FreeRooms-OTA_HotelAvailNotifRS-warning.xml", OTAHotelAvailNotifRS.class},
+                {"GuestRequests-OTA_ReadRQ.xml", OTAReadRQ.class},
+                {"GuestRequests-OTA_ReadRQ-ack.xml", OTANotifReportRQ.class},
+                {"GuestRequests-OTA_ResRetrieveRS-cancellation.xml", OTAResRetrieveRS.class},
+                {"GuestRequests-OTA_ResRetrieveRS-error.xml", OTAResRetrieveRS.class},
+                {"GuestRequests-OTA_ResRetrieveRS-reservation.xml", OTAResRetrieveRS.class},
+                {"GuestRequests-OTA_ResRetrieveRS-reservation-empty.xml", OTAResRetrieveRS.class},
+                {"Inventory-OTA_HotelDescriptiveContentNotifRQ.xml", OTAHotelDescriptiveContentNotifRQ.class},
+                {"Inventory-OTA_HotelDescriptiveContentNotifRQ-delete-all.xml", OTAHotelDescriptiveContentNotifRQ.class},
+                {"Inventory-OTA_HotelDescriptiveContentNotifRQ-hotelinfo.xml", OTAHotelDescriptiveContentNotifRQ.class},
+                {"Inventory-OTA_HotelDescriptiveContentNotifRS-advisory.xml", OTAHotelDescriptiveContentNotifRS.class},
+                {"Inventory-OTA_HotelDescriptiveContentNotifRS-error.xml", OTAHotelDescriptiveContentNotifRS.class},
+                {"Inventory-OTA_HotelDescriptiveContentNotifRS-success.xml", OTAHotelDescriptiveContentNotifRS.class},
+                {"Inventory-OTA_HotelDescriptiveContentNotifRS-warning.xml", OTAHotelDescriptiveContentNotifRS.class},
+                {"Inventory-OTA_HotelDescriptiveInfoRQ-basicpullRQ.xml", OTAHotelDescriptiveInfoRQ.class},
+                {"Inventory-OTA_HotelDescriptiveInfoRQ-hotelinfo.xml", OTAHotelDescriptiveInfoRQ.class},
+                {"Inventory-OTA_HotelDescriptiveInfoRS-basicpullRS.xml", OTAHotelDescriptiveInfoRS.class},
+                {"Inventory-OTA_HotelDescriptiveInfoRS-hotelinfo.xml", OTAHotelDescriptiveInfoRS.class},
+                {"RatePlans-OTA_HotelRatePlanNotifRQ.xml", OTAHotelRatePlanNotifRQ.class},
+                {"RatePlans-OTA_HotelRatePlanNotifRS-advisory.xml", OTAHotelRatePlanNotifRS.class},
+                {"RatePlans-OTA_HotelRatePlanNotifRS-error.xml", OTAHotelRatePlanNotifRS.class},
+                {"RatePlans-OTA_HotelRatePlanNotifRS-success.xml", OTAHotelRatePlanNotifRS.class},
+                {"RatePlans-OTA_HotelRatePlanNotifRS-warning.xml", OTAHotelRatePlanNotifRS.class},
+        };
+    }
+
+    @Test(dataProvider = "xmlValid")
+    public <T> void fullConversion(String xmlFile, Class<T> classToBeBound) throws Exception {
+        String filename = "examples/v_2017_10/" + xmlFile;
+        Context ctx = this.prepareCtx(filename);
+
+        Key<T> key = Key.key("data key", classToBeBound);
+        Schema schema = XmlValidationSchemaProvider.buildRngSchemaForAlpineBitsVersion("2017-10");
+
+        // XML to object
+        XmlRequestMappingMiddleware<T> xmlToObjectMiddleware = this.validatingXmlToObjectMiddleware(key, classToBeBound, schema);
+        xmlToObjectMiddleware.handleContext(ctx, () -> {
+        });
+
+        // Object to XML
+        XmlResponseMappingMiddleware<T> objectToXmlMiddleware = this.validatingObjectToXmlMiddleware(key, classToBeBound, schema);
+        objectToXmlMiddleware.handleContext(ctx, () -> {
+        });
+
+        InputStream inputXmlStream = this.getClass().getClassLoader().getResourceAsStream(filename);
+        ByteArrayOutputStream outputXmlStream = (ByteArrayOutputStream) ctx.getOrThrow(ResponseContextKeys.RESPONSE_CONTENT_STREAM);
+        String outputXml = outputXmlStream.toString("UTF-8");
+
+        Diff xmlDiff = DiffBuilder.compare(inputXmlStream).withTest(outputXml)
+                .checkForSimilar()
+                .ignoreWhitespace()
+                .ignoreComments()
+                .withDifferenceEvaluator(new UnitTestDifferenceEvaluator())
+                .build();
+
+        if (xmlDiff.hasDifferences()) {
+            //CHECKSTYLE:OFF
+            System.err.println(filename + " XML conversion difference found:");
+            //CHECKSTYLE:ON
+            xmlDiff.getDifferences().forEach(System.err::println);
+        }
+
+        assertFalse(xmlDiff.hasDifferences());
+    }
+
+    private Context prepareCtx(String xmlFile) {
+        Context ctx = new SimpleContext();
+        InputStream is = this.getClass().getClassLoader().getResourceAsStream(xmlFile);
+        ctx.put(RequestContextKey.REQUEST_CONTENT_STREAM, is);
+
+        OutputStream os = new ByteArrayOutputStream();
+        ctx.put(ResponseContextKeys.RESPONSE_CONTENT_STREAM, os);
+        return ctx;
+    }
+
+    private <T> XmlRequestMappingMiddleware<T> validatingXmlToObjectMiddleware(Key<T> key, Class<T> classToBeBound, Schema schema) throws JAXBException {
+        XmlToObjectConverter<T> converter = this.validatingXmlToObjectConverter(classToBeBound, schema);
+        return new XmlRequestMappingMiddleware<>(converter, key);
+    }
+
+    private <T> XmlToObjectConverter<T> validatingXmlToObjectConverter(Class<T> classToBeBound, Schema schema) throws JAXBException {
+        return new JAXBXmlToObjectConverter.Builder(classToBeBound).schema(schema).build();
+    }
+
+    private <T> XmlResponseMappingMiddleware<T> validatingObjectToXmlMiddleware(Key<T> key, Class<T> classToBeBound, Schema schema) throws JAXBException {
+        ObjectToXmlConverter<T> converter = this.validatingObjectToXmlConverter(classToBeBound, schema);
+        return new XmlResponseMappingMiddleware<>(converter, key);
+    }
+
+    private <T> ObjectToXmlConverter<T> validatingObjectToXmlConverter(Class<T> classToBeBound, Schema schema) throws JAXBException {
+        return new JAXBObjectToXmlConverter.Builder(classToBeBound).schema(schema).prettyPrint(true).build();
+    }
+}

--- a/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/XmlRequestMappingMiddlewareIT.java
+++ b/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/XmlRequestMappingMiddlewareIT.java
@@ -1,0 +1,184 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.middleware;
+
+import it.bz.idm.alpinebits.servlet.impl.AlpineBitsServlet;
+import it.bz.idm.alpinebits.xml.middleware.utils.NotValidatingXmlRequestMappingMiddleware;
+import it.bz.idm.alpinebits.xml.middleware.utils.RngValidatingXmlRequestMappingMiddleware;
+import it.bz.idm.alpinebits.xml.middleware.utils.XsdValidatingXmlRequestMappingMiddleware;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAReadRQ;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.InputStream;
+import java.net.URL;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * Integration tests for {@link XmlRequestMappingMiddleware}.
+ */
+public class XmlRequestMappingMiddlewareIT extends Arquillian {
+
+    @ArquillianResource
+    private URL base;
+
+    @Deployment(name = "NoValidation", testable = false)
+    @SuppressWarnings("ArquillianTooManyDeployment")
+    public static WebArchive createNotValidatingDeployment() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "test-no-validation.war")
+                .addClasses(AlpineBitsServlet.class)
+                .addClasses(NotValidatingXmlRequestMappingMiddleware.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource("web/context.xml", "context.xml")
+                .addAsWebInfResource("web/web-not-validating-xml-request-wrapping-middleware-integration-test.xml", "web.xml");
+
+        return war;
+    }
+
+    @Deployment(name = "RngValidation", testable = false)
+    @SuppressWarnings("ArquillianTooManyDeployment")
+    public static WebArchive createRngValidatingDeployment() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "test-rng-validation.war")
+                .addClasses(AlpineBitsServlet.class)
+                .addClasses(RngValidatingXmlRequestMappingMiddleware.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource("web/context.xml", "context.xml")
+                .addAsWebInfResource("web/web-rng-validating-xml-request-wrapping-middleware-integration-test.xml", "web.xml");
+
+        return war;
+    }
+
+    @Deployment(name = "XsdValidation", testable = false)
+    @SuppressWarnings("ArquillianTooManyDeployment")
+    public static WebArchive createXsdValidatingDeployment() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "test-xsd-validation.war")
+                .addClasses(AlpineBitsServlet.class)
+                .addClasses(XsdValidatingXmlRequestMappingMiddleware.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource("web/context.xml", "context.xml")
+                .addAsWebInfResource("web/web-xsd-validating-xml-request-wrapping-middleware-integration-test.xml", "web.xml");
+
+        return war;
+    }
+
+    @Test
+    @OperateOnDeployment("NoValidation")
+    @RunAsClient
+    public void testHandleContext_NoXml() {
+        given()
+                .multiPart("action", "some action")
+                .when()
+                .post(this.base + "AlpineBits")
+                .then()
+                .statusCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
+                .content(containsString("ERROR:"));
+    }
+
+    @Test
+    @OperateOnDeployment("NoValidation")
+    @RunAsClient
+    public void testHandleContext_NotXml() {
+        given()
+                .multiPart("action", "some action")
+                .multiPart("request", "this is not an XML")
+                .when()
+                .post(this.base + "AlpineBits")
+                .then()
+                .statusCode(HttpServletResponse.SC_BAD_REQUEST)
+                .content(containsString("ERROR:"));
+    }
+
+    @Test
+    @OperateOnDeployment("NoValidation")
+    @RunAsClient
+    public void testHandleContext_Ok() {
+        InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples/v_2017_10/GuestRequests-OTA_ReadRQ.xml");
+
+        given()
+                .multiPart("action", "some action")
+                .multiPart("request", "request", is)
+                .when()
+                .post(this.base + "AlpineBits")
+                .then()
+                .statusCode(HttpServletResponse.SC_OK)
+                .content(containsString(OTAReadRQ.class.toString()));
+    }
+
+    @Test
+    @OperateOnDeployment("RngValidation")
+    @RunAsClient
+    public void testHandleContext_RngValidation_InvalidXML() {
+        InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples/v_2017_10/GuestRequests-OTA_ReadRQ-invalid.xml");
+
+        given()
+                .multiPart("action", "some action")
+                .multiPart("request", "request", is)
+                .when()
+                .post(this.base + "AlpineBits")
+                .then()
+                .statusCode(HttpServletResponse.SC_BAD_REQUEST)
+                .content(containsString("ERROR:"));
+    }
+
+    @Test
+    @OperateOnDeployment("RngValidation")
+    @RunAsClient
+    public void testHandleContext_RngValidation_Ok() {
+        InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples/v_2017_10/GuestRequests-OTA_ReadRQ.xml");
+
+        given()
+                .multiPart("action", "some action")
+                .multiPart("request", "request", is)
+                .when()
+                .post(this.base + "AlpineBits")
+                .then()
+                .statusCode(HttpServletResponse.SC_OK)
+                .content(containsString(OTAReadRQ.class.toString()));
+    }
+
+    @Test
+    @OperateOnDeployment("XsdValidation")
+    @RunAsClient
+    public void testHandleContext_XsdValidation_InvalidXML() {
+        InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples/v_2017_10/GuestRequests-OTA_ReadRQ-invalid.xml");
+
+        given()
+                .multiPart("action", "some action")
+                .multiPart("request", "request", is)
+                .when()
+                .post(this.base + "AlpineBits")
+                .then()
+                .statusCode(HttpServletResponse.SC_BAD_REQUEST)
+                .content(containsString("ERROR:"));
+    }
+
+    @Test
+    @OperateOnDeployment("XsdValidation")
+    @RunAsClient
+    public void testHandleContext_XsdValidation_Ok() {
+        InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples/v_2017_10/GuestRequests-OTA_ReadRQ.xml");
+
+        given()
+                .multiPart("action", "some action")
+                .multiPart("request", "request", is)
+                .when()
+                .post(this.base + "AlpineBits")
+                .then()
+                .statusCode(HttpServletResponse.SC_OK)
+                .content(containsString(OTAReadRQ.class.toString()));
+    }
+}

--- a/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/XmlRequestMappingMiddlewareTest.java
+++ b/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/XmlRequestMappingMiddlewareTest.java
@@ -1,0 +1,145 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.middleware;
+
+import it.bz.idm.alpinebits.common.context.RequestContextKey;
+import it.bz.idm.alpinebits.middleware.Context;
+import it.bz.idm.alpinebits.middleware.Key;
+import it.bz.idm.alpinebits.middleware.Middleware;
+import it.bz.idm.alpinebits.middleware.RequiredContextKeyMissingException;
+import it.bz.idm.alpinebits.middleware.impl.SimpleContext;
+import it.bz.idm.alpinebits.xml.JAXBXmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.XmlConversionException;
+import it.bz.idm.alpinebits.xml.XmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.XmlValidationSchemaProvider;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAReadRQ;
+import org.testng.annotations.Test;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.validation.Schema;
+import java.io.InputStream;
+
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Test cases for {@link XmlRequestMappingMiddleware} class.
+ */
+public class XmlRequestMappingMiddlewareTest {
+
+    private static final Key<OTAReadRQ> DEFAULT_CTX_KEY = Key.key("test", OTAReadRQ.class);
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConstructor_ConverterIsNull() {
+        new XmlRequestMappingMiddleware<>(null, null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConstructor_BusinessContextKeyIsNull() throws Exception {
+        XmlToObjectConverter<Object> converter = this.notValidatingConverter(Object.class);
+        new XmlRequestMappingMiddleware(converter, null);
+    }
+
+    @Test(expectedExceptions = RequiredContextKeyMissingException.class)
+    public void testHandleContext_RequestContentStreamIsNull() throws Exception {
+        Context ctx = this.getDefaultCtx();
+        ctx.remove(RequestContextKey.REQUEST_CONTENT_STREAM);
+        Middleware middleware = this.notValidatingMiddleware();
+        middleware.handleContext(ctx, null);
+    }
+
+    @Test
+    public void testHandleContext_NoValidation() throws Exception {
+        Context ctx = this.getDefaultCtx();
+
+        Middleware middleware = this.notValidatingMiddleware();
+        middleware.handleContext(ctx, () -> {
+        });
+
+        OTAReadRQ businessData = ctx.getOrThrow(DEFAULT_CTX_KEY);
+        assertNotNull(businessData);
+    }
+
+    @Test(expectedExceptions = XmlConversionException.class)
+    public void testHandleContext_RngValidationError() throws Exception {
+        Context ctx = this.getDefaultCtx();
+        InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples/v_2017_10/GuestRequests-OTA_ReadRQ-invalid.xml");
+        ctx.put(RequestContextKey.REQUEST_CONTENT_STREAM, is);
+
+        Schema schema = XmlValidationSchemaProvider.buildRngSchemaForAlpineBitsVersion("2017-10");
+        XmlRequestMappingMiddleware<OTAReadRQ> middleware = this.validatingMiddleware(schema);
+        middleware.handleContext(ctx, () -> {
+        });
+    }
+
+    @Test
+    public void testHandleContext_RngValidationOk() throws Exception {
+        Context ctx = this.getDefaultCtx();
+        InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples/v_2017_10/GuestRequests-OTA_ReadRQ.xml");
+        ctx.put(RequestContextKey.REQUEST_CONTENT_STREAM, is);
+
+        Schema schema = XmlValidationSchemaProvider.buildRngSchemaForAlpineBitsVersion("2017-10");
+        XmlRequestMappingMiddleware<OTAReadRQ> middleware = this.validatingMiddleware(schema);
+        middleware.handleContext(ctx, () -> {
+        });
+
+        OTAReadRQ businessData = ctx.getOrThrow(DEFAULT_CTX_KEY);
+        assertNotNull(businessData);
+    }
+
+    @Test(expectedExceptions = XmlConversionException.class)
+    public void testHandleContext_XsdValidationError() throws Exception {
+        Context ctx = this.getDefaultCtx();
+        InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples/v_2017_10/GuestRequests-OTA_ReadRQ-invalid.xml");
+        ctx.put(RequestContextKey.REQUEST_CONTENT_STREAM, is);
+
+        Schema schema = XmlValidationSchemaProvider.buildXsdSchemaForAlpineBitsVersion("2017-10");
+        XmlRequestMappingMiddleware<OTAReadRQ> middleware = this.validatingMiddleware(schema);
+        middleware.handleContext(ctx, () -> {
+        });
+    }
+
+    @Test
+    public void testHandleContext_XsdValidationOk() throws Exception {
+        Context ctx = this.getDefaultCtx();
+        InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples/v_2017_10/GuestRequests-OTA_ReadRQ.xml");
+        ctx.put(RequestContextKey.REQUEST_CONTENT_STREAM, is);
+
+        Schema schema = XmlValidationSchemaProvider.buildXsdSchemaForAlpineBitsVersion("2017-10");
+        XmlRequestMappingMiddleware<OTAReadRQ> middleware = this.validatingMiddleware(schema);
+        middleware.handleContext(ctx, () -> {
+        });
+
+        OTAReadRQ businessData = ctx.getOrThrow(DEFAULT_CTX_KEY);
+        assertNotNull(businessData);
+    }
+
+    private Context getDefaultCtx() {
+        Context ctx = new SimpleContext();
+        InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples/v_2017_10/GuestRequests-OTA_ReadRQ.xml");
+        ctx.put(RequestContextKey.REQUEST_CONTENT_STREAM, is);
+        return ctx;
+    }
+
+    private XmlRequestMappingMiddleware<OTAReadRQ> notValidatingMiddleware() throws JAXBException {
+        XmlToObjectConverter<OTAReadRQ> converter = this.notValidatingConverter(OTAReadRQ.class);
+        return new XmlRequestMappingMiddleware<>(converter, DEFAULT_CTX_KEY);
+    }
+
+    private XmlRequestMappingMiddleware<OTAReadRQ> validatingMiddleware(Schema schema) throws JAXBException {
+        XmlToObjectConverter<OTAReadRQ> converter = this.validatingConverter(OTAReadRQ.class, schema);
+        return new XmlRequestMappingMiddleware<>(converter, DEFAULT_CTX_KEY);
+    }
+
+    private <T> XmlToObjectConverter<T> notValidatingConverter(Class<T> classToBeBound) throws JAXBException {
+        return new JAXBXmlToObjectConverter.Builder(classToBeBound).build();
+    }
+
+    private <T> XmlToObjectConverter<T> validatingConverter(Class<T> classToBeBound, Schema schema) throws JAXBException {
+        return new JAXBXmlToObjectConverter.Builder(classToBeBound).schema(schema).build();
+    }
+
+}

--- a/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/XmlResponseMappingMiddlewareIT.java
+++ b/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/XmlResponseMappingMiddlewareIT.java
@@ -1,0 +1,177 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.middleware;
+
+import it.bz.idm.alpinebits.servlet.impl.AlpineBitsServlet;
+import it.bz.idm.alpinebits.xml.middleware.utils.NotValidatingXmlResponseMappingMiddleware;
+import it.bz.idm.alpinebits.xml.middleware.utils.RngValidatingXmlResponseMappingMiddleware;
+import it.bz.idm.alpinebits.xml.middleware.utils.XsdValidatingXmlResponseMappingMiddleware;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import javax.servlet.http.HttpServletResponse;
+import java.net.URL;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * Integration tests for {@link XmlRequestMappingMiddleware}.
+ */
+public class XmlResponseMappingMiddlewareIT extends Arquillian {
+
+    @ArquillianResource
+    private URL base;
+
+    @Deployment(name = "NoValidation", testable = false)
+    @SuppressWarnings("ArquillianTooManyDeployment")
+    public static WebArchive createNotValidatingDeployment() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "test-no-validation.war")
+                .addClasses(AlpineBitsServlet.class)
+                .addClasses(NotValidatingXmlResponseMappingMiddleware.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource("web/context.xml", "context.xml")
+                .addAsWebInfResource("web/web-not-validating-xml-response-wrapping-middleware-integration-test.xml", "web.xml");
+
+        return war;
+    }
+
+    @Deployment(name = "RngValidation", testable = false)
+    @SuppressWarnings("ArquillianTooManyDeployment")
+    public static WebArchive createRngValidatingDeployment() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "test-rng-validation.war")
+                .addClasses(AlpineBitsServlet.class)
+                .addClasses(RngValidatingXmlResponseMappingMiddleware.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource("web/context.xml", "context.xml")
+                .addAsWebInfResource("web/web-rng-validating-xml-response-wrapping-middleware-integration-test.xml", "web.xml");
+
+        return war;
+    }
+
+    @Deployment(name = "RngValidationError", testable = false)
+    @SuppressWarnings("ArquillianTooManyDeployment")
+    public static WebArchive createRngValidatingErrorDeployment() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "test-rng-validation-error.war")
+                .addClasses(AlpineBitsServlet.class)
+                .addClasses(RngValidatingXmlResponseMappingMiddleware.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource("web/context.xml", "context.xml")
+                .addAsWebInfResource("web/web-rng-validating-error-xml-response-wrapping-middleware-integration-test.xml", "web.xml");
+
+        return war;
+    }
+
+    @Deployment(name = "XsdValidation", testable = false)
+    @SuppressWarnings("ArquillianTooManyDeployment")
+    public static WebArchive createXsdValidatingDeployment() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "test-xsd-validation.war")
+                .addClasses(AlpineBitsServlet.class)
+                .addClasses(XsdValidatingXmlResponseMappingMiddleware.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource("web/context.xml", "context.xml")
+                .addAsWebInfResource("web/web-xsd-validating-xml-response-wrapping-middleware-integration-test.xml", "web.xml");
+
+        return war;
+    }
+
+    @Deployment(name = "XsdValidationError", testable = false)
+    @SuppressWarnings("ArquillianTooManyDeployment")
+    public static WebArchive createXsdValidatingErrorDeployment() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "test-xsd-validation-error.war")
+                .addClasses(AlpineBitsServlet.class)
+                .addClasses(XsdValidatingXmlResponseMappingMiddleware.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource("web/context.xml", "context.xml")
+                .addAsWebInfResource("web/web-xsd-validating-error-xml-response-wrapping-middleware-integration-test.xml", "web.xml");
+
+        return war;
+    }
+
+    @Test
+    @OperateOnDeployment("NoValidation")
+    @RunAsClient
+    public void testHandleContext_Ok() {
+        given()
+                .multiPart("action", "some action")
+                .multiPart("request", "some string")
+                .when()
+                .post(this.base + "AlpineBits")
+                .then()
+                .statusCode(HttpServletResponse.SC_OK)
+                .content(
+                        containsString("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"),
+                        containsString("Success"));
+    }
+
+    @Test
+    @OperateOnDeployment("RngValidationError")
+    @RunAsClient
+    public void testHandleContext_RngValidation_InvalidXML() {
+        given()
+                .multiPart("action", "some action")
+                .multiPart("request", "some string")
+                .when()
+                .post(this.base + "AlpineBits")
+                .then()
+                .statusCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
+                .content(containsString("ERROR:"));
+    }
+
+    @Test
+    @OperateOnDeployment("RngValidation")
+    @RunAsClient
+    public void testHandleContext_RngValidation_Ok() {
+        given()
+                .multiPart("action", "some action")
+                .multiPart("request", "some string")
+                .when()
+                .post(this.base + "AlpineBits")
+                .then()
+                .statusCode(HttpServletResponse.SC_OK)
+                .content(
+                        containsString("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"),
+                        containsString("Success"));
+    }
+
+    @Test
+    @OperateOnDeployment("XsdValidationError")
+    @RunAsClient
+    public void testHandleContext_XsdValidation_InvalidXML() {
+        given()
+                .multiPart("action", "some action")
+                .multiPart("request", "some string")
+                .when()
+                .post(this.base + "AlpineBits")
+                .then()
+                .statusCode(HttpServletResponse.SC_INTERNAL_SERVER_ERROR)
+                .content(containsString("ERROR:"));
+    }
+
+    @Test
+    @OperateOnDeployment("XsdValidation")
+    @RunAsClient
+    public void testHandleContext_XsdValidation_Ok() {
+        given()
+                .multiPart("action", "some action")
+                .multiPart("request", "some string")
+                .when()
+                .post(this.base + "AlpineBits")
+                .then()
+                .statusCode(HttpServletResponse.SC_OK)
+                .content(
+                        containsString("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"),
+                        containsString("Success"));
+    }
+}

--- a/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/XmlResponseMappingMiddlewareTest.java
+++ b/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/XmlResponseMappingMiddlewareTest.java
@@ -1,0 +1,148 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.middleware;
+
+import it.bz.idm.alpinebits.common.context.ResponseContextKeys;
+import it.bz.idm.alpinebits.middleware.Context;
+import it.bz.idm.alpinebits.middleware.Key;
+import it.bz.idm.alpinebits.middleware.Middleware;
+import it.bz.idm.alpinebits.middleware.RequiredContextKeyMissingException;
+import it.bz.idm.alpinebits.middleware.impl.SimpleContext;
+import it.bz.idm.alpinebits.xml.JAXBObjectToXmlConverter;
+import it.bz.idm.alpinebits.xml.JAXBXmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.ObjectToXmlConverter;
+import it.bz.idm.alpinebits.xml.XmlConversionException;
+import it.bz.idm.alpinebits.xml.XmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.XmlValidationSchemaProvider;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAResRetrieveRS;
+import org.testng.annotations.Test;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.validation.Schema;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Test cases for {@link XmlResponseMappingMiddleware} class.
+ */
+public class XmlResponseMappingMiddlewareTest {
+
+    private static final Key<OTAResRetrieveRS> DEFAULT_CTX_KEY = Key.key("test", OTAResRetrieveRS.class);
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConstructor_ConverterIsNull() {
+        new XmlResponseMappingMiddleware(null, null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testConstructor_BusinessContextKeyIsNull() throws Exception {
+        ObjectToXmlConverter<Object> converter = this.notValidatingConverter(Object.class);
+        new XmlResponseMappingMiddleware(converter, null);
+    }
+
+    @Test(expectedExceptions = RequiredContextKeyMissingException.class)
+    public void testHandleContext_ResponseDataIsNull() throws Exception {
+        Middleware middleware = this.notValidatingMiddleware();
+        Context ctx = new SimpleContext();
+        middleware.handleContext(ctx, () -> {
+        });
+    }
+
+    @Test(expectedExceptions = RequiredContextKeyMissingException.class)
+    public void testHandleContext_ResponseContentStreamIsNull() throws Exception {
+        Middleware middleware = this.notValidatingMiddleware();
+        Context ctx = new SimpleContext();
+        ctx.put(DEFAULT_CTX_KEY, new OTAResRetrieveRS());
+        middleware.handleContext(ctx, () -> {
+        });
+    }
+
+    @Test
+    public void testHandleContext_NoValidation() throws Exception {
+        Context ctx = this.getDefaultCtx();
+
+        Middleware middleware = this.notValidatingMiddleware();
+        middleware.handleContext(ctx, () -> {
+        });
+
+        OTAResRetrieveRS businessData = ctx.getOrThrow(DEFAULT_CTX_KEY);
+        assertNotNull(businessData);
+    }
+
+    @Test(expectedExceptions = XmlConversionException.class)
+    public void testHandleContext_RngValidationError() throws Exception {
+        Context ctx = this.getDefaultCtx();
+
+        ctx.getOrThrow(DEFAULT_CTX_KEY).setVersion(null);
+        Middleware middleware = this.validatingMiddleware(XmlValidationSchemaProvider.buildRngSchemaForAlpineBitsVersion("2017-10"));
+        middleware.handleContext(ctx, () -> {
+        });
+    }
+
+    @Test
+    public void testHandleContext_RngValidationOk() throws Exception {
+        Context ctx = this.getDefaultCtx();
+
+        Middleware middleware = this.validatingMiddleware(XmlValidationSchemaProvider.buildRngSchemaForAlpineBitsVersion("2017-10"));
+        middleware.handleContext(ctx, () -> {
+        });
+    }
+
+    @Test(expectedExceptions = XmlConversionException.class)
+    public void testHandleContext_XsdValidationError() throws Exception {
+        Context ctx = this.getDefaultCtx();
+
+        ctx.getOrThrow(DEFAULT_CTX_KEY).setVersion(null);
+        Middleware middleware = this.validatingMiddleware(XmlValidationSchemaProvider.buildXsdSchemaForAlpineBitsVersion("2017-10"));
+        middleware.handleContext(ctx, () -> {
+        });
+    }
+
+    @Test
+    public void testHandleContext_XsdValidationOk() throws Exception {
+        Context ctx = this.getDefaultCtx();
+
+        Middleware middleware = this.validatingMiddleware(XmlValidationSchemaProvider.buildXsdSchemaForAlpineBitsVersion("2017-10"));
+        middleware.handleContext(ctx, () -> {
+        });
+    }
+
+    private Context getDefaultCtx() throws JAXBException {
+        Context ctx = new SimpleContext();
+        OutputStream os = new ByteArrayOutputStream();
+        ctx.put(ResponseContextKeys.RESPONSE_CONTENT_STREAM, os);
+
+        InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples/v_2017_10/GuestRequests-OTA_ResRetrieveRS-reservation.xml");
+        Schema schema = XmlValidationSchemaProvider.buildRngSchemaForAlpineBitsVersion("2017-10");
+        XmlToObjectConverter<OTAResRetrieveRS> converter = new JAXBXmlToObjectConverter.Builder(OTAResRetrieveRS.class).schema(schema).build();
+        OTAResRetrieveRS responseData = converter.toObject(is);
+        ctx.put(DEFAULT_CTX_KEY, responseData);
+        return ctx;
+    }
+
+    private XmlResponseMappingMiddleware<OTAResRetrieveRS> notValidatingMiddleware() throws JAXBException {
+        ObjectToXmlConverter<OTAResRetrieveRS> converter = this.notValidatingConverter(OTAResRetrieveRS.class);
+        return new XmlResponseMappingMiddleware<>(converter, DEFAULT_CTX_KEY);
+    }
+
+    private XmlResponseMappingMiddleware<OTAResRetrieveRS> validatingMiddleware(Schema schema) throws JAXBException {
+        ObjectToXmlConverter<OTAResRetrieveRS> converter = this.validatingConverter(OTAResRetrieveRS.class, schema);
+        return new XmlResponseMappingMiddleware<>(converter, DEFAULT_CTX_KEY);
+    }
+
+    private <T> ObjectToXmlConverter<T> notValidatingConverter(Class<T> classToBeBound) throws JAXBException {
+        return new JAXBObjectToXmlConverter.Builder(classToBeBound).build();
+    }
+
+    private <T> ObjectToXmlConverter<T> validatingConverter(Class<T> classToBeBound, Schema schema) throws JAXBException {
+        return new JAXBObjectToXmlConverter.Builder(classToBeBound).schema(schema).build();
+    }
+
+}

--- a/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/utils/NotValidatingXmlRequestMappingMiddleware.java
+++ b/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/utils/NotValidatingXmlRequestMappingMiddleware.java
@@ -1,0 +1,71 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.middleware.utils;
+
+import it.bz.idm.alpinebits.common.context.ResponseContextKeys;
+import it.bz.idm.alpinebits.common.utils.middleware.ComposingMiddlewareBuilder;
+import it.bz.idm.alpinebits.middleware.Context;
+import it.bz.idm.alpinebits.middleware.Key;
+import it.bz.idm.alpinebits.middleware.Middleware;
+import it.bz.idm.alpinebits.middleware.MiddlewareChain;
+import it.bz.idm.alpinebits.servlet.middleware.MultipartFormDataParserMiddleware;
+import it.bz.idm.alpinebits.xml.JAXBXmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.XmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.middleware.XmlRequestMappingMiddleware;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAReadRQ;
+
+import javax.xml.bind.JAXBException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+
+/**
+ * This helper class for XmlRequestMappingMiddleware configures the middleware
+ * chain needed for integration tests, where no validation is active.
+ */
+public class NotValidatingXmlRequestMappingMiddleware implements Middleware {
+
+    private static final Key<OTAReadRQ> DEFAULT_CTX_KEY = Key.key("test", OTAReadRQ.class);
+
+    private final Middleware middleware;
+
+    public NotValidatingXmlRequestMappingMiddleware() {
+        try {
+            this.middleware = ComposingMiddlewareBuilder.compose(Arrays.asList(
+                    new MultipartFormDataParserMiddleware(),
+                    this.notValidatingMiddleware()
+            ));
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void handleContext(Context ctx, MiddlewareChain chain) {
+        this.middleware.handleContext(ctx, chain);
+
+        OTAReadRQ otaReadRQ = ctx.getOrThrow(NotValidatingXmlRequestMappingMiddleware.DEFAULT_CTX_KEY);
+
+        OutputStream os = ctx.getOrThrow(ResponseContextKeys.RESPONSE_CONTENT_STREAM);
+
+        try {
+            os.write(otaReadRQ.getClass().toString().getBytes(Charset.forName("UTF-8")));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private XmlRequestMappingMiddleware<OTAReadRQ> notValidatingMiddleware() throws JAXBException {
+        XmlToObjectConverter<OTAReadRQ> converter = this.notValidatingConverter(OTAReadRQ.class);
+        return new XmlRequestMappingMiddleware<>(converter, DEFAULT_CTX_KEY);
+    }
+
+    private <T> XmlToObjectConverter<T> notValidatingConverter(Class<T> classToBeBound) throws JAXBException {
+        return new JAXBXmlToObjectConverter.Builder(classToBeBound).build();
+    }
+}

--- a/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/utils/NotValidatingXmlResponseMappingMiddleware.java
+++ b/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/utils/NotValidatingXmlResponseMappingMiddleware.java
@@ -1,0 +1,72 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.middleware.utils;
+
+import it.bz.idm.alpinebits.common.utils.middleware.ComposingMiddlewareBuilder;
+import it.bz.idm.alpinebits.middleware.Context;
+import it.bz.idm.alpinebits.middleware.Key;
+import it.bz.idm.alpinebits.middleware.Middleware;
+import it.bz.idm.alpinebits.middleware.MiddlewareChain;
+import it.bz.idm.alpinebits.servlet.middleware.MultipartFormDataParserMiddleware;
+import it.bz.idm.alpinebits.xml.JAXBObjectToXmlConverter;
+import it.bz.idm.alpinebits.xml.JAXBXmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.ObjectToXmlConverter;
+import it.bz.idm.alpinebits.xml.XmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.XmlValidationSchemaProvider;
+import it.bz.idm.alpinebits.xml.middleware.XmlResponseMappingMiddleware;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAResRetrieveRS;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.validation.Schema;
+import java.io.InputStream;
+import java.util.Arrays;
+
+/**
+ * This helper class for XmlRequestMappingMiddleware configures the middleware
+ * chain needed for integration tests, where no validation is active.
+ */
+public class NotValidatingXmlResponseMappingMiddleware implements Middleware {
+
+    private static final Key<OTAResRetrieveRS> DEFAULT_CTX_KEY = Key.key("test", OTAResRetrieveRS.class);
+
+    private final Middleware middleware;
+
+    public NotValidatingXmlResponseMappingMiddleware() {
+        try {
+            this.middleware = ComposingMiddlewareBuilder.compose(Arrays.asList(
+                    new MultipartFormDataParserMiddleware(),
+                    this.notValidatingMiddleware()
+            ));
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void handleContext(Context ctx, MiddlewareChain chain) {
+        try {
+            InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples/v_2017_10/GuestRequests-OTA_ResRetrieveRS-reservation.xml");
+            Schema schema = XmlValidationSchemaProvider.buildRngSchemaForAlpineBitsVersion("2017-10");
+            XmlToObjectConverter<OTAResRetrieveRS> converter = new JAXBXmlToObjectConverter.Builder(OTAResRetrieveRS.class).schema(schema).build();
+            OTAResRetrieveRS responseData = converter.toObject(is);
+            ctx.put(DEFAULT_CTX_KEY, responseData);
+
+            this.middleware.handleContext(ctx, chain);
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private XmlResponseMappingMiddleware<OTAResRetrieveRS> notValidatingMiddleware() throws JAXBException {
+        ObjectToXmlConverter<OTAResRetrieveRS> converter = this.notValidatingConverter(OTAResRetrieveRS.class);
+        return new XmlResponseMappingMiddleware<>(converter, DEFAULT_CTX_KEY);
+    }
+
+    private <T> ObjectToXmlConverter<T> notValidatingConverter(Class<T> classToBeBound) throws JAXBException {
+        return new JAXBObjectToXmlConverter.Builder(classToBeBound).prettyPrint(true).build();
+    }
+}

--- a/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/utils/RngValidatingErrorXmlResponseMappingMiddleware.java
+++ b/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/utils/RngValidatingErrorXmlResponseMappingMiddleware.java
@@ -1,0 +1,73 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.middleware.utils;
+
+import it.bz.idm.alpinebits.common.utils.middleware.ComposingMiddlewareBuilder;
+import it.bz.idm.alpinebits.middleware.Context;
+import it.bz.idm.alpinebits.middleware.Key;
+import it.bz.idm.alpinebits.middleware.Middleware;
+import it.bz.idm.alpinebits.middleware.MiddlewareChain;
+import it.bz.idm.alpinebits.servlet.middleware.MultipartFormDataParserMiddleware;
+import it.bz.idm.alpinebits.xml.JAXBObjectToXmlConverter;
+import it.bz.idm.alpinebits.xml.JAXBXmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.ObjectToXmlConverter;
+import it.bz.idm.alpinebits.xml.XmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.XmlValidationSchemaProvider;
+import it.bz.idm.alpinebits.xml.middleware.XmlResponseMappingMiddleware;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAResRetrieveRS;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.validation.Schema;
+import java.io.InputStream;
+import java.util.Arrays;
+
+/**
+ * This helper class for XmlRequestMappingMiddleware configures the middleware
+ * chain needed for integration tests, where the RNG validation is active.
+ */
+public class RngValidatingErrorXmlResponseMappingMiddleware implements Middleware {
+
+    private static final Key<OTAResRetrieveRS> DEFAULT_CTX_KEY = Key.key("test", OTAResRetrieveRS.class);
+
+    private final Middleware middleware;
+
+    public RngValidatingErrorXmlResponseMappingMiddleware() {
+        try {
+            this.middleware = ComposingMiddlewareBuilder.compose(Arrays.asList(
+                    new MultipartFormDataParserMiddleware(),
+                    this.validatingMiddleware()
+            ));
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void handleContext(Context ctx, MiddlewareChain chain) {
+        try {
+            InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples/v_2017_10/GuestRequests-OTA_ResRetrieveRS-reservation-invalid.xml");
+            Schema schema = XmlValidationSchemaProvider.buildRngSchemaForAlpineBitsVersion("2017-10");
+            XmlToObjectConverter<OTAResRetrieveRS> converter = new JAXBXmlToObjectConverter.Builder(OTAResRetrieveRS.class).schema(schema).build();
+            OTAResRetrieveRS responseData = converter.toObject(is);
+            ctx.put(DEFAULT_CTX_KEY, responseData);
+
+            this.middleware.handleContext(ctx, chain);
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private XmlResponseMappingMiddleware<OTAResRetrieveRS> validatingMiddleware() throws JAXBException {
+        Schema schema = XmlValidationSchemaProvider.buildRngSchemaForAlpineBitsVersion("2017-10");
+        ObjectToXmlConverter<OTAResRetrieveRS> converter = this.validatingConverter(OTAResRetrieveRS.class, schema);
+        return new XmlResponseMappingMiddleware<>(converter, DEFAULT_CTX_KEY);
+    }
+
+    private <T> ObjectToXmlConverter<T> validatingConverter(Class<T> classToBeBound, Schema schema) throws JAXBException {
+        return new JAXBObjectToXmlConverter.Builder(classToBeBound).prettyPrint(true).schema(schema).build();
+    }
+}

--- a/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/utils/RngValidatingXmlRequestMappingMiddleware.java
+++ b/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/utils/RngValidatingXmlRequestMappingMiddleware.java
@@ -1,0 +1,74 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.middleware.utils;
+
+import it.bz.idm.alpinebits.common.context.ResponseContextKeys;
+import it.bz.idm.alpinebits.common.utils.middleware.ComposingMiddlewareBuilder;
+import it.bz.idm.alpinebits.middleware.Context;
+import it.bz.idm.alpinebits.middleware.Key;
+import it.bz.idm.alpinebits.middleware.Middleware;
+import it.bz.idm.alpinebits.middleware.MiddlewareChain;
+import it.bz.idm.alpinebits.servlet.middleware.MultipartFormDataParserMiddleware;
+import it.bz.idm.alpinebits.xml.JAXBXmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.XmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.XmlValidationSchemaProvider;
+import it.bz.idm.alpinebits.xml.middleware.XmlRequestMappingMiddleware;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAReadRQ;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.validation.Schema;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+
+/**
+ * This helper class for XmlRequestMappingMiddleware configures the middleware
+ * chain needed for integration tests, where the RNG validation is active.
+ */
+public class RngValidatingXmlRequestMappingMiddleware implements Middleware {
+
+    private static final Key<OTAReadRQ> DEFAULT_CTX_KEY = Key.key("test", OTAReadRQ.class);
+
+    private final Middleware middleware;
+
+    public RngValidatingXmlRequestMappingMiddleware() {
+        try {
+            this.middleware = ComposingMiddlewareBuilder.compose(Arrays.asList(
+                    new MultipartFormDataParserMiddleware(),
+                    this.validatingMiddleware()
+            ));
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void handleContext(Context ctx, MiddlewareChain chain) {
+        this.middleware.handleContext(ctx, chain);
+
+        OTAReadRQ otaReadRQ = ctx.getOrThrow(RngValidatingXmlRequestMappingMiddleware.DEFAULT_CTX_KEY);
+
+        OutputStream os = ctx.getOrThrow(ResponseContextKeys.RESPONSE_CONTENT_STREAM);
+
+        try {
+            os.write(otaReadRQ.getClass().toString().getBytes(Charset.forName("UTF-8")));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private XmlRequestMappingMiddleware<OTAReadRQ> validatingMiddleware() throws JAXBException {
+        Schema schema = XmlValidationSchemaProvider.buildRngSchemaForAlpineBitsVersion("2017-10");
+        XmlToObjectConverter<OTAReadRQ> converter = this.validatingConverter(OTAReadRQ.class, schema);
+        return new XmlRequestMappingMiddleware<>(converter, DEFAULT_CTX_KEY);
+    }
+
+    private <T> XmlToObjectConverter<T> validatingConverter(Class<T> classToBeBound, Schema schema) throws JAXBException {
+        return new JAXBXmlToObjectConverter.Builder(classToBeBound).schema(schema).build();
+    }
+}

--- a/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/utils/RngValidatingXmlResponseMappingMiddleware.java
+++ b/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/utils/RngValidatingXmlResponseMappingMiddleware.java
@@ -1,0 +1,73 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.middleware.utils;
+
+import it.bz.idm.alpinebits.common.utils.middleware.ComposingMiddlewareBuilder;
+import it.bz.idm.alpinebits.middleware.Context;
+import it.bz.idm.alpinebits.middleware.Key;
+import it.bz.idm.alpinebits.middleware.Middleware;
+import it.bz.idm.alpinebits.middleware.MiddlewareChain;
+import it.bz.idm.alpinebits.servlet.middleware.MultipartFormDataParserMiddleware;
+import it.bz.idm.alpinebits.xml.JAXBObjectToXmlConverter;
+import it.bz.idm.alpinebits.xml.JAXBXmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.ObjectToXmlConverter;
+import it.bz.idm.alpinebits.xml.XmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.XmlValidationSchemaProvider;
+import it.bz.idm.alpinebits.xml.middleware.XmlResponseMappingMiddleware;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAResRetrieveRS;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.validation.Schema;
+import java.io.InputStream;
+import java.util.Arrays;
+
+/**
+ * This helper class for XmlRequestMappingMiddleware configures the middleware
+ * chain needed for integration tests, where the RNG validation is active.
+ */
+public class RngValidatingXmlResponseMappingMiddleware implements Middleware {
+
+    private static final Key<OTAResRetrieveRS> DEFAULT_CTX_KEY = Key.key("test", OTAResRetrieveRS.class);
+
+    private final Middleware middleware;
+
+    public RngValidatingXmlResponseMappingMiddleware() {
+        try {
+            this.middleware = ComposingMiddlewareBuilder.compose(Arrays.asList(
+                    new MultipartFormDataParserMiddleware(),
+                    this.validatingMiddleware()
+            ));
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void handleContext(Context ctx, MiddlewareChain chain) {
+        try {
+            InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples/v_2017_10/GuestRequests-OTA_ResRetrieveRS-reservation.xml");
+            Schema schema = XmlValidationSchemaProvider.buildRngSchemaForAlpineBitsVersion("2017-10");
+            XmlToObjectConverter<OTAResRetrieveRS> converter = new JAXBXmlToObjectConverter.Builder(OTAResRetrieveRS.class).schema(schema).build();
+            OTAResRetrieveRS responseData = converter.toObject(is);
+            ctx.put(DEFAULT_CTX_KEY, responseData);
+
+            this.middleware.handleContext(ctx, chain);
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private XmlResponseMappingMiddleware<OTAResRetrieveRS> validatingMiddleware() throws JAXBException {
+        Schema schema = XmlValidationSchemaProvider.buildRngSchemaForAlpineBitsVersion("2017-10");
+        ObjectToXmlConverter<OTAResRetrieveRS> converter = this.validatingConverter(OTAResRetrieveRS.class, schema);
+        return new XmlResponseMappingMiddleware<>(converter, DEFAULT_CTX_KEY);
+    }
+
+    private <T> ObjectToXmlConverter<T> validatingConverter(Class<T> classToBeBound, Schema schema) throws JAXBException {
+        return new JAXBObjectToXmlConverter.Builder(classToBeBound).prettyPrint(true).schema(schema).build();
+    }
+}

--- a/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/utils/UnitTestDifferenceEvaluator.java
+++ b/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/utils/UnitTestDifferenceEvaluator.java
@@ -1,0 +1,67 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.middleware.utils;
+
+import org.w3c.dom.Node;
+import org.xmlunit.diff.Comparison;
+import org.xmlunit.diff.ComparisonResult;
+import org.xmlunit.diff.DifferenceEvaluator;
+import org.xmlunit.diff.DifferenceEvaluators;
+
+/**
+ * This is a custom {@link DifferenceEvaluator} for XMLUnit
+ * to evaluate the difference between two XML.
+ * <p>
+ * The reason for this custom implementation to exist is,
+ * that XMLUnit reports an error for boolean values, if
+ * they differ in their spelling. For example,
+ * "0" and "false" are reported as differences, although
+ * they represent the same value (both spellings are
+ * correct according to the XML standard). The same goes
+ * for "1" and "true".
+ * <p>
+ * Note, that this evaluator is used for unit tests only.
+ *
+ * @see <a href="https://github.com/xmlunit/xmlunit">XMLUnit on GitHub</a>
+ */
+public class UnitTestDifferenceEvaluator implements DifferenceEvaluator {
+
+    @Override
+    public ComparisonResult evaluate(Comparison comparison, ComparisonResult outcome) {
+        // If there is no difference, return early
+        if (outcome == ComparisonResult.EQUAL) {
+            return outcome;
+        }
+
+        // Try to evaluate differences using the default DifferenceEvaluator
+        // and return ComparisonResult.SIMILAR if the default
+        // DifferenceEvaluator says so
+        ComparisonResult defaulEvalutorOutcome = DifferenceEvaluators.Default.evaluate(comparison, outcome);
+        if (defaulEvalutorOutcome == ComparisonResult.SIMILAR) {
+            return ComparisonResult.SIMILAR;
+        }
+
+        final Node controlNode = comparison.getControlDetails().getTarget();
+        final Node testNode = comparison.getTestDetails().getTarget();
+
+        // Check if nodes are boolean and match, although
+        // have a different representation (e.g "0" and "false")
+        if (nodesAreBooleanAndMatch(controlNode, testNode)) {
+            return ComparisonResult.SIMILAR;
+        }
+
+        return outcome;
+    }
+
+    private boolean nodesAreBooleanAndMatch(Node controlNode, Node testNode) {
+        return "false".equals(controlNode.getNodeValue()) && "0".equals(testNode.getNodeValue())
+                || "true".equals(controlNode.getNodeValue()) && "1".equals(testNode.getNodeValue())
+                || "0".equals(controlNode.getNodeValue()) && "false".equals(testNode.getNodeValue())
+                || "1".equals(controlNode.getNodeValue()) && "true".equals(testNode.getNodeValue());
+    }
+
+}

--- a/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/utils/XsdValidatingErrorXmlResponseMappingMiddleware.java
+++ b/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/utils/XsdValidatingErrorXmlResponseMappingMiddleware.java
@@ -1,0 +1,73 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.middleware.utils;
+
+import it.bz.idm.alpinebits.common.utils.middleware.ComposingMiddlewareBuilder;
+import it.bz.idm.alpinebits.middleware.Context;
+import it.bz.idm.alpinebits.middleware.Key;
+import it.bz.idm.alpinebits.middleware.Middleware;
+import it.bz.idm.alpinebits.middleware.MiddlewareChain;
+import it.bz.idm.alpinebits.servlet.middleware.MultipartFormDataParserMiddleware;
+import it.bz.idm.alpinebits.xml.JAXBObjectToXmlConverter;
+import it.bz.idm.alpinebits.xml.JAXBXmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.ObjectToXmlConverter;
+import it.bz.idm.alpinebits.xml.XmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.XmlValidationSchemaProvider;
+import it.bz.idm.alpinebits.xml.middleware.XmlResponseMappingMiddleware;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAResRetrieveRS;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.validation.Schema;
+import java.io.InputStream;
+import java.util.Arrays;
+
+/**
+ * This helper class for XmlRequestMappingMiddleware configures the middleware
+ * chain needed for integration tests, where the XSD validation is active.
+ */
+public class XsdValidatingErrorXmlResponseMappingMiddleware implements Middleware {
+
+    private static final Key<OTAResRetrieveRS> DEFAULT_CTX_KEY = Key.key("test", OTAResRetrieveRS.class);
+
+    private final Middleware middleware;
+
+    public XsdValidatingErrorXmlResponseMappingMiddleware() {
+        try {
+            this.middleware = ComposingMiddlewareBuilder.compose(Arrays.asList(
+                    new MultipartFormDataParserMiddleware(),
+                    this.validatingMiddleware()
+            ));
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void handleContext(Context ctx, MiddlewareChain chain) {
+        try {
+            InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples/v_2017_10/GuestRequests-OTA_ResRetrieveRS-reservation-invalid.xml");
+            Schema schema = XmlValidationSchemaProvider.buildRngSchemaForAlpineBitsVersion("2017-10");
+            XmlToObjectConverter<OTAResRetrieveRS> converter = new JAXBXmlToObjectConverter.Builder(OTAResRetrieveRS.class).schema(schema).build();
+            OTAResRetrieveRS responseData = converter.toObject(is);
+            ctx.put(DEFAULT_CTX_KEY, responseData);
+
+            this.middleware.handleContext(ctx, chain);
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private XmlResponseMappingMiddleware<OTAResRetrieveRS> validatingMiddleware() throws JAXBException {
+        Schema schema = XmlValidationSchemaProvider.buildRngSchemaForAlpineBitsVersion("2017-10");
+        ObjectToXmlConverter<OTAResRetrieveRS> converter = this.validatingConverter(OTAResRetrieveRS.class, schema);
+        return new XmlResponseMappingMiddleware<>(converter, DEFAULT_CTX_KEY);
+    }
+
+    private <T> ObjectToXmlConverter<T> validatingConverter(Class<T> classToBeBound, Schema schema) throws JAXBException {
+        return new JAXBObjectToXmlConverter.Builder(classToBeBound).prettyPrint(true).schema(schema).build();
+    }
+}

--- a/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/utils/XsdValidatingXmlRequestMappingMiddleware.java
+++ b/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/utils/XsdValidatingXmlRequestMappingMiddleware.java
@@ -1,0 +1,74 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.middleware.utils;
+
+import it.bz.idm.alpinebits.common.context.ResponseContextKeys;
+import it.bz.idm.alpinebits.common.utils.middleware.ComposingMiddlewareBuilder;
+import it.bz.idm.alpinebits.middleware.Context;
+import it.bz.idm.alpinebits.middleware.Key;
+import it.bz.idm.alpinebits.middleware.Middleware;
+import it.bz.idm.alpinebits.middleware.MiddlewareChain;
+import it.bz.idm.alpinebits.servlet.middleware.MultipartFormDataParserMiddleware;
+import it.bz.idm.alpinebits.xml.JAXBXmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.XmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.XmlValidationSchemaProvider;
+import it.bz.idm.alpinebits.xml.middleware.XmlRequestMappingMiddleware;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAReadRQ;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.validation.Schema;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+
+/**
+ * This helper class for XmlRequestMappingMiddleware configures the middleware
+ * chain needed for integration tests, where the XSD validation is active.
+ */
+public class XsdValidatingXmlRequestMappingMiddleware implements Middleware {
+
+    private static final Key<OTAReadRQ> DEFAULT_CTX_KEY = Key.key("test", OTAReadRQ.class);
+
+    private final Middleware middleware;
+
+    public XsdValidatingXmlRequestMappingMiddleware() {
+        try {
+            this.middleware = ComposingMiddlewareBuilder.compose(Arrays.asList(
+                    new MultipartFormDataParserMiddleware(),
+                    this.validatingMiddleware()
+            ));
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void handleContext(Context ctx, MiddlewareChain chain) {
+        this.middleware.handleContext(ctx, chain);
+
+        OTAReadRQ otaReadRQ = ctx.getOrThrow(XsdValidatingXmlRequestMappingMiddleware.DEFAULT_CTX_KEY);
+
+        OutputStream os = ctx.getOrThrow(ResponseContextKeys.RESPONSE_CONTENT_STREAM);
+
+        try {
+            os.write(otaReadRQ.getClass().toString().getBytes(Charset.forName("UTF-8")));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private XmlRequestMappingMiddleware<OTAReadRQ> validatingMiddleware() throws JAXBException {
+        Schema schema = XmlValidationSchemaProvider.buildXsdSchemaForAlpineBitsVersion("2017-10");
+        XmlToObjectConverter<OTAReadRQ> converter = this.validatingConverter(OTAReadRQ.class, schema);
+        return new XmlRequestMappingMiddleware<>(converter, DEFAULT_CTX_KEY);
+    }
+
+    private <T> XmlToObjectConverter<T> validatingConverter(Class<T> classToBeBound, Schema schema) throws JAXBException {
+        return new JAXBXmlToObjectConverter.Builder(classToBeBound).schema(schema).build();
+    }
+}

--- a/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/utils/XsdValidatingXmlResponseMappingMiddleware.java
+++ b/alpinebits-xml/impl/src/test/java/it/bz/idm/alpinebits/xml/middleware/utils/XsdValidatingXmlResponseMappingMiddleware.java
@@ -1,0 +1,73 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package it.bz.idm.alpinebits.xml.middleware.utils;
+
+import it.bz.idm.alpinebits.common.utils.middleware.ComposingMiddlewareBuilder;
+import it.bz.idm.alpinebits.middleware.Context;
+import it.bz.idm.alpinebits.middleware.Key;
+import it.bz.idm.alpinebits.middleware.Middleware;
+import it.bz.idm.alpinebits.middleware.MiddlewareChain;
+import it.bz.idm.alpinebits.servlet.middleware.MultipartFormDataParserMiddleware;
+import it.bz.idm.alpinebits.xml.JAXBObjectToXmlConverter;
+import it.bz.idm.alpinebits.xml.JAXBXmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.ObjectToXmlConverter;
+import it.bz.idm.alpinebits.xml.XmlToObjectConverter;
+import it.bz.idm.alpinebits.xml.XmlValidationSchemaProvider;
+import it.bz.idm.alpinebits.xml.middleware.XmlResponseMappingMiddleware;
+import it.bz.idm.alpinebits.xml.schema.v_2017_10.OTAResRetrieveRS;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.validation.Schema;
+import java.io.InputStream;
+import java.util.Arrays;
+
+/**
+ * This helper class for XmlRequestMappingMiddleware configures the middleware
+ * chain needed for integration tests, where the XSD validation is active.
+ */
+public class XsdValidatingXmlResponseMappingMiddleware implements Middleware {
+
+    private static final Key<OTAResRetrieveRS> DEFAULT_CTX_KEY = Key.key("test", OTAResRetrieveRS.class);
+
+    private final Middleware middleware;
+
+    public XsdValidatingXmlResponseMappingMiddleware() {
+        try {
+            this.middleware = ComposingMiddlewareBuilder.compose(Arrays.asList(
+                    new MultipartFormDataParserMiddleware(),
+                    this.validatingMiddleware()
+            ));
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void handleContext(Context ctx, MiddlewareChain chain) {
+        try {
+            InputStream is = this.getClass().getClassLoader().getResourceAsStream("examples/v_2017_10/GuestRequests-OTA_ResRetrieveRS-reservation.xml");
+            Schema schema = XmlValidationSchemaProvider.buildRngSchemaForAlpineBitsVersion("2017-10");
+            XmlToObjectConverter<OTAResRetrieveRS> converter = new JAXBXmlToObjectConverter.Builder(OTAResRetrieveRS.class).schema(schema).build();
+            OTAResRetrieveRS responseData = converter.toObject(is);
+            ctx.put(DEFAULT_CTX_KEY, responseData);
+
+            this.middleware.handleContext(ctx, chain);
+        } catch (JAXBException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private XmlResponseMappingMiddleware<OTAResRetrieveRS> validatingMiddleware() throws JAXBException {
+        Schema schema = XmlValidationSchemaProvider.buildRngSchemaForAlpineBitsVersion("2017-10");
+        ObjectToXmlConverter<OTAResRetrieveRS> converter = this.validatingConverter(OTAResRetrieveRS.class, schema);
+        return new XmlResponseMappingMiddleware<>(converter, DEFAULT_CTX_KEY);
+    }
+
+    private <T> ObjectToXmlConverter<T> validatingConverter(Class<T> classToBeBound, Schema schema) throws JAXBException {
+        return new JAXBObjectToXmlConverter.Builder(classToBeBound).prettyPrint(true).schema(schema).build();
+    }
+}

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/BaseRates-OTA_HotelRatePlanRQ.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/BaseRates-OTA_HotelRatePlanRQ.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2017-10
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2017-10 1.0
+-->
+
+<OTA_HotelRatePlanRQ xmlns="http://www.opentravel.org/OTA/2003/05"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelRatePlanRQ.xsd"
+                     Version="3.000">
+  <RatePlans>
+    <RatePlan>
+
+      <!-- If the DateRange element exists, all matching data will be returned.
+
+           If DateRange is omitted only data that was not sent already, i.e. a delta, is returned.
+           Note that it is also possible to set Start only or End only. -->
+
+      <DateRange Start="2016-12-25" End="2017-01-03" />
+
+      <!-- If RatePlanCandidate elements exist, only the matching rate plans must be returned:
+           RatePlanCode is used for single rate plans, RatePlanID is used for all rate plans with the
+           same Master code (if supported). If RatePlanCandidates is omitted, all rate plans have to
+           be returned. -->
+
+      <RatePlanCandidates>
+        <RatePlanCandidate RatePlanCode="DailyRate-HB" RatePlanID="DailyRate"/>
+        <RatePlanCandidate RatePlanCode="SPECIAL"/>
+      </RatePlanCandidates>
+
+      <!-- Specify either HotelCode or HotelName or both -->
+
+      <HotelRef HotelCode="123" HotelName="Frangart Inn" />
+
+    </RatePlan>
+  </RatePlans>
+</OTA_HotelRatePlanRQ>
+

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/BaseRates-OTA_HotelRatePlanRS.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/BaseRates-OTA_HotelRatePlanRS.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2017-10
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2017-10 1.0
+-->
+
+<OTA_HotelRatePlanRS xmlns="http://www.opentravel.org/OTA/2003/05"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelRatePlanRS.xsd"
+                     Version="3.000">
+
+    <Success/> 
+
+    <RatePlans HotelCode="123" HotelName="Frangart Inn">
+        <RatePlan RatePlanCode="Base" CurrencyCode="EUR">
+            <Rates>
+                <Rate RateTimeUnit="Day" UnitMultiplier="1">
+                    <BaseByGuestAmts>
+                        <BaseByGuestAmt Type="7"/>
+                    </BaseByGuestAmts>
+                    <MealsIncluded MealPlanIndicator="true" MealPlanCodes="12"/>
+                </Rate>
+                <Rate Start="2016-12-29" End="2016-12-31" InvTypeCode="EZ">
+                    <BaseByGuestAmts>
+                        <BaseByGuestAmt NumberOfGuests="1"
+                                        AmountAfterTax="130.00"/>
+                    </BaseByGuestAmts>
+                </Rate>
+                <Rate Start="2016-12-29" End="2016-12-31" InvTypeCode="DZ">
+                    <BaseByGuestAmts>
+                        <BaseByGuestAmt NumberOfGuests="2"
+                                        AmountAfterTax="180.00"/>
+                    </BaseByGuestAmts>
+                </Rate>
+            </Rates>
+            <Description Name="title">
+                <Text TextFormat="PlainText" Language="en">Lorem ipsum.</Text>
+                <Text TextFormat="PlainText" Language="it">Lorem ipsum.</Text>
+                <!-- more languages ... -->
+            </Description>
+        </RatePlan>
+    </RatePlans>
+
+</OTA_HotelRatePlanRS> 

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/FreeRooms-OTA_HotelAvailNotifRQ-empty.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/FreeRooms-OTA_HotelAvailNotifRQ-empty.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2014-04
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2014-04 1.0
+-->
+
+<OTA_HotelAvailNotifRQ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xmlns="http://www.opentravel.org/OTA/2003/05" 
+                       Version="3.000" 
+                       xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelAvailNotifRQ.xsd">
+  <UniqueID Type="16" ID="1" Instance="CompleteSet"/>
+  <AvailStatusMessages HotelCode="...">
+    <AvailStatusMessage/>
+  </AvailStatusMessages>
+</OTA_HotelAvailNotifRQ>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/FreeRooms-OTA_HotelAvailNotifRQ.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/FreeRooms-OTA_HotelAvailNotifRQ.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2017-10
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2017-10 1.0
+-->
+
+<OTA_HotelAvailNotifRQ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+                       xmlns="http://www.opentravel.org/OTA/2003/05"
+                       xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelAvailNotifRQ.xsd"
+                       Version="1.002">
+
+    <UniqueID Type="16" ID="1" Instance="CompleteSet"/>
+
+    <AvailStatusMessages HotelCode="123" HotelName="Frangart Inn">
+
+        <AvailStatusMessage BookingLimit="1" BookingLimitMessageType="SetLimit" BookingThreshold="0">
+            <StatusApplicationControl Start="2010-08-01" End="2010-08-10" InvTypeCode="double" InvCode="101S" />
+        </AvailStatusMessage>
+
+        <AvailStatusMessage BookingLimit="1" BookingLimitMessageType="SetLimit" BookingThreshold="0">
+            <StatusApplicationControl Start="2010-08-21" End="2010-08-30" InvTypeCode="double" InvCode="101S" />
+        </AvailStatusMessage>
+
+    </AvailStatusMessages>
+
+</OTA_HotelAvailNotifRQ>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/FreeRooms-OTA_HotelAvailNotifRS-advisory.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/FreeRooms-OTA_HotelAvailNotifRS-advisory.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2014-04
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2014-04 1.0
+-->
+
+<OTA_HotelAvailNotifRS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xmlns="http://www.opentravel.org/OTA/2003/05"
+                       xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelAvailNotifRS.xsd"
+                       Version="1.001">
+
+    <Success/>
+
+    <Warnings>
+        <Warning Type="11">
+            last full data set received more than 48 hours ago
+        </Warning>
+    </Warnings>
+
+</OTA_HotelAvailNotifRS>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/FreeRooms-OTA_HotelAvailNotifRS-error.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/FreeRooms-OTA_HotelAvailNotifRS-error.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2014-04
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2014-04 1.0
+-->
+
+<OTA_HotelAvailNotifRS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xmlns="http://www.opentravel.org/OTA/2003/05"
+                       xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelAvailNotifRS.xsd"
+                       Version="1.001">
+
+    <Errors>
+        <Error Type="13" Code="404">
+            Invalid start/end date combination
+        </Error>
+    </Errors>
+
+</OTA_HotelAvailNotifRS>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/FreeRooms-OTA_HotelAvailNotifRS-success.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/FreeRooms-OTA_HotelAvailNotifRS-success.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2014-04
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2014-04 1.0
+-->
+
+<OTA_HotelAvailNotifRS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xmlns="http://www.opentravel.org/OTA/2003/05"
+                       xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelAvailNotifRS.xsd"
+                       Version="1.001">
+
+    <Success/>
+
+</OTA_HotelAvailNotifRS>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/FreeRooms-OTA_HotelAvailNotifRS-warning.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/FreeRooms-OTA_HotelAvailNotifRS-warning.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2014-04
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2014-04 1.0
+-->
+
+<OTA_HotelAvailNotifRS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xmlns="http://www.opentravel.org/OTA/2003/05"
+                       xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelAvailNotifRS.xsd"
+                       Version="1.001">
+
+    <Success/>
+
+    <Warnings>
+        <Warning Type="3">
+            dates are too far in the future for this server to process
+        </Warning>
+    </Warnings>
+
+</OTA_HotelAvailNotifRS>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/GuestRequests-OTA_ReadRQ-ack.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/GuestRequests-OTA_ReadRQ-ack.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2015-07
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2015-07 1.0
+     v. 2014-04 1.0
+-->
+
+<OTA_NotifReportRQ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+                   xmlns="http://www.opentravel.org/OTA/2003/05" 
+                   xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_NotifReportRQ.xsd" 
+                   Version="1.000">
+
+    <Success/>
+
+    <Warnings>
+        <!-- refuse reservation with ID=f054bbd2f5ebab9 -->
+        <Warning Type="3" Code="450" RecordID="f054bbd2f5ebab9">Unable to process reservation</Warning>
+    </Warnings>
+
+    <NotifDetails>
+        <HotelNotifReport>
+            <HotelReservations>
+
+                <HotelReservation>
+                    <!-- ACK reservation with ID="6b34fe24ac2ff810" -->
+                    <UniqueID Type="14" ID="6b34fe24ac2ff810"/>
+                </HotelReservation>
+
+                <HotelReservation>
+                    <!-- ACK cancellation with ID="c24e8b15ca469388" -->
+                    <UniqueID Type="15" ID="c24e8b15ca469388"/>
+                </HotelReservation>
+
+                <HotelReservation>
+                    <!-- ACK quote request with ID="1000000000000001" -->
+                    <UniqueID Type="14" ID="1000000000000001"/>
+                </HotelReservation>
+
+            </HotelReservations>
+        </HotelNotifReport>
+    </NotifDetails>
+
+</OTA_NotifReportRQ>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/GuestRequests-OTA_ReadRQ-invalid.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/GuestRequests-OTA_ReadRQ-invalid.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+     AlpineBits 2014-04
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2014-04 1.0
+-->
+
+<OTA_ReadRQ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.opentravel.org/OTA/2003/05"
+            xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_ReadRQ.xsd"
+            Version="1.001">
+
+    <!-- This element is not allowed here. The responseoutcome of this file should therefor fail -->
+    <InvalidElement/>
+
+    <ReadRequests>
+
+        <HotelReadRequest HotelCode="123" HotelName="Frangart Inn">
+           <SelectionCriteria Start="2012-03-21T15:00:00+01:00"></SelectionCriteria>
+       </HotelReadRequest>
+
+    </ReadRequests>
+
+</OTA_ReadRQ>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/GuestRequests-OTA_ReadRQ.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/GuestRequests-OTA_ReadRQ.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2014-04
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2014-04 1.0
+-->
+
+<OTA_ReadRQ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://www.opentravel.org/OTA/2003/05"
+            xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_ReadRQ.xsd"
+            Version="1.001">
+
+    <ReadRequests>
+
+        <HotelReadRequest HotelCode="123" HotelName="Frangart Inn">
+           <SelectionCriteria Start="2012-03-21T15:00:00+01:00"></SelectionCriteria>
+       </HotelReadRequest>
+
+    </ReadRequests>
+
+</OTA_ReadRQ>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/GuestRequests-OTA_ResRetrieveRS-cancellation.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/GuestRequests-OTA_ResRetrieveRS-cancellation.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2014-04
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2015-07b 1.0
+     v. 2014-04  1.0
+-->
+
+<OTA_ResRetrieveRS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.opentravel.org/OTA/2003/05"
+                   xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_ResRetrieveRS.xsd"
+                   Version="7.000">
+
+    <Success/>
+
+    <ReservationsList>
+
+        <HotelReservation CreateDateTime="2012-03-21T15:00:00+01:00" ResStatus="Cancelled">
+
+              <!-- Type 15 -> Cancellation -->
+            <UniqueID Type="15" ID="c24e8b15ca469388"/>
+
+             <!-- the following are optional for cancellations: -->
+             <!--
+             <RoomStays>     ...  </RoomStays>
+             <ResGuests>     ...  </ResGuests>
+             <ResGlobalInfo> ...  </ResGlobalInfo>
+             -->
+
+        </HotelReservation>
+
+    </ReservationsList>
+
+</OTA_ResRetrieveRS>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/GuestRequests-OTA_ResRetrieveRS-error.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/GuestRequests-OTA_ResRetrieveRS-error.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2014-04
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2014-04 1.0
+-->
+
+<OTA_ResRetrieveRS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.opentravel.org/OTA/2003/05"
+                   xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_ResRetrieveRS.xsd"
+                   Version="7.000">
+
+    <Errors>
+        <Error Type="13" Code="392">
+            Invalid hotel code
+        </Error>
+    </Errors>
+
+</OTA_ResRetrieveRS>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/GuestRequests-OTA_ResRetrieveRS-reservation-empty.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/GuestRequests-OTA_ResRetrieveRS-reservation-empty.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2014-04
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2014-04 1.0
+-->
+
+<OTA_ResRetrieveRS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.opentravel.org/OTA/2003/05"
+                   Version="7.000"
+                   xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_ResRetrieveRS.xsd">
+  <Success/>
+  <ReservationsList/>
+</OTA_ResRetrieveRS>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/GuestRequests-OTA_ResRetrieveRS-reservation.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/GuestRequests-OTA_ResRetrieveRS-reservation.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2014-04
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2015-07 1.0 updated to 2015-07
+     v. 2014-04 1.0
+-->
+
+<OTA_ResRetrieveRS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.opentravel.org/OTA/2003/05"
+                   xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_ResRetrieveRS.xsd"
+                   Version="7.000">
+
+    <Success/>
+
+    <ReservationsList>
+
+        <HotelReservation CreateDateTime="2012-03-21T15:00:00+01:00" ResStatus="Reserved">
+
+              <!-- Type 14 -> Reservation -->
+            <UniqueID Type="14" ID="6b34fe24ac2ff810"/>
+
+            <RoomStays>
+
+                <RoomStay>
+
+                    <RoomTypes>
+                        <RoomType RoomTypeCode="bigsuite" RoomClassificationCode="42"/>
+                    </RoomTypes>
+
+                    <RatePlans>
+                        <RatePlan RatePlanCode="123456-xyz">
+                            <Commission Percent="15"/>
+                            <!-- Code 1 -> All inclusive -->
+                            <MealsIncluded MealPlanIndicator="true" MealPlanCodes="1"/>
+                        </RatePlan>
+                    </RatePlans>
+
+                    <!-- 2 adults + 1 child + 1 child = 4 guests -->
+                    <GuestCounts>
+                        <!-- 2 adults -->
+                        <GuestCount Count="2"/>
+                        <!-- 1 child -->
+                        <GuestCount Count="1" Age="9"/>
+                        <!-- 1 child -->
+                        <GuestCount Count="1" Age="3"/>
+                    </GuestCounts>
+
+                    <TimeSpan Start="2012-01-01" End="2012-01-12"/>
+
+                    <Guarantee>
+                        <GuaranteesAccepted>
+                            <GuaranteeAccepted>
+                                <PaymentCard CardCode="VI" ExpireDate="1216">
+                                    <CardHolderName>Otto Mustermann</CardHolderName>
+                                    <CardNumber>
+                                        <PlainText>4444333322221111
+                                        </PlainText>
+                                    </CardNumber>
+                                </PaymentCard>
+                            </GuaranteeAccepted>
+                        </GuaranteesAccepted>
+                    </Guarantee>
+
+                    <Total AmountAfterTax="299" CurrencyCode="EUR"/>
+
+                </RoomStay>
+
+            </RoomStays>
+
+            <ResGuests>
+                <ResGuest>
+                    <Profiles>
+                        <ProfileInfo>
+                            <Profile>
+
+                                <Customer Gender="Male" BirthDate="1980-01-01" Language="de">
+
+                                    <PersonName>
+                                        <NamePrefix>Herr</NamePrefix>
+                                        <GivenName>Otto</GivenName>
+                                        <Surname>Mustermann</Surname>
+                                        <NameTitle>Dr</NameTitle>
+                                    </PersonName>
+
+                                    <!-- Code 1 -> Voice -->
+                                    <Telephone PhoneTechType="1" PhoneNumber="+4934567891"/>
+                                    <!-- Code 3 -> Fax -->
+                                    <Telephone PhoneTechType="3" PhoneNumber="+4934567892"/>
+                                    <!-- Code 5 -> Mobile -->
+                                    <Telephone PhoneTechType="5" PhoneNumber="+4934567893"/>
+
+                                    <Email Remark="newsletter:yes">otto.mustermann@example.com</Email>
+
+                                    <Address Remark="catalog:yes">
+
+                                        <AddressLine>Musterstraße 1</AddressLine>
+                                        <CityName>Musterstadt</CityName>
+                                        <PostalCode>1234</PostalCode>
+                                        <CountryName Code="DE"/>
+
+                                    </Address>
+
+                                </Customer>
+
+                            </Profile>
+                        </ProfileInfo>
+                    </Profiles>
+                </ResGuest>
+            </ResGuests>
+
+            <ResGlobalInfo>
+
+                <Comments>
+
+                    <Comment Name="included services">
+                        <ListItem ListItem="1" Language="de">Parkplatz</ListItem>
+                        <ListItem ListItem="2" Language="de">Schwimmbad</ListItem>
+                        <ListItem ListItem="3" Language="de">Skipass</ListItem>
+                    </Comment>
+
+                    <Comment Name="customer comment">
+                        <Text>
+                            Sind Hunde erlaubt?
+
+                            Mfg.
+                            Otto Mustermann.
+                        </Text>
+                    </Comment>
+
+                </Comments>
+
+                <CancelPenalties>
+                    <CancelPenalty>
+                        <PenaltyDescription>
+                            <Text>
+                            Cancellation is handled by hotel.
+                            Penalty is 50%, if canceled within 3 days before show, 100% otherwise.
+                            </Text>
+                        </PenaltyDescription>
+                    </CancelPenalty>
+                </CancelPenalties>
+
+                <HotelReservationIDs>
+                    <!-- ResID_Type 13 -> Internet Broker -->
+                    <HotelReservationID ResID_Type="13"
+                                        ResID_Value="Slogan"
+                                        ResID_Source="www.example.com"
+                                        ResID_SourceContext="top banner" />
+                </HotelReservationIDs>
+
+                <Profiles>
+                    <ProfileInfo>
+                        <!-- ProfileType 4 -> Travel Agent --> 
+                        <Profile ProfileType="4">
+                            <CompanyInfo>
+                                <CompanyName Code="123" CodeContext="ABC">ACME Travel Agency</CompanyName>
+                                <!-- Code 1 -> Voice -->
+                                <AddressInfo>
+                                    <AddressLine>Musterstraße 1</AddressLine>
+                                    <CityName>Flaneid</CityName>
+                                    <PostalCode>12345</PostalCode>
+                                    <CountryName Code="IT"/>
+                                </AddressInfo>
+                                <TelephoneInfo PhoneTechType="1" PhoneNumber="+391234567890"/>
+                                <Email>info@example.com</Email>
+                            </CompanyInfo>
+                        </Profile>
+                    </ProfileInfo>
+                </Profiles>
+
+               <!-- this is needed for OTA-2015A compatibility -->
+               <BasicPropertyInfo/>
+
+            </ResGlobalInfo>
+
+        </HotelReservation>
+
+    </ReservationsList>
+
+</OTA_ResRetrieveRS>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveContentNotifRQ-delete-all.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveContentNotifRQ-delete-all.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2017-10
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2017-10 1.0
+-->
+
+<OTA_HotelDescriptiveContentNotifRQ xmlns="http://www.opentravel.org/OTA/2003/05"
+                                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="5.000"
+                                    TimeStamp="2014-10-16T17:00:40"
+                                    xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelDescriptiveContentNotifRQ.xsd">
+    <HotelDescriptiveContents>
+        <HotelDescriptiveContent HotelCode="9996">
+            <FacilityInfo>
+                <GuestRooms>
+                </GuestRooms>
+            </FacilityInfo>
+        </HotelDescriptiveContent>
+    </HotelDescriptiveContents>
+</OTA_HotelDescriptiveContentNotifRQ>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveContentNotifRQ-hotelinfo.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveContentNotifRQ-hotelinfo.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+     AlpineBits 2017-10
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2017-10 1.0
+-->
+
+<OTA_HotelDescriptiveContentNotifRQ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                    xmlns="http://www.opentravel.org/OTA/2003/05"
+                                    xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelDescriptiveContentNotifRQ.xsd"
+                                    Version="8.000">
+
+    <HotelDescriptiveContents>
+
+        <HotelDescriptiveContent HotelCode="123" HotelName="Frangart Inn">
+
+            <!-- FacilityInfo: additional descriptive content for room categories -->
+
+            <FacilityInfo>
+                <GuestRooms>
+                    <GuestRoom Code="DZ">
+                        <MultimediaDescriptions>
+                            <MultimediaDescription>
+                                <ImageItems>
+                                    <ImageItem Category="6">
+                                        <ImageFormat CopyrightNotice="Image copyright">
+                                            <URL>https://..../HotelLogo.jpg</URL>
+                                        </ImageFormat>
+                                        <Description TextFormat="PlainText" Language="en">Image description
+                                        </Description>
+                                    </ImageItem>
+                                    <!--
+                                    .....
+                                    -->
+                                </ImageItems>
+                            </MultimediaDescription>
+                        </MultimediaDescriptions>
+                    </GuestRoom>
+                </GuestRooms>
+            </FacilityInfo>
+
+        </HotelDescriptiveContent>
+
+    </HotelDescriptiveContents>
+
+</OTA_HotelDescriptiveContentNotifRQ>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveContentNotifRQ.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveContentNotifRQ.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2015-07
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2015-07 1.0
+-->
+
+<OTA_HotelDescriptiveContentNotifRQ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+                                    xmlns="http://www.opentravel.org/OTA/2003/05" 
+                                    xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelDescriptiveContentNotifRQ.xsd" 
+                                    Version="8.000">
+
+  <HotelDescriptiveContents>
+
+    <HotelDescriptiveContent HotelCode="123" HotelName="Frangart Inn">
+
+      <FacilityInfo>
+
+        <GuestRooms>
+
+          <!-- This element defines a category and contains its basic description -->
+
+          <GuestRoom Code="DZ" MaxOccupancy="2" MinOccupancy="1" MaxChildOccupancy="1">
+
+            <!-- RoomClassificationCode = "42" means Room, 13 Apartment, see OTA table GRI -->
+
+            <TypeRoom StandardOccupancy="2" RoomClassificationCode="42"/>
+
+            <Amenities>
+
+              <!-- 26 means Crib, see OTA table RMA -->
+
+              <Amenity RoomAmenityCode="26"/>
+
+            </Amenities>
+
+            <MultimediaDescriptions>
+
+              <MultimediaDescription InfoCode="25">
+
+                <TextItems>
+
+                  <TextItem>
+
+                    <Description TextFormat="PlainText" Language="en">Double room</Description>
+
+                    <Description TextFormat="PlainText" Language="de">Doppelzimmer</Description>
+
+                    <Description TextFormat="PlainText" Language="it">Camera doppia</Description>
+
+                  </TextItem>
+
+                </TextItems>
+
+              </MultimediaDescription>
+
+              <MultimediaDescription InfoCode="1">
+
+                <TextItems>
+
+                  <TextItem>
+
+                    <Description TextFormat="PlainText" Language="en">Description of the double room.</Description>
+
+                    <Description TextFormat="PlainText" Language="de">Doppelzimmer Beschreibung.</Description>
+
+                    <Description TextFormat="PlainText" Language="it">Descrizione della camera doppia.</Description>
+
+                  </TextItem>
+
+                </TextItems>
+
+              </MultimediaDescription>
+
+              <MultimediaDescription InfoCode="23">
+
+                <ImageItems>
+
+                  <!-- 6 means Guest room, see OTA table PIC -->
+
+                  <ImageItem Category="6">
+
+                    <ImageFormat CopyrightNotice="Copyright notice 2015">
+
+                      <URL>http://www.example.com/image.jpg</URL>
+
+                    </ImageFormat>
+
+                    <Description TextFormat="PlainText" Language="en">Picture of the room</Description>
+
+                    <Description TextFormat="PlainText" Language="de">Zimmerbild</Description>
+
+                    <Description TextFormat="PlainText" Language="it">Immagine della stanza</Description>
+
+                  </ImageItem>
+
+                </ImageItems>
+
+              </MultimediaDescription>
+
+            </MultimediaDescriptions>
+
+          </GuestRoom>
+
+          <!-- Following elements define the single Rooms that belong to the Category -->
+
+          <GuestRoom Code="DZ">
+
+            <TypeRoom RoomID="101"/>
+
+          </GuestRoom>
+
+          <GuestRoom Code="DZ">
+
+            <TypeRoom RoomID="102"/>
+
+          </GuestRoom>
+
+          <GuestRoom Code="DZ">
+
+            <TypeRoom RoomID="103"/>
+
+          </GuestRoom>
+
+          <GuestRoom Code="DZ">
+
+            <TypeRoom RoomID="104"/>
+
+          </GuestRoom>
+
+          <GuestRoom Code="DZ">
+
+            <TypeRoom RoomID="105"/>
+
+          </GuestRoom>
+
+        </GuestRooms>
+
+      </FacilityInfo>
+
+    </HotelDescriptiveContent>
+
+  </HotelDescriptiveContents>
+
+</OTA_HotelDescriptiveContentNotifRQ>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveContentNotifRS-advisory.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveContentNotifRS-advisory.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2014-04
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2015-07 1.0
+-->
+
+<OTA_HotelDescriptiveContentNotifRS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                    xmlns="http://www.opentravel.org/OTA/2003/05"
+                                    xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelDescriptiveContentNotifRS.xsd"
+                                    Version="3.000">
+
+    <Success/>
+
+    <Warnings>
+        <Warning Type="11">
+            description text contains lorem ipsum
+        </Warning>
+    </Warnings>
+
+</OTA_HotelDescriptiveContentNotifRS>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveContentNotifRS-error.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveContentNotifRS-error.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2014-04
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2015-07 1.0
+-->
+
+<OTA_HotelDescriptiveContentNotifRS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                    xmlns="http://www.opentravel.org/OTA/2003/05"
+                                    xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelDescriptiveContentNotifRS.xsd"
+                                    Version="3.000">
+
+    <Errors>
+        <Error Type="13" Code="404">
+            incosistent values for occupancy
+        </Error>
+    </Errors>
+
+</OTA_HotelDescriptiveContentNotifRS>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveContentNotifRS-success.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveContentNotifRS-success.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2014-04
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2015-07 1.0
+-->
+
+<OTA_HotelDescriptiveContentNotifRS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                    xmlns="http://www.opentravel.org/OTA/2003/05"
+                                    xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelDescriptiveContentNotifRS.xsd"
+                                    Version="3.000">
+
+    <Success/>
+
+</OTA_HotelDescriptiveContentNotifRS>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveContentNotifRS-warning.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveContentNotifRS-warning.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2014-04
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2015-07 1.0
+-->
+
+<OTA_HotelDescriptiveContentNotifRS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                    xmlns="http://www.opentravel.org/OTA/2003/05"
+                                    xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelDescriptiveContentNotifRS.xsd"
+                                    Version="3.000">
+
+    <Success/>
+
+    <Warnings>
+        <Warning Type="3">
+            too many products
+        </Warning>
+    </Warnings>
+
+</OTA_HotelDescriptiveContentNotifRS>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveInfoRQ-basicpullRQ.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveInfoRQ-basicpullRQ.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2017-10
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2017-10 1.0
+-->
+
+<OTA_HotelDescriptiveInfoRQ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                            xmlns="http://www.opentravel.org/OTA/2003/05"
+                            xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelDescriptiveInfoRQ.xsd"
+                            Version="3.000">
+
+    <HotelDescriptiveInfos>
+        <HotelDescriptiveInfo HotelCode="123" HotelName="Frangart Inn"/>
+    </HotelDescriptiveInfos>
+
+</OTA_HotelDescriptiveInfoRQ>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveInfoRQ-hotelinfo.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveInfoRQ-hotelinfo.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2017-10
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2017-10 1.0
+-->
+
+<OTA_HotelDescriptiveInfoRQ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                            xmlns="http://www.opentravel.org/OTA/2003/05"
+                            xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelDescriptiveInfoRQ.xsd"
+                            Version="3.000">
+
+    <HotelDescriptiveInfos>
+        <HotelDescriptiveInfo HotelCode="123" HotelName="Frangart Inn"/>
+    </HotelDescriptiveInfos>
+
+</OTA_HotelDescriptiveInfoRQ>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveInfoRS-basicpullRS.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveInfoRS-basicpullRS.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2015-07
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2015-07 1.0
+-->
+
+<OTA_HotelDescriptiveInfoRS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+                            xmlns="http://www.opentravel.org/OTA/2003/05" 
+                            xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelDescriptiveInfoRS.xsd"
+                            Version="8.000">
+
+  <Success/>
+
+  <HotelDescriptiveContents>
+
+    <HotelDescriptiveContent HotelCode="123" HotelName="Frangart Inn">
+
+      <FacilityInfo>
+
+        <GuestRooms>
+
+          <!-- This element defines a category and contains its basic description -->
+
+          <GuestRoom Code="DZ" MaxOccupancy="2" MinOccupancy="1" MaxChildOccupancy="1">
+
+            <!-- RoomClassificationCode = "42" means Room, 13 Apartment, see OTA table GRI -->
+
+            <TypeRoom StandardOccupancy="2" RoomClassificationCode="42"/>
+
+            <Amenities>
+
+              <!-- 26 means Crib, see OTA table RMA -->
+
+              <Amenity RoomAmenityCode="26"/>
+
+            </Amenities>
+
+            <MultimediaDescriptions>
+
+              <MultimediaDescription InfoCode="25">
+
+                <TextItems>
+
+                  <TextItem>
+
+                    <Description TextFormat="PlainText" Language="en">Double room</Description>
+
+                    <Description TextFormat="PlainText" Language="de">Doppelzimmer</Description>
+
+                    <Description TextFormat="PlainText" Language="it">Camera doppia</Description>
+
+                  </TextItem>
+
+                </TextItems>
+
+              </MultimediaDescription>
+
+              <MultimediaDescription InfoCode="1">
+
+                <TextItems>
+
+                  <TextItem>
+
+                    <Description TextFormat="PlainText" Language="en">Description of the double room.</Description>
+
+                    <Description TextFormat="PlainText" Language="de">Doppelzimmer Beschreibung.</Description>
+
+                    <Description TextFormat="PlainText" Language="it">Descrizione della camera doppia.</Description>
+
+                  </TextItem>
+
+                </TextItems>
+
+              </MultimediaDescription>
+
+              <MultimediaDescription InfoCode="23">
+
+                <ImageItems>
+
+                  <!-- 6 means Guest room, see OTA table PIC -->
+
+                  <ImageItem Category="6">
+
+                    <ImageFormat CopyrightNotice="Copyright notice 2015">
+
+                      <URL>http://www.example.com/image.jpg</URL>
+
+                    </ImageFormat>
+
+                    <Description TextFormat="PlainText" Language="en">Picture of the room</Description>
+
+                    <Description TextFormat="PlainText" Language="de">Zimmerbild</Description>
+
+                    <Description TextFormat="PlainText" Language="it">Immagine della stanza</Description>
+
+                  </ImageItem>
+
+                </ImageItems>
+
+              </MultimediaDescription>
+
+            </MultimediaDescriptions>
+
+          </GuestRoom>
+
+          <!-- Following elements define the single Rooms that belong to the Category -->
+
+          <GuestRoom Code="DZ">
+
+            <TypeRoom RoomID="101"/>
+
+          </GuestRoom>
+
+          <GuestRoom Code="DZ">
+
+            <TypeRoom RoomID="102"/>
+
+          </GuestRoom>
+
+          <GuestRoom Code="DZ">
+
+            <TypeRoom RoomID="103"/>
+
+          </GuestRoom>
+
+          <GuestRoom Code="DZ">
+
+            <TypeRoom RoomID="104"/>
+
+          </GuestRoom>
+
+          <GuestRoom Code="DZ">
+
+            <TypeRoom RoomID="105"/>
+
+          </GuestRoom>
+
+        </GuestRooms>
+
+      </FacilityInfo>
+
+    </HotelDescriptiveContent>
+
+  </HotelDescriptiveContents>
+
+</OTA_HotelDescriptiveInfoRS>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveInfoRS-hotelinfo.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/Inventory-OTA_HotelDescriptiveInfoRS-hotelinfo.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2017-10
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2017-10 1.0
+-->
+
+<OTA_HotelDescriptiveInfoRS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                            xmlns="http://www.opentravel.org/OTA/2003/05"
+                            xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelDescriptiveInfoRS.xsd"
+                            Version="3.000">
+
+    <Success/>
+
+    <HotelDescriptiveContents>
+
+        <HotelDescriptiveContent HotelCode="123" HotelName="Frangart Inn">
+
+            <!-- FacilityInfo: additional descriptive content for room categories -->
+
+            <FacilityInfo>
+                <GuestRooms>
+                    <GuestRoom Code="DZ">
+                        <MultimediaDescriptions>
+                            <MultimediaDescription>
+                                <ImageItems>
+                                    <ImageItem Category="6">
+                                        <ImageFormat CopyrightNotice="Image copyright">
+                                            <URL>https://..../HotelLogo.jpg</URL>
+                                        </ImageFormat>
+                                        <Description TextFormat="PlainText" Language="en">Image description
+                                        </Description>
+                                    </ImageItem>
+                                    <!--
+                                    .....
+                                    -->
+                                </ImageItems>
+                            </MultimediaDescription>
+                        </MultimediaDescriptions>
+                    </GuestRoom>
+                </GuestRooms>
+            </FacilityInfo>
+
+        </HotelDescriptiveContent>
+
+    </HotelDescriptiveContents>
+
+</OTA_HotelDescriptiveInfoRS>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/RatePlans-OTA_HotelRatePlanNotifRQ.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/RatePlans-OTA_HotelRatePlanNotifRQ.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2017-10
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2017-10 1.0 adapted for static rates
+     v. 2015-07 1.0 LengthOfStay -> Time set to 5 for SetMaxLOS
+                    BaseByGuestAmt -> AmountAfterTax corrected to be consistent with the choice of Type="7" (per person)
+     v. 2014-04 1.2 removed third example Offer element (only at most two Offer elements are allowed)
+     v. 2014-04 1.1 Description: fixed Name="Short Description" -> Name="title" and added example content
+     v. 2014-04 1.0
+-->
+
+<OTA_HotelRatePlanNotifRQ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                          xmlns="http://www.opentravel.org/OTA/2003/05"
+                          xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelRatePlanNotifRQ.xsd"
+                          Version="1.000">
+
+    <RatePlans HotelCode="123" HotelName="Frangart Inn">
+
+        <RatePlan RatePlanNotifType="New" CurrencyCode="EUR" RatePlanCode="Rate1-4-HB">
+
+            <BookingRules>
+
+                <BookingRule Start="2014-03-03" End="2014-04-17">
+
+                    <LengthsOfStay>
+                        <LengthOfStay Time="5" TimeUnit="Day" MinMaxMessageType="SetMinLOS"/>
+                        <LengthOfStay Time="5" TimeUnit="Day" MinMaxMessageType="SetMaxLOS"/>
+                    </LengthsOfStay>
+
+                    <DOW_Restrictions>
+                        <ArrivalDaysOfWeek   Mon="1" Tue="1" Weds="1" Thur="1" Fri="1" Sat="1" Sun="1"/>
+                        <DepartureDaysOfWeek Mon="1" Tue="1" Weds="1" Thur="1" Fri="1" Sat="1" Sun="1"/>
+                    </DOW_Restrictions>
+
+                    <RestrictionStatus Restriction="Master" Status="Open"/>
+
+                </BookingRule>
+
+            </BookingRules>
+
+            <Rates>
+
+                <!-- first in list: the static rate - values apply to every rate in the rate plan -->
+
+                <Rate RateTimeUnit="Day" UnitMultiplier="1">
+                    <BaseByGuestAmts>
+                        <BaseByGuestAmt Type="7"/>
+                    </BaseByGuestAmts>
+                    <MealsIncluded MealPlanIndicator="true" MealPlanCodes="12"/>
+                </Rate>
+
+                <!-- following: "normal" rates ... -->
+
+                <Rate InvTypeCode="double" Start="2014-03-03" End="2014-03-08">
+                    <BaseByGuestAmts>
+                        <BaseByGuestAmt NumberOfGuests="1" AgeQualifyingCode="10" AmountAfterTax="106"/>
+                        <BaseByGuestAmt NumberOfGuests="2" AgeQualifyingCode="10" AmountAfterTax="96"/>
+                    </BaseByGuestAmts>
+                    <AdditionalGuestAmounts>
+                        <AdditionalGuestAmount AgeQualifyingCode="10" Amount="76.8"/>
+                        <AdditionalGuestAmount AgeQualifyingCode="8"              MaxAge="3" Amount="0"    />
+                        <AdditionalGuestAmount AgeQualifyingCode="8"  MinAge="3"  MaxAge="6" Amount="38.4" />
+                        <AdditionalGuestAmount AgeQualifyingCode="8"  MinAge="6"  MaxAge="10" Amount="48"  />
+                        <AdditionalGuestAmount AgeQualifyingCode="8"  MinAge="10" MaxAge="16" Amount="67.2"/>
+                    </AdditionalGuestAmounts>
+                </Rate>
+
+            </Rates>
+
+            <Supplements>
+
+                <Supplement InvType="EXTRA" InvCode="0x539" AddToBasicRateIndicator="true" MandatoryIndicator="true" ChargeTypeCode="18">
+                    <Description Name="title">
+                        <Text TextFormat="PlainText" Language="de">Endreinigung</Text>
+                        <Text TextFormat="PlainText" Language="it">Pulizia finale</Text>
+                        <!-- more languages ... -->
+                    </Description>
+                    <Description Name="intro">
+                        <Text TextFormat="PlainText" Language="de">Die Endreinigung lorem ipsum dolor sit amet.</Text>
+                        <Text TextFormat="PlainText" Language="it">La pulizia finale lorem ipsum dolor sit amet.</Text>
+                        <!-- more languages ... -->
+                    </Description>
+                </Supplement>
+
+                <Supplement InvType="EXTRA" InvCode="0x539" Amount="20" Start="2014-10-01" End="2014-10-11"/>
+
+            </Supplements>
+
+            <Offers>
+                <Offer>
+                    <OfferRules>
+                        <OfferRule>
+                            <Occupancy AgeQualifyingCode="10" MinAge="16"/>
+                            <Occupancy AgeQualifyingCode="8"/>
+                        </OfferRule>
+                    </OfferRules>
+                </Offer>
+            </Offers>
+
+            <Description Name="title">
+                <Text TextFormat="PlainText" Language="en">Lorem ipsum.</Text>
+                <Text TextFormat="PlainText" Language="it">Lorem ipsum.</Text>
+                <!-- more languages ... -->
+            </Description>
+
+            <Description Name="intro">
+                <Text TextFormat="PlainText" Language="en">Lorem ipsum dolor sit amet.</Text>
+                <Text TextFormat="PlainText" Language="it">Lorem ipsum dolor sit amet.</Text>
+                <!-- more languages ... -->
+            </Description>
+
+        </RatePlan>
+
+    </RatePlans>
+
+</OTA_HotelRatePlanNotifRQ>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/RatePlans-OTA_HotelRatePlanNotifRS-advisory.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/RatePlans-OTA_HotelRatePlanNotifRS-advisory.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2015-07
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2015-07 1.0
+-->
+
+<OTA_HotelRatePlanNotifRS xmlns="http://www.opentravel.org/OTA/2003/05" 
+                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+                          xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelRatePlanNotifRS.xsd" 
+                          Version="3.14">
+
+    <Success/>
+
+    <Warnings>
+        <Warning Type="11">
+            end date is less than 3 days from now
+        </Warning>
+    </Warnings>
+
+</OTA_HotelRatePlanNotifRS>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/RatePlans-OTA_HotelRatePlanNotifRS-error.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/RatePlans-OTA_HotelRatePlanNotifRS-error.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2015-07
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2015-07 1.0
+-->
+
+<OTA_HotelRatePlanNotifRS xmlns="http://www.opentravel.org/OTA/2003/05" 
+                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+                          xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelRatePlanNotifRS.xsd" 
+                          Version="3.14">
+
+    <Errors>
+        <Error Type="13" Code="404">
+            Invalid start/end date combination
+        </Error>
+    </Errors>
+
+</OTA_HotelRatePlanNotifRS>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/RatePlans-OTA_HotelRatePlanNotifRS-success.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/RatePlans-OTA_HotelRatePlanNotifRS-success.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2015-07
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2015-07 1.0
+-->
+
+<OTA_HotelRatePlanNotifRS xmlns="http://www.opentravel.org/OTA/2003/05" 
+                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+                          xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelRatePlanNotifRS.xsd" 
+                          Version="3.14">
+
+    <Success/>
+
+</OTA_HotelRatePlanNotifRS>

--- a/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/RatePlans-OTA_HotelRatePlanNotifRS-warning.xml
+++ b/alpinebits-xml/impl/src/test/resources/examples/v_2017_10/RatePlans-OTA_HotelRatePlanNotifRS-warning.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2015-07
+     http://www.alpinebits.org/
+
+     sample message file
+
+     changelog:
+     v. 2015-07 1.0
+-->
+
+<OTA_HotelRatePlanNotifRS xmlns="http://www.opentravel.org/OTA/2003/05" 
+                          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+                          xsi:schemaLocation="http://www.opentravel.org/OTA/2003/05 OTA_HotelRatePlanNotifRS.xsd" 
+                          Version="3.14">
+
+    <Success/>
+
+    <Warnings>
+        <Warning Type="3">
+            dates are too far in the future for this server to process
+        </Warning>
+    </Warnings>
+
+</OTA_HotelRatePlanNotifRS>

--- a/alpinebits-xml/impl/src/test/resources/schema/alpinebits-2017-10-invalid.rng
+++ b/alpinebits-xml/impl/src/test/resources/schema/alpinebits-2017-10-invalid.rng
@@ -1,0 +1,2822 @@
+!!!!Invalid XML, therefor invalid RNG
+<?xml version="1.0"?>
+
+<!--
+     AlpineBits 2017-10 
+     http://www.alpinebits.org/
+
+     Relax-NG grammar file
+
+     changelog:
+
+    v. 2017-10  1.3 -  Inventory common type def_hoteldescriptivecontents -> FacilityInfo -> ... -> MultimediaDescription (allow one or more ImageItem elements for InfoCode="23")
+
+    v. 2017-10  1.2 -  FreeRooms:       OTA_HotelAvailNotifRQ -> AvailStatusMessages -> ...  -> StatusApplicationControl (make BookingThreshold not mandatory)
+
+    v. 2017-10  1.1 -  RatePlans:       RatePlans > RatePlan > Offers: allow only MinLOS and MaxLOS attributes (not the forward ones too)
+
+    v. 2017-10  1.0 -  FreeRooms:       OTA_HotelAvailNotifRQ -> UniqueID (added allowed value to attribute Type, by Luca Rainone)
+                       FreeRooms:       OTA_HotelAvailNotifRQ -> AvailStatusMessages -> ...  -> StatusApplicationControl (added new mandatory attribute BookingThreshold)
+
+                       GuestRequests:   OTA_ResRetrieveRS -> ReservationsList -> ... -> RatePlan (added element Commission)
+                       GuestRequests:   OTA_ResRetrieveRS -> ReservationsList -> ... -> CardNumber (added attributes EncryptedValue and EncryptionMethod) 
+                       GuestRequests:   OTA_ResRetrieveRS -> ReservationsList -> ... -> RoomStay > RoomTypes (made optional)
+
+                       SimplePackages section removed
+
+                       Inventory has become Inventory/Basic (Push) and Inventory/HotelInfo (Push):
+                                        OTA_HotelDescriptiveContentNotifRQ (major changes, one being that empty GuestRooms elements are now allowed by Luca Rainone)
+
+                       Inventory/Basic (Pull) and Inventory/HotelInfo (Pull) added
+ 
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> BookingRules -> ... -> LengthOfStay (added allowed values to attribute MinMaxMessageType)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Supplements -> Supplement (added element PrerequisiteInventory)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Supplements -> Supplement -> Description (major changes)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Offers -> Offer (major changes)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Description (major changes)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> ... -> BaseByGuestAmt (NumberOfGuests and Type are optional now to allow static rates)
+
+                       BaseRates section added
+
+    v. 2015-07b 1.4 - weaken the schema for Inventory (to prepare for upcoming release that will support Inventory deltas):
+
+                      - the RoomAmenityCode attribute becomes optional to allow empty Amenity elements 
+                      - the MultimediaDescription element can be empty
+
+    v. 2015-07b 1.3 - RatePlans > RatePlan > Description > TextFormat can now also be "HTML" (besides "PlainText")
+
+    v. 2015-07b 1.2 - added optional attributes RatePlanID and RatePlanQualifier to RatePlan
+                      for the new OTA_HotelRatePlanNotif_accept_RatePlanJoin capability
+
+    v. 2015-07b 1.1 - added def_invTypeCode_string type (string with up to 8 chars) used for the following attributes that identify room categories:
+
+                      FreeRooms:     OTA_HotelAvailNotifRQ -> AvailStatusMessages -> AvailStatusMessage -> StatusApplicationControl -> InvTypeCode
+                      GuestRequests: OTA_ResRetrieveRS -> ReservationList -> HotelReservation -> RoomStays -> RoomStay -> RoomTypes > RoomType -> RoomTypeCode
+                      Inventory:     OTA_HotelDescriptiveContentNotifRQ -> HotelDescriptiveContents -> HotelDescriptiveContent -> FacilityInfo -> GuestRooms -> GuestRoom -> Code
+                      RatePlan:      OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> BookingRules -> BookingRule -> Code
+                      RatePlan:      OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Rates -> Rate -> InvTypeCode
+
+    v. 2015-07b 1.0 - RatePlans > RatePlan > Rates > Rate > BaseByGuestAmts > AmountAfterTax
+                      must be > 0.0 (was: >= 0.0)
+
+     v. 2015-07 2.8 - Inventory: fixed the checks for the HotelDescriptiveContent attributes
+
+     v. 2015-07 2.7 - Inventory: reconciled with the definitions given in the updated document
+
+     v. 2015-07 2.6 - added section for New Inventory (exact name pending)
+
+     v. 2015-07 2.5 - made sub-elements of HotelReservation > ... > Customer > Address {0,1} optional
+
+     v. 2015-07 2.4 - added a choice of 'Modify' for ResStatusValue
+
+     v. 2015-07 2.3 - added MinCount attribute to Offer>>Guest
+
+     v. 2015-07 2.2 - changes to Supplement: a few attributes are removed and many attributes are made optional
+
+     v. 2015-07 2.1 - RatePlans/Supplements: changed format of description
+
+     v. 2015-07 2.0 - GuestRequests: ResGuests >> Customer: attributes Gender and Language are now optional
+
+     v. 2015-07 1.9 - allow Warnings in OTA_NotifReportRQ messages
+
+     v. 2015-07 1.8 - GuestRequests: use CardNumber -> PlainText instead of the Remark attribute of
+                      PaymentCard under Guarantee; add BasicPropertyInfo element at the end of the 
+                      ResGlobalInfo block for OTA-2015A compatiblity
+
+     v. 2015-07 1.7 - allowed more than one HotelReservationID
+
+     v. 2015-07 1.6 - RatePlans: allow optional PrerequisiteInventory element under Supplement element
+
+     v. 2015-07 1.5 - Inventory: removed Amenities and added optional Room -> RoomTypeCode
+
+     v. 2015-07 1.4 - HotelReservationID -> ResID_Type is not limited to 13 anymore
+
+     v. 2015-07 1.3 - new section in RoomStays: Guarantee -> GuaranteesAccepted -> GuaranteeAccepted -> PaymentCard
+
+     v. 2015-07 1.2 - new section in ResGlobalInfo: Profiles -> ProfileInfo -> Profile -> CompanyInfo
+
+     v. 2015-07 1.1 - HotelReservation > RoomStays > RoomStay > RoomTypes > RoomType is now
+                      mandatory and has a new optional attribute RoomClassificationCode
+
+     v. 2015-07 1.0 - OTA_NotifReportRS besides Success, now also allows Error responses 
+
+     v. 2014-04 1.5 - [fixed] InvCode attribute in Supplement changed from def_int_ge0 to def_nonempty_string
+
+     v. 2014-04 1.4 - [strictness improvement] made BaseByGuestAmt->NumberOfGuests attribute mandatory for
+                      RatePlans and SimplePackages, made BaseByGuestAmt->Type attribute mandatory for RatePlans
+
+     v. 2014-04 1.3 - [improvement] RatePlans: remove RatePlan->Rate attributes that are not allowed
+                      (problem inherited from the xsd version where Rate is shared with SimplePackages
+
+     v. 2014-04 1.2 - [fixed] RatePlans: optional Rate attributes RateTimeUnit and UnitMultiplier added
+
+     v. 2014-04 1.1 - [fixed] GuestRequests: Email->Remark is an optional attribute
+                    - [fixed] GuestRequests: ReservationsList can be empty
+
+     v. 2014-04 1.0 - complete rewrite for 2014-04
+
+-->
+
+<rng:grammar     xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        ns="http://www.opentravel.org/OTA/2003/05"
+           datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+  <rng:start>
+    <rng:choice>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * FreeRooms                                                                     -->
+      <!-- ******************************************************************************* -->
+
+      <!-- FreeRooms: OTA_HotelAvailNotifRQ -->
+
+      <rng:element name="OTA_HotelAvailNotifRQ">
+
+        <!-- UniqueID {0,1} -->
+
+        <rng:optional>
+          <rng:element name="UniqueID">
+
+            <rng:attribute name="Type">
+              <rng:choice>
+                <rng:value type="string">16</rng:value>
+                <rng:value type="string">35</rng:value>
+              </rng:choice>
+            </rng:attribute>
+            <rng:attribute name="ID"/> <!-- an ID is required by OTA, we ignore the value -->
+            <rng:attribute name="Instance">
+              <rng:value type="string">CompleteSet</rng:value>
+            </rng:attribute>
+
+          </rng:element>
+        </rng:optional>
+
+         <!-- AvailStatusMessages {1} -->
+
+        <rng:element name="AvailStatusMessages">
+
+          <rng:oneOrMore>
+            <rng:choice>
+              <rng:attribute name="HotelCode">
+                <rng:ref name="def_nonempty_string"/>
+              </rng:attribute>
+              <rng:attribute name="HotelName">
+                <rng:ref name="def_nonempty_string"/>
+              </rng:attribute>
+            </rng:choice>
+          </rng:oneOrMore>
+
+          <!-- AvailStatusMessages > AvailStatusMessage (1,} -->
+
+          <rng:oneOrMore>
+            <rng:element name="AvailStatusMessage">
+
+              <!-- AvailStatusMessage is either empty or has
+                 attributes BookingLimit, BookingLimitMessageType, BookingThreshold (optional)
+                 and contains one StatusApplicationControl element -->
+
+              <rng:optional>
+
+                <rng:element name="StatusApplicationControl">
+
+                  <rng:attribute name="Start">
+                    <rng:ref name="def_date"/>
+                  </rng:attribute>
+                  <rng:attribute name="End">
+                    <rng:ref name="def_date"/>
+                  </rng:attribute>
+                  <rng:attribute name="InvTypeCode">
+                    <rng:ref name="def_invTypeCode_string"/>
+                  </rng:attribute>
+                  <rng:optional>
+                    <rng:attribute name="InvCode">
+                      <rng:ref name="def_nonempty_string"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                </rng:element>
+
+                <rng:attribute name="BookingLimit">
+                  <rng:ref name="def_int_ge0"/>
+                </rng:attribute>
+                <rng:optional>
+                  <rng:attribute name="BookingThreshold">
+                    <rng:ref name="def_int_ge0"/>
+                  </rng:attribute>
+                </rng:optional>
+                <rng:attribute name="BookingLimitMessageType">
+                  <rng:value type="string">SetLimit</rng:value>
+                </rng:attribute>
+
+              </rng:optional>
+
+            </rng:element>
+          </rng:oneOrMore>
+
+        </rng:element>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- FreeRooms: OTA_HotelAvailNotifRQ -->
+
+      <rng:element name="OTA_HotelAvailNotifRS">
+
+        <rng:ref name="def_generic_response"/>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * GuestRequests                                                                 -->
+      <!-- ******************************************************************************* -->
+
+      <!-- GuestRequests: OTA_ReadRQ -->
+
+      <rng:element name="OTA_ReadRQ">
+
+        <rng:element name="ReadRequests">
+    
+          <rng:element name="HotelReadRequest">
+        
+            <rng:optional>
+              <rng:element name="SelectionCriteria">
+          
+                <rng:attribute name="Start">
+                  <rng:ref name="def_datetime"/>
+                </rng:attribute>
+          
+              </rng:element>
+            </rng:optional>
+
+            <rng:oneOrMore>
+              <rng:choice>
+                <rng:attribute name="HotelCode">
+                  <rng:ref name="def_nonempty_string"/>
+                </rng:attribute>
+                <rng:attribute name="HotelName">
+                  <rng:ref name="def_nonempty_string"/>
+                </rng:attribute>
+              </rng:choice>
+            </rng:oneOrMore>
+
+          </rng:element>
+
+        </rng:element>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+  
+      </rng:element>
+
+      <!-- GuestRequests: OTA_ResRetrieveRS -->
+
+      <rng:element name="OTA_ResRetrieveRS">
+        <rng:choice>
+
+          <!-- choice: Errors {1} -->
+
+          <rng:element name="Errors">
+
+            <!-- Errors > Error {1,} -->
+
+            <rng:oneOrMore>
+              <rng:element name="Error">
+
+                <rng:attribute name="Type">
+                  <rng:value type="string">13</rng:value>
+                </rng:attribute>
+                <rng:attribute name="Code">
+                  <rng:ref name="def_int_ge0"/>
+                </rng:attribute>
+
+                <rng:text/>
+
+              </rng:element>
+
+            </rng:oneOrMore>
+          </rng:element>
+
+          <!-- choice: Success {1} + ReservationsList {1} -->
+
+          <rng:group>
+
+            <rng:element name="Success">
+              <rng:empty/>
+            </rng:element>
+
+            <rng:element name="ReservationsList">
+
+              <!-- HotelReservation {0,} -->
+
+              <rng:zeroOrMore>
+                <rng:element name="HotelReservation">
+
+                  <!-- HotelReservation > UniqueID {1} -->
+
+                  <rng:element name="UniqueID">
+
+                    <rng:attribute name="Type">
+                      <rng:choice>
+                        <rng:value>14</rng:value>
+                        <rng:value>15</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+
+                    <rng:attribute name="ID">
+                      <rng:ref name="def_nonempty_string"/>
+                    </rng:attribute>
+
+                  </rng:element>
+
+                  <!-- HotelReservation > RoomStays {0,1} -->
+
+                  <rng:optional>
+                    <rng:element name="RoomStays">
+
+                      <!-- HotelReservation > RoomStays > RoomStay {1,} -->
+
+                      <rng:oneOrMore>
+                        <rng:element name="RoomStay">
+
+                          <!-- HotelReservation > RoomStays > RoomStay > RoomTypes {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="RoomTypes">
+
+                              <!-- HotelReservation > RoomStays > RoomStay > RoomTypes > RoomType {1} -->
+
+                              <rng:element name="RoomType">
+                                <rng:optional>
+                                  <rng:attribute name="RoomTypeCode">
+                                    <rng:ref name="def_invTypeCode_string"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="RoomClassificationCode">
+                                    <rng:ref name="def_int_ge0"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                              </rng:element>
+                         
+                            </rng:element>
+                          </rng:optional>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > RatePlans {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="RatePlans">
+
+                              <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan {1} -->
+
+                              <rng:element name="RatePlan">
+
+                                <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan > Commission {0,1} -->
+
+                                <rng:optional>
+                                  <rng:element name="Commission">
+                                    <rng:choice>
+
+                                      <!-- Commission has either attribute "Percent" ... -->
+
+                                      <rng:attribute name="Percent">
+                                        <rng:ref name="def_int_ge0"/>
+                                      </rng:attribute>
+
+                                      <!-- ... or subelement "CommissionPayableAmount" -->
+
+                                      <rng:element name="CommissionPayableAmount">
+                                        <rng:attribute name="Amount">
+                                          <rng:ref name="def_decimal_ge0"/>
+                                        </rng:attribute>
+                                        <rng:attribute name="CurrencyCode">
+                                          <rng:choice>
+                                            <rng:value>EUR</rng:value>
+                                          </rng:choice>
+                                        </rng:attribute>
+                                      </rng:element>
+
+                                    </rng:choice>
+                                  </rng:element>
+                                </rng:optional>
+
+                                <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan > MealsIncluded {0,1} -->
+
+                                <rng:optional>
+                                  <rng:element name="MealsIncluded">
+
+                                    <rng:attribute name="MealPlanIndicator">
+                                      <rng:choice>
+                                        <rng:value>1</rng:value>
+                                        <rng:value>true</rng:value>
+                                      </rng:choice>
+                                    </rng:attribute>
+                                    <rng:attribute name="MealPlanCodes">
+                                      <rng:choice>
+                                        <rng:value>1</rng:value>
+                                        <rng:value>3</rng:value>
+                                        <rng:value>10</rng:value>
+                                        <rng:value>12</rng:value>
+                                        <rng:value>14</rng:value>
+                                      </rng:choice>
+                                    </rng:attribute>
+
+                                  </rng:element>
+                                </rng:optional>
+
+                                <rng:optional>
+                                  <rng:attribute name="RatePlanCode">
+                                    <rng:ref name="def_nonempty_string"/>
+                                  </rng:attribute>
+                                </rng:optional>
+
+                              </rng:element>
+
+                            </rng:element>
+
+                          </rng:optional>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > GuestCounts {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="GuestCounts">
+
+                              <!-- HotelReservation > RoomStays > RoomStay > GuestCounts > GuestCount {1,} -->
+
+                              <rng:oneOrMore>
+                                <rng:element name="GuestCount">
+
+                                  <rng:attribute name="Count">
+                                    <rng:ref name="def_int_gt0"/>
+                                  </rng:attribute>
+                                  <rng:optional>
+                                    <rng:attribute name="Age">
+                                      <rng:ref name="def_int_ge0"/>
+                                    </rng:attribute>
+                                  </rng:optional>
+
+                                </rng:element>
+                              </rng:oneOrMore>
+
+                            </rng:element>
+                          </rng:optional>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > TimeSpan {1} -->
+
+                          <rng:element name="TimeSpan">
+
+                            <!-- HotelReservation > RoomStays > RoomStay > TimeSpan > StartDateWindow {0,1} -->
+
+                            <rng:optional>
+                              <rng:element name="StartDateWindow">
+
+                                <rng:attribute name="EarliestDate">
+                                  <rng:ref name="def_date"/>
+                                </rng:attribute>
+                                <rng:attribute name="LatestDate">
+                                  <rng:ref name="def_date"/>
+                                </rng:attribute>
+
+                              </rng:element>
+                            </rng:optional>
+
+                            <rng:optional>
+                              <rng:attribute name="Start">
+                                <rng:ref name="def_date"/>
+                              </rng:attribute>
+                            </rng:optional>
+                            <rng:optional>
+                              <rng:attribute name="End">
+                                <rng:ref name="def_date"/>
+                              </rng:attribute>
+                            </rng:optional>
+                            <rng:optional>
+                              <rng:attribute name="Duration">
+                                <rng:data type="string">
+                                  <rng:param name="pattern">P[0-9]+N</rng:param>
+                                </rng:data>
+                              </rng:attribute>
+                            </rng:optional>
+
+                          </rng:element>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > Guarantee {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="Guarantee">
+                              <rng:element name="GuaranteesAccepted">
+                                <rng:element name="GuaranteeAccepted">
+
+                                  <rng:element name="PaymentCard">
+
+                                    <rng:attribute name="CardCode">
+                                      <rng:data type="string">
+                                        <rng:param name="pattern">[A-Z][A-Z]?</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+                                    <rng:attribute name="ExpireDate">
+                                      <rng:data type="string">
+                                        <rng:param name="pattern">[0-9][0-9][0-9][0-9]</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+
+                                    <rng:element name="CardHolderName">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:element>
+
+                                    <rng:element name="CardNumber">
+
+                                      <rng:choice>
+
+                                        <rng:element name="PlainText">
+                                          <rng:ref name="def_nonempty_string"/>
+                                        </rng:element>
+
+                                        <rng:group>
+                                          <rng:attribute name="EncryptedValue">
+                                            <rng:ref name="def_nonempty_string"/>
+                                          </rng:attribute>
+                                          <rng:attribute name="EncryptionMethod">
+                                            <rng:ref name="def_nonempty_string"/>
+                                          </rng:attribute>
+                                        </rng:group>
+
+                                      </rng:choice>
+
+                                    </rng:element>
+
+                                  </rng:element>
+
+                                </rng:element>
+                              </rng:element>
+                            </rng:element>
+                          </rng:optional>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > Total {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="Total">
+
+                              <rng:attribute name="AmountAfterTax">
+                                <rng:ref name="def_decimal_ge0"/>
+                              </rng:attribute>
+                              <rng:attribute name="CurrencyCode">
+                                <rng:ref name="def_nonempty_string"/>
+                              </rng:attribute>
+
+                            </rng:element>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:oneOrMore>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <!-- HotelReservation > ResGuests {0, 1} -->
+
+                  <rng:optional>
+                    <rng:element name="ResGuests">
+                      <rng:element name="ResGuest">
+                        <rng:element name="Profiles">
+                          <rng:element name="ProfileInfo">
+                            <rng:element name="Profile">
+
+                              <!-- HotelReservation > ... > Customer {1} -->
+
+                              <rng:element name="Customer">
+
+                                <!-- HotelReservation > ... > Customer > PersonName {1} -->
+
+                                <rng:element name="PersonName">
+
+                                  <rng:optional>
+                                    <rng:element name="NamePrefix">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:element>
+                                  </rng:optional>
+                                  <rng:element name="GivenName">
+                                    <rng:ref name="def_nonempty_string"/>
+                                  </rng:element>
+                                  <rng:element name="Surname">
+                                    <rng:ref name="def_nonempty_string"/>
+                                  </rng:element>
+                                  <rng:optional>
+                                    <rng:element name="NameTitle">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:element>
+
+                                  </rng:optional>
+                                </rng:element>
+
+                                <!-- HotelReservation > ... > Customer > Telephone {0,} -->
+
+                                <rng:zeroOrMore>
+                                  <rng:element name="Telephone">
+
+                                    <rng:attribute name="PhoneTechType">
+                                      <rng:data type="string">
+                                        <rng:param name="pattern">(1|3|5)</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+                                    <rng:attribute name="PhoneNumber">
+                                      <rng:data type="string">
+                                        <rng:param name="pattern">\+?[0-9]+</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+
+                                  </rng:element>
+                                </rng:zeroOrMore>
+
+                                <!-- HotelReservation > ... > Customer > Email {0,1} -->
+
+                                <rng:optional>
+                                  <rng:element name="Email">
+                                    <rng:ref name="def_email_string"/>
+                                    <rng:optional>
+                                      <rng:attribute name="Remark">
+                                        <rng:data type="string">
+                                          <rng:param name="pattern">newsletter:(no|yes)</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                    </rng:optional>
+
+                                  </rng:element>
+                                </rng:optional>
+
+                                <!-- HotelReservation > ... > Customer > Address {0,1} -->
+
+                                <rng:optional>
+                                  <rng:element name="Address">
+
+                                    <rng:optional>
+                                      <rng:element name="AddressLine">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                    </rng:optional>
+
+                                    <rng:optional>
+                                      <rng:element name="CityName">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                    </rng:optional>
+
+                                    <rng:optional>
+                                      <rng:element name="PostalCode">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                    </rng:optional>
+
+                                    <rng:optional>
+                                      <rng:element name="CountryName">
+                                        <rng:attribute name="Code">
+                                          <rng:data type="string">
+                                            <rng:param name="pattern">[A-Z][A-Z]</rng:param>
+                                          </rng:data>
+                                        </rng:attribute>
+                                      </rng:element>
+                                    </rng:optional>
+
+                                    <rng:optional>
+                                      <rng:attribute name="Remark">
+                                        <rng:data type="string">
+                                          <rng:param name="pattern">catalog:(no|yes)</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                    </rng:optional>
+
+                                  </rng:element>
+                                </rng:optional>
+
+                                <rng:optional>
+                                  <rng:attribute name="Gender">
+                                    <rng:data type="string">
+                                      <rng:param name="pattern">(Unknown|Male|Female)</rng:param>
+                                    </rng:data>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="BirthDate">
+                                    <rng:ref name="def_date"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Language">
+                                    <rng:data type="language">
+                                      <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                    </rng:data>
+                                  </rng:attribute>
+                                </rng:optional>
+
+                              </rng:element>
+                            </rng:element>
+                          </rng:element>
+                        </rng:element>
+                      </rng:element>
+                    </rng:element>
+                  </rng:optional>
+
+                  <!-- HotelReservation > ResGlobalInfo {0,1} -->
+
+                  <rng:optional>
+                    <rng:element name="ResGlobalInfo">
+
+                      <!-- HotelReservation > ResGlobalInfo > Comments {0,1} -->
+
+                      <rng:optional>
+                        <rng:element name="Comments">
+
+                          <!-- HotelReservation > ResGlobalInfo > Comments {1,} (actually {1,2} but Relax-NG cannot do this) -->
+
+                          <rng:oneOrMore>
+                            <rng:element name="Comment">
+                         
+                              <rng:choice>
+                                <rng:zeroOrMore>
+                         
+                                  <rng:element name="ListItem">
+                                    <rng:ref name="def_nonempty_string"/>
+                                    <rng:attribute name="ListItem">
+                                      <rng:ref name="def_int_ge0"/>
+                                    </rng:attribute>
+                                    <rng:attribute name="Language">
+                                      <rng:data type="language">
+                                        <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+                         
+                                  </rng:element>
+                                </rng:zeroOrMore>
+                         
+                                <rng:optional>
+                                  <rng:element name="Text">
+                                    <rng:ref name="def_nonempty_string"/>
+                                  </rng:element>
+                                </rng:optional>
+                         
+                              </rng:choice>
+                         
+                              <rng:attribute name="Name">
+                                <rng:choice>
+                                  <rng:value>included services</rng:value>
+                                  <rng:value>customer comment</rng:value>
+                                </rng:choice>
+                              </rng:attribute>
+                         
+                            </rng:element>
+                          </rng:oneOrMore>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <!-- HotelReservation > ResGlobalInfo > CancelPenalties {0,1} -->
+
+                      <rng:optional>
+                        <rng:element name="CancelPenalties">
+                          <rng:element name="CancelPenalty">
+                            <rng:element name="PenaltyDescription">
+                              <rng:element name="Text">
+                                <rng:ref name="def_nonempty_string"/>
+                              </rng:element>
+                            </rng:element>
+                          </rng:element>
+                        </rng:element>
+                      </rng:optional>
+
+                      <!-- HotelReservation > ResGlobalInfo > HotelReservationIDs {0,1} -->
+
+                      <rng:optional>
+                        <rng:element name="HotelReservationIDs">
+
+                          <rng:oneOrMore>
+                            <rng:element name="HotelReservationID">
+                          
+                              <rng:attribute name="ResID_Type">
+                                  <rng:ref name="def_int_gt0"/>
+                              </rng:attribute>
+                              <rng:optional>
+                                <rng:attribute name="ResID_Value">
+                                  <rng:ref name="def_nonempty_string"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="ResID_Source">
+                                  <rng:ref name="def_nonempty_string"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="ResID_SourceContext">
+                                  <rng:ref name="def_nonempty_string"/>
+                                </rng:attribute>
+                              </rng:optional>
+                          
+                            </rng:element>
+                          </rng:oneOrMore>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <!-- HotelReservation > ResGlobalInfo > Profiles {0,1} -->
+
+                      <rng:optional>
+                        <rng:element name="Profiles">
+                          <rng:element name="ProfileInfo">
+                            <rng:element name="Profile">
+                          
+                              <rng:attribute name="ProfileType">
+                                <rng:choice>
+                                  <rng:value>4</rng:value>
+                                </rng:choice>
+                              </rng:attribute>
+                          
+                              <rng:element name="CompanyInfo">
+                          
+                                  <rng:element name="CompanyName">
+                                    <rng:ref name="def_nonempty_string"/>
+                                    <rng:attribute name="Code">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:attribute>
+                                    <rng:attribute name="CodeContext">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:attribute>
+                                  </rng:element>
+                          
+                                  <rng:optional>
+                                    <rng:element name="AddressInfo">
+                                      <rng:element name="AddressLine">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                      <rng:element name="CityName">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                      <rng:element name="PostalCode">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                      <rng:element name="CountryName">
+                                        <rng:attribute name="Code">
+                                          <rng:data type="string">
+                                            <rng:param name="pattern">[A-Z][A-Z]</rng:param>
+                                          </rng:data>
+                                        </rng:attribute>
+                                      </rng:element>
+                                    </rng:element>
+                                  </rng:optional>
+                          
+                                  <rng:optional>
+                                    <rng:element name="TelephoneInfo">
+                                      <rng:attribute name="PhoneTechType">
+                                        <rng:data type="string">
+                                          <rng:param name="pattern">(1|3|5)</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                      <rng:attribute name="PhoneNumber">
+                                        <rng:data type="string">
+                                          <rng:param name="pattern">\+?[0-9]+</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                    </rng:element>
+                                  </rng:optional>
+                                  <rng:optional>
+                                    <rng:element name="Email">
+                                      <rng:ref name="def_email_string"/>
+                                    </rng:element>
+                                  </rng:optional>
+                          
+                              </rng:element>
+                          
+                            </rng:element>
+                          </rng:element>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <rng:element name="BasicPropertyInfo">
+                        <rng:empty/>
+                      </rng:element>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:attribute name="CreateDateTime">
+                    <rng:ref name="def_datetime"/>
+                  </rng:attribute>
+                  <rng:attribute name="ResStatus">
+                    <rng:choice>
+                      <rng:value>Requested</rng:value>
+                      <rng:value>Reserved</rng:value>
+                      <rng:value>Cancelled</rng:value>
+                      <rng:value>Modify</rng:value>
+                    </rng:choice>
+                  </rng:attribute>
+
+                </rng:element>
+              </rng:zeroOrMore>
+
+            </rng:element>
+          </rng:group>
+
+        </rng:choice>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- GuestRequests: OTA_NotifReportRQ -->
+
+      <rng:element name="OTA_NotifReportRQ">
+
+        <rng:element name="Success">
+          <rng:empty/>
+        </rng:element>
+
+        <rng:optional>
+          <rng:element name="Warnings">
+        
+            <!-- Warnings > Warning {1,} -->
+
+            <rng:oneOrMore>
+              <rng:element name="Warning">
+          
+                <rng:attribute name="Type">
+                  <rng:ref name="def_int_gt0"/>
+                </rng:attribute>
+
+                <rng:attribute name="Code">
+                  <rng:ref name="def_int_gt0"/>
+                </rng:attribute>
+
+                  <rng:attribute name="RecordID">
+                    <rng:ref name="def_nonempty_string"/>
+                  </rng:attribute>
+
+                <rng:text/>
+          
+              </rng:element>
+            </rng:oneOrMore>
+
+          </rng:element>
+        </rng:optional>
+
+        <rng:optional>
+          <rng:element name="NotifDetails">
+
+            <rng:element name="HotelNotifReport">
+
+              <rng:element name="HotelReservations">
+
+                <rng:oneOrMore>
+                  <rng:element name="HotelReservation">
+
+                    <rng:element name="UniqueID">
+
+                      <rng:attribute name="Type">
+                        <rng:choice>
+                          <rng:value>14</rng:value>
+                          <rng:value>15</rng:value>
+                        </rng:choice>
+                      </rng:attribute>
+                      <rng:attribute name="ID">
+                        <rng:ref name="def_nonempty_string"/>
+                      </rng:attribute>
+
+                    </rng:element>
+
+                  </rng:element>
+                </rng:oneOrMore>
+
+              </rng:element>
+
+            </rng:element>
+
+          </rng:element>
+
+        </rng:optional>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- GuestRequests: OTA_NotifReportRS -->
+
+      <rng:element name="OTA_NotifReportRS">
+
+        <rng:choice>
+
+          <!-- choice: Errors {1} -->
+
+          <rng:element name="Errors">
+
+            <!-- Errors > Error {1,} -->
+
+            <rng:oneOrMore>
+              <rng:element name="Error">
+
+                <rng:attribute name="Type">
+                  <rng:value type="string">13</rng:value>
+                </rng:attribute>
+                <rng:attribute name="Code">
+                  <rng:ref name="def_int_ge0"/>
+                </rng:attribute>
+
+                <rng:text/>
+
+              </rng:element>
+
+            </rng:oneOrMore>
+
+          </rng:element>
+
+          <!-- choice: Success {1} -->
+
+          <rng:element name="Success">
+            <rng:empty/>
+          </rng:element>
+
+        </rng:choice>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+ 
+      </rng:element>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * Inventory/Basic (Push) and Inventory/HotelInfo (Push)                         -->
+      <!-- ******************************************************************************* -->
+
+      <!-- Inventory: OTA_HotelDescriptiveContentNotifRQ -->
+
+      <rng:element name="OTA_HotelDescriptiveContentNotifRQ">
+
+        <rng:ref name="def_hoteldescriptivecontents"/>
+        
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- Inventory: OTA_HotelDescriptiveContentNotifRS -->
+
+      <rng:element name="OTA_HotelDescriptiveContentNotifRS">
+
+        <rng:ref name="def_generic_response"/>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * Inventory/Basic (Pull) and Inventory/HotelInfo (Pull)                         -->
+      <!-- ******************************************************************************* -->
+
+      <!-- Inventory: OTA_HotelDescriptiveInfoRQ -->
+
+      <rng:element name="OTA_HotelDescriptiveInfoRQ">
+
+        <rng:element name="HotelDescriptiveInfos">
+
+          <rng:element name="HotelDescriptiveInfo">
+            <rng:oneOrMore>
+              <rng:choice>
+                <rng:attribute name="HotelCode">
+                  <rng:ref name="def_nonempty_string"/>
+                </rng:attribute>
+                <rng:attribute name="HotelName">
+                  <rng:ref name="def_nonempty_string"/>
+                </rng:attribute>
+              </rng:choice>
+            </rng:oneOrMore>
+          </rng:element>
+
+        </rng:element>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+       
+      <!-- Inventory: OTA_HotelDescriptiveInfoRS -->
+
+      <rng:element name="OTA_HotelDescriptiveInfoRS">
+
+        <rng:choice>
+
+          <!-- choice: Errors {1} -->
+       
+          <rng:element name="Errors">
+        
+            <!-- Errors > Error {1,} -->
+       
+            <rng:oneOrMore>
+              <rng:element name="Error">
+       
+                <rng:attribute name="Type">
+                  <rng:value type="string">13</rng:value>
+                </rng:attribute>
+                <rng:attribute name="Code">
+                  <rng:ref name="def_int_gt0"/>
+                </rng:attribute>
+       
+                <rng:text/>
+       
+              </rng:element>
+            </rng:oneOrMore>
+       
+          </rng:element>
+       
+          <!-- choice: Success {1} + HotelDescriptiveContents {1} -->
+       
+          <rng:group>
+       
+            <rng:element name="Success">
+              <rng:empty/>
+            </rng:element>
+       
+            <rng:ref name="def_hoteldescriptivecontents"/>
+      
+          </rng:group>
+
+        </rng:choice>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+ 
+      <!-- ******************************************************************************* -->
+      <!-- * RatePlans                                                                     -->
+      <!-- ******************************************************************************* -->
+
+      <!-- RatePlans: OTA_HotelRatePlanNotifRQ  --> 
+
+      <rng:element name="OTA_HotelRatePlanNotifRQ">
+
+        <!-- UniqueID {0,1} -->
+
+        <rng:optional>
+          <rng:element name="UniqueID">
+
+            <rng:attribute name="Type">
+              <rng:value type="string">16</rng:value>
+            </rng:attribute>
+            <rng:attribute name="ID"/> <!-- an ID is required by OTA, we ignore the value -->
+            <rng:attribute name="Instance">
+              <rng:value type="string">CompleteSet</rng:value>
+            </rng:attribute>
+
+          </rng:element>
+        </rng:optional>
+
+        <!-- RatePlans {1} -->
+
+        <rng:ref name="def_rateplans"/>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- RatePlans: OTA_HotelRatePlanNotifRS -->
+
+      <rng:element name="OTA_HotelRatePlanNotifRS">
+
+        <rng:ref name="def_generic_response"/>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * BaseRates                                                                     -->
+      <!-- ******************************************************************************* -->
+
+      <!-- BaseRates: OTA_HotelRatePlanRQ --> 
+
+      <rng:element name="OTA_HotelRatePlanRQ">
+
+        <!-- RatePlans {1} -->
+
+        <rng:element name="RatePlans">
+
+          <!-- RatePlans > RatePlan {1} -->
+
+          <rng:element name="RatePlan">
+
+            <rng:oneOrMore>
+              <rng:choice>
+
+                <rng:element name="DateRange">
+                  <rng:optional>
+                    <rng:attribute name="Start">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="End">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+                </rng:element>
+
+                <rng:element name="RatePlanCandidates">
+                  <rng:oneOrMore>
+                    <rng:element name="RatePlanCandidate">
+                      <rng:optional>
+                         <rng:attribute name="RatePlanCode">
+                           <rng:ref name="def_nonempty_string"/>
+                         </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                         <rng:attribute name="RatePlanID">
+                           <rng:ref name="def_nonempty_string"/>
+                         </rng:attribute>
+                      </rng:optional>
+                    </rng:element>
+                  </rng:oneOrMore>
+                </rng:element>
+
+                <rng:element name="HotelRef">
+                  <rng:optional>
+                     <rng:attribute name="HotelCode">
+                       <rng:ref name="def_nonempty_string"/>
+                     </rng:attribute>
+                   </rng:optional>
+                  <rng:optional>
+                     <rng:attribute name="HotelName">
+                       <rng:ref name="def_nonempty_string"/>
+                     </rng:attribute>
+                  </rng:optional>
+                </rng:element>
+
+              </rng:choice>
+            </rng:oneOrMore>
+ 
+          </rng:element> <!-- close RatePlan -->
+
+        </rng:element> <!-- close RatePlans -->
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element> 
+
+      <!-- BaseRates: OTA_HotelRatePlanRS -->
+
+      <rng:element name="OTA_HotelRatePlanRS">
+
+        <rng:choice>
+
+          <!-- choice: Errors {1} -->
+       
+          <rng:element name="Errors">
+        
+            <!-- Errors > Error {1,} -->
+       
+            <rng:oneOrMore>
+              <rng:element name="Error">
+       
+                <rng:attribute name="Type">
+                  <rng:value type="string">13</rng:value>
+                </rng:attribute>
+                <rng:attribute name="Code">
+                  <rng:ref name="def_int_gt0"/>
+                </rng:attribute>
+       
+                <rng:text/>
+       
+              </rng:element>
+            </rng:oneOrMore>
+       
+          </rng:element>
+       
+          <!-- choice: Success {1} + RatePlans {1} -->
+       
+          <rng:group>
+       
+            <rng:element name="Success">
+              <rng:empty/>
+            </rng:element>
+       
+            <rng:ref name="def_rateplans"/>
+      
+          </rng:group>
+
+        </rng:choice>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+ 
+    </rng:choice>
+  </rng:start>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for HotelDescriptiveContents element as used                -->
+  <!-- * in the Inventory types                                                        -->
+  <!-- ******************************************************************************* -->
+
+  <rng:define name="def_hoteldescriptivecontents">
+
+    <rng:element name="HotelDescriptiveContents">
+
+      <rng:element name="HotelDescriptiveContent">
+
+          <!-- HotelInfo -->
+
+          <rng:optional>
+            <rng:element name="HotelInfo">
+              <rng:zeroOrMore>
+                <rng:ref name="def_anything"/>
+              </rng:zeroOrMore>
+              <rng:zeroOrMore>
+                <rng:ref name="def_any_attribute"/>
+              </rng:zeroOrMore>
+            </rng:element>
+          </rng:optional>
+
+          <!-- FacilityInfo --> 
+
+          <rng:optional>
+            <rng:element name="FacilityInfo">
+       
+                <rng:element name="GuestRooms">
+                  
+                  <rng:zeroOrMore>
+                    <rng:choice>
+       
+                      <!-- basic content + basic descriptions + optionally additional description -->
+                      <rng:element name="GuestRoom">
+       
+                        <rng:element name="TypeRoom">
+                          <rng:optional>
+                            <rng:attribute name="StandardOccupancy">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="RoomClassificationCode">
+                              <rng:ref name="def_int_ge0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="RoomID">
+                              <rng:ref name="def_nonempty_string"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Size">
+                              <rng:ref name="def_int_ge0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                        </rng:element>
+       
+                        <rng:optional>
+                          <rng:element name="Amenities">
+                            <rng:oneOrMore>
+                              <rng:element name="Amenity">
+                                  <rng:optional>
+                                    <rng:attribute name="RoomAmenityCode">
+                                      <rng:ref name="def_int_gt0"/>
+                                    </rng:attribute>
+                                  </rng:optional>
+                              </rng:element>
+                            </rng:oneOrMore>
+                          </rng:element>
+                        </rng:optional>
+       
+                        <rng:optional>
+                          <rng:element name="MultimediaDescriptions">
+       
+                            <rng:oneOrMore>
+       
+                              <rng:choice>
+       
+                                <!-- basic description: Long name + Description -->
+                                <rng:element name="MultimediaDescription">
+       
+                                  <rng:optional>
+                                    <rng:element name="TextItems">
+                                      <rng:element name="TextItem">
+                                        <rng:zeroOrMore>
+                                          <rng:element name="Description">
+                                            <rng:ref name="def_nonempty_string"/>
+                                            <rng:attribute name="TextFormat">
+                                              <rng:choice>
+                                                <rng:value>PlainText</rng:value>
+                                              </rng:choice>
+                                            </rng:attribute>
+                                            <rng:attribute name="Language">
+                                              <rng:data type="language">
+                                                <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                              </rng:data>
+                                            </rng:attribute>
+                                          </rng:element>
+                                        </rng:zeroOrMore>
+                                      </rng:element>
+                                    </rng:element>
+                                  </rng:optional>
+       
+                                  <rng:optional>
+                                    <rng:attribute name="InfoCode">
+                                      <rng:choice>
+                                        <rng:value>1</rng:value>
+                                        <rng:value>25</rng:value>
+                                      </rng:choice>
+                                    </rng:attribute>
+                                  </rng:optional>
+       
+                                </rng:element>
+       
+                                <!-- basic description: Pictures -->
+                                <rng:element name="MultimediaDescription">
+       
+                                  <rng:optional>
+                                    <rng:element name="ImageItems">
+
+                                      <rng:oneOrMore>
+                                        <rng:element name="ImageItem">
+                                          <rng:element name="ImageFormat">
+                                            <rng:element name="URL">
+                                              <rng:ref name="def_url_string"/>
+                                            </rng:element>
+                                            <rng:optional>
+                                              <rng:attribute name="CopyrightNotice">
+                                                <rng:ref name="def_nonempty_string"/>
+                                              </rng:attribute>
+                                            </rng:optional>
+                                          </rng:element>
+                                      
+                                          <rng:zeroOrMore>
+                                            <rng:element name="Description">
+                                              <rng:ref name="def_nonempty_string"/>
+                                              <rng:attribute name="TextFormat">
+                                                <rng:choice>
+                                                  <rng:value>PlainText</rng:value>
+                                                </rng:choice>
+                                              </rng:attribute>
+                                              <rng:attribute name="Language">
+                                                <rng:data type="language">
+                                                  <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                                </rng:data>
+                                              </rng:attribute>
+                                            </rng:element>
+                                          </rng:zeroOrMore>
+                                      
+                                          <rng:attribute name="Category">
+                                            <rng:ref name="def_int_gt0"/>
+                                          </rng:attribute>
+
+                                        </rng:element>
+                                      </rng:oneOrMore>
+
+                                    </rng:element>
+                                  </rng:optional>
+       
+                                  <rng:optional>
+                                    <rng:attribute name="InfoCode">
+                                      <rng:choice>
+                                        <rng:value>23</rng:value>
+                                      </rng:choice>
+                                    </rng:attribute>
+                                  </rng:optional>
+       
+                                </rng:element>
+       
+                                <!-- additional description -->
+                                <rng:element name="MultimediaDescription">
+       
+                                  <rng:optional>
+                                    <rng:element name="ImageItems">
+                                  
+                                      <rng:oneOrMore>
+                                        <rng:element name="ImageItem">
+                                          <rng:element name="ImageFormat">
+                                            <rng:element name="URL">
+                                              <rng:ref name="def_url_string"/>
+                                            </rng:element>
+                                            <rng:optional>
+                                              <rng:attribute name="CopyrightNotice">
+                                                <rng:ref name="def_nonempty_string"/>
+                                              </rng:attribute>
+                                            </rng:optional>
+                                          </rng:element>
+                                  
+                                          <rng:zeroOrMore>
+                                            <rng:element name="Description">
+                                              <rng:ref name="def_nonempty_string"/>
+                                              <rng:attribute name="TextFormat">
+                                                <rng:choice>
+                                                  <rng:value>PlainText</rng:value>
+                                                </rng:choice>
+                                              </rng:attribute>
+                                              <rng:attribute name="Language">
+                                                <rng:data type="language">
+                                                  <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                                </rng:data>
+                                              </rng:attribute>
+                                            </rng:element>
+                                          </rng:zeroOrMore>
+                                  
+                                          <rng:attribute name="Category">
+                                            <rng:ref name="def_int_gt0"/>
+                                          </rng:attribute>
+                                        </rng:element>
+                                      </rng:oneOrMore>
+                                  
+                                    </rng:element>
+                                  </rng:optional>
+       
+                                </rng:element>
+       
+                              </rng:choice>
+                            </rng:oneOrMore>
+       
+                          </rng:element>
+                        </rng:optional>
+       
+                        <rng:attribute name="Code">
+                          <rng:ref name="def_invTypeCode_string"/>
+                        </rng:attribute>
+                        <rng:optional>
+                          <rng:attribute name="MaxOccupancy">
+                            <rng:ref name="def_int_gt0"/>
+                          </rng:attribute>
+                        </rng:optional>
+                        <rng:optional>
+                          <rng:attribute name="MinOccupancy">
+                            <rng:ref name="def_int_gt0"/>
+                          </rng:attribute>
+                        </rng:optional>
+                        <rng:optional>
+                          <rng:attribute name="MaxChildOccupancy">
+                            <rng:ref name="def_int_gt0"/>
+                          </rng:attribute>
+                        </rng:optional>
+                        <rng:optional>
+                          <rng:attribute name="ID">
+                            <rng:ref name="def_invTypeCode_string"/>
+                          </rng:attribute>
+                        </rng:optional>
+
+                      </rng:element>
+       
+                      <!-- additional detail only -->
+                      <rng:element name="GuestRoom">
+       
+                        <rng:element name="MultimediaDescriptions">
+                          <rng:element name="MultimediaDescription">
+                            <rng:element name="ImageItems">
+       
+                              <rng:oneOrMore>
+                                <rng:element name="ImageItem">
+                                  <rng:element name="ImageFormat">
+                                    <rng:element name="URL">
+                                      <rng:ref name="def_url_string"/>
+                                    </rng:element>
+                                    <rng:optional>
+                                      <rng:attribute name="CopyrightNotice">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:attribute>
+                                    </rng:optional>
+                                  </rng:element>
+       
+                                  <rng:zeroOrMore>
+                                    <rng:element name="Description">
+                                      <rng:ref name="def_nonempty_string"/>
+                                      <rng:attribute name="TextFormat">
+                                        <rng:choice>
+                                          <rng:value>PlainText</rng:value>
+                                        </rng:choice>
+                                      </rng:attribute>
+                                      <rng:attribute name="Language">
+                                        <rng:data type="language">
+                                          <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                    </rng:element>
+                                  </rng:zeroOrMore>
+       
+                                  <rng:attribute name="Category">
+                                    <rng:ref name="def_int_gt0"/>
+                                  </rng:attribute>
+                                </rng:element>
+                              </rng:oneOrMore>
+       
+                            </rng:element>
+                          </rng:element>
+                        </rng:element>
+       
+                      <rng:attribute name="Code">
+                        <rng:ref name="def_nonempty_string"/>
+                      </rng:attribute>
+                      </rng:element>
+       
+                      <!-- room list -->
+                      <rng:element name="GuestRoom">
+                        <rng:element name="TypeRoom">
+                          <rng:attribute name="RoomID">
+                            <rng:ref name="def_nonempty_string"/>
+                          </rng:attribute>
+                        </rng:element>
+                      <rng:attribute name="Code">
+                        <rng:ref name="def_nonempty_string"/>
+                      </rng:attribute>
+                      </rng:element>
+       
+                    </rng:choice>
+                  </rng:zeroOrMore>
+                  
+                </rng:element>
+            </rng:element>
+          </rng:optional>
+       
+          <!-- Policies -->
+
+          <rng:optional>
+            <rng:element name="Policies">
+              <rng:zeroOrMore>
+                <rng:ref name="def_anything"/>
+              </rng:zeroOrMore>
+              <rng:zeroOrMore>
+                <rng:ref name="def_any_attribute"/>
+              </rng:zeroOrMore>
+            </rng:element>
+          </rng:optional>
+
+          <!-- AffiliationInfo -->
+
+          <rng:optional>
+            <rng:element name="AffiliationInfo">
+              <rng:zeroOrMore>
+                <rng:ref name="def_anything"/>
+              </rng:zeroOrMore>
+              <rng:zeroOrMore>
+                <rng:ref name="def_any_attribute"/>
+              </rng:zeroOrMore>
+            </rng:element>
+          </rng:optional>
+
+
+          <!-- ContactInfos -->
+
+          <rng:optional>
+            <rng:element name="ContactInfos">
+              <rng:zeroOrMore>
+                <rng:ref name="def_anything"/>
+              </rng:zeroOrMore>
+              <rng:zeroOrMore>
+                <rng:ref name="def_any_attribute"/>
+              </rng:zeroOrMore>
+            </rng:element>
+          </rng:optional>
+
+        <rng:oneOrMore>
+          <rng:choice>
+            <rng:attribute name="HotelCode">
+              <rng:ref name="def_nonempty_string"/>
+            </rng:attribute>
+            <rng:attribute name="HotelName">
+              <rng:ref name="def_nonempty_string"/>
+            </rng:attribute>
+            <rng:attribute name="HotelCityCode">
+              <rng:ref name="def_nonempty_string"/>
+            </rng:attribute>
+          </rng:choice>
+        </rng:oneOrMore>
+
+      </rng:element>
+        
+    </rng:element>
+
+  </rng:define>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for RatePlans element as used                               -->
+  <!-- * in RatePlans and BaseRates                                                    -->
+  <!-- ******************************************************************************* -->
+
+  <rng:define name="def_rateplans">
+
+    <rng:element name="RatePlans">
+
+      <!-- RatePlans > RatePlan {1,} -->
+
+      <rng:oneOrMore>
+        <rng:element name="RatePlan">
+
+          <!-- RatePlans > RatePlan > BookingRules {0,1} -->
+
+          <rng:optional>
+            <rng:element name="BookingRules">
+
+              <rng:oneOrMore>
+                <rng:element name="BookingRule">
+
+                  <rng:optional>
+                    <rng:element name="LengthsOfStay">
+
+                      <rng:oneOrMore>
+                        <rng:element name="LengthOfStay">
+
+                          <rng:attribute name="Time">
+                            <rng:ref name="def_decimal_ge0"/>
+                          </rng:attribute>
+                          <rng:attribute name="TimeUnit">
+                            <rng:value type="string">Day</rng:value>
+                          </rng:attribute>
+                          <rng:attribute name="MinMaxMessageType">
+                            <rng:choice>
+                              <rng:value>SetMinLOS</rng:value>
+                              <rng:value>SetForwardMinStay</rng:value>
+                              <rng:value>SetMaxLOS</rng:value>
+                              <rng:value>SetForwardMaxStay</rng:value>
+                            </rng:choice>
+                          </rng:attribute>
+
+                        </rng:element>
+                      </rng:oneOrMore>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:element name="DOW_Restrictions">
+
+                      <rng:optional>
+                        <rng:element name="ArrivalDaysOfWeek">
+
+                          <rng:optional>
+                            <rng:attribute name="Mon">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Tue">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Weds">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Thur">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Fri">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Sat">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Sun">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <rng:optional>
+                        <rng:element name="DepartureDaysOfWeek">
+
+                          <rng:optional>
+                            <rng:attribute name="Mon">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Tue">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Weds">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Thur">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Fri">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Sat">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Sun">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:optional>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:element name="RestrictionStatus">
+
+                      <rng:optional>
+                        <rng:attribute name="Restriction">
+                          <rng:choice>
+                            <rng:value>Master</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="Status">
+                          <rng:choice>
+                            <rng:value>Open</rng:value>
+                            <rng:value>Close</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:optional>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="CodeContext">
+                      <rng:choice>
+                        <rng:value>ROOMTYPE</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="Code">
+                      <rng:ref name="def_invTypeCode_string"/>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="Start">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="End">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+                </rng:element>
+              </rng:oneOrMore>
+
+            </rng:element>
+          </rng:optional>
+
+          <!-- RatePlans > RatePlan > Rates {0,1} -->
+
+          <rng:optional>
+            <rng:element name="Rates">
+
+              <rng:oneOrMore>
+                <rng:element name="Rate">
+
+                  <rng:optional>
+                    <rng:element name="BaseByGuestAmts">
+
+                      <rng:oneOrMore>
+                        <rng:element name="BaseByGuestAmt">
+
+                          <rng:optional>
+                            <rng:attribute name="NumberOfGuests">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="AmountAfterTax">
+                              <rng:ref name="def_decimal_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="CurrencyCode">
+                              <rng:choice>
+                                <rng:value>EUR</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Type">
+                              <rng:choice>
+                                <rng:value>7</rng:value>
+                                <rng:value>25</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="AgeQualifyingCode">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:oneOrMore>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:element name="AdditionalGuestAmounts">
+
+                      <rng:oneOrMore>
+                        <rng:element name="AdditionalGuestAmount">
+
+                          <rng:optional>
+                            <rng:attribute name="Amount">
+                              <rng:ref name="def_decimal_ge0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="AgeQualifyingCode">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="MinAge">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="MaxAge">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:oneOrMore>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:element name="MealsIncluded">
+
+                      <rng:optional>
+                        <rng:attribute name="MealPlanCodes">
+                          <rng:choice>
+                            <rng:value>1</rng:value>
+                            <rng:value>3</rng:value>
+                            <rng:value>10</rng:value>
+                            <rng:value>12</rng:value>
+                            <rng:value>14</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="MealPlanIndicator">
+                          <rng:choice>
+                            <rng:value>1</rng:value>
+                            <rng:value>true</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:optional>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="Start">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="End">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="RateTimeUnit">
+                      <rng:choice>
+                        <rng:value type="string">Day</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="UnitMultiplier">
+                      <rng:ref name="def_int_gt0"/>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="InvTypeCode">
+                      <rng:ref name="def_invTypeCode_string"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                </rng:element>
+              </rng:oneOrMore>
+
+            </rng:element>
+          </rng:optional>
+
+          <!-- RatePlans > RatePlan > Supplements {0,1} -->
+
+          <rng:optional>
+            <rng:element name="Supplements">
+
+              <rng:oneOrMore>
+                <rng:element name="Supplement">
+
+                  <rng:optional>
+                    <rng:choice>
+                      <rng:element name="PrerequisiteInventory">
+                        <rng:attribute name="InvCode">
+                          <rng:data type="string">
+                              <rng:param name="pattern">[01]{7}</rng:param>
+                            </rng:data>
+                        </rng:attribute>
+                        <rng:attribute name="InvType">
+                          <rng:choice>
+                            <rng:value>ALPINEBITSDOW</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:element>
+                      <rng:element name="PrerequisiteInventory">
+                        <rng:attribute name="InvCode">
+                          <rng:ref name="def_invTypeCode_string"/>
+                        </rng:attribute>
+                        <rng:attribute name="InvType">
+                          <rng:choice>
+                            <rng:value>ROOMTYPE</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:element>
+                    </rng:choice>
+                  </rng:optional>
+
+                  <!-- RatePlans > RatePlan > Supplements > Supplement > Description {0,} (actually {0,5} but Relax-NG cannot do this) -->
+           
+                  <rng:zeroOrMore>
+                    <rng:element name="Description">
+           
+                      <rng:oneOrMore>
+                        <rng:choice>
+           
+                          <rng:element name="ListItem">
+                            <rng:ref name="def_nonempty_string"/>
+                          </rng:element>
+                        
+                          <rng:element name="Image">
+                            <rng:ref name="def_url_string"/>
+                          </rng:element>
+           
+                          <rng:element name="Text">
+                            <rng:ref name="def_nonempty_string"/>
+                            <rng:attribute name="TextFormat">
+                              <rng:choice>
+                                <rng:value>PlainText</rng:value>
+                                <rng:value>HTML</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+                            <rng:optional>
+                              <rng:attribute name="Language">
+                                <rng:data type="language">
+                                  <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                </rng:data>
+                              </rng:attribute>
+                            </rng:optional>
+                          </rng:element>
+           
+                          <rng:element name="URL">
+                            <rng:ref name="def_url_string"/>
+                          </rng:element>
+           
+                        </rng:choice>
+                      </rng:oneOrMore>
+           
+                      <rng:attribute name="Name">
+                        <rng:choice>
+                          <rng:value>title</rng:value>
+                          <rng:value>intro</rng:value>
+                          <rng:value>description</rng:value>
+                          <rng:value>gallery</rng:value>
+                          <rng:value>codelist</rng:value>
+                        </rng:choice>
+                      </rng:attribute>
+           
+                    </rng:element>
+                  </rng:zeroOrMore>
+
+                  <rng:optional>
+                    <rng:attribute name="AddToBasicRateIndicator">
+                      <rng:choice>
+                        <rng:value>1</rng:value>
+                        <rng:value>true</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="ChargeTypeCode">
+                      <rng:choice>
+                        <rng:value>1</rng:value>
+                        <rng:value>12</rng:value>
+                        <rng:value>18</rng:value>
+                        <rng:value>19</rng:value>
+                        <rng:value>20</rng:value>
+                        <rng:value>21</rng:value>
+                        <rng:value>24</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+                  </rng:optional>
+               
+                  <rng:optional>
+                    <rng:attribute name="Amount">
+                      <rng:ref name="def_decimal_ge0"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="InvType">
+                      <rng:choice>
+                        <rng:value>EXTRA</rng:value>
+                        <rng:value>ALPINEBITSEXTRA</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="InvCode">
+                      <rng:ref name="def_nonempty_string"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="MandatoryIndicator">
+                      <rng:ref name="def_bool"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="Start">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="End">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                </rng:element>
+              </rng:oneOrMore>
+
+            </rng:element>
+          </rng:optional>
+
+          <!-- RatePlans > RatePlan > Offers {0,1}  -->
+
+          <rng:optional>
+            <rng:element name="Offers">
+
+              <rng:oneOrMore>
+                <rng:element name="Offer">
+
+                  <rng:zeroOrMore>
+                    <rng:element name="OfferRules">
+
+                      <rng:element name="OfferRule">
+
+                        <rng:optional>
+                          <rng:element name="LengthsOfStay">
+                      
+                            <rng:oneOrMore>
+                              <rng:element name="LengthOfStay">
+                      
+                                <rng:attribute name="Time">
+                                  <rng:ref name="def_decimal_ge0"/>
+                                </rng:attribute>
+                                <rng:attribute name="TimeUnit">
+                                  <rng:value type="string">Day</rng:value>
+                                </rng:attribute>
+                                <rng:attribute name="MinMaxMessageType">
+                                  <rng:choice>
+                                    <rng:value>SetMinLOS</rng:value>
+                                    <rng:value>SetMaxLOS</rng:value>
+                                  </rng:choice>
+                                </rng:attribute>
+                      
+                              </rng:element>
+                            </rng:oneOrMore>
+                      
+                          </rng:element>
+                        </rng:optional>
+                      
+                        <rng:optional>
+                          <rng:element name="DOW_Restrictions">
+                      
+                            <rng:optional>
+                              <rng:element name="ArrivalDaysOfWeek">
+                      
+                                <rng:optional>
+                                  <rng:attribute name="Mon">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Tue">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Weds">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Thur">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Fri">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Sat">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Sun">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                      
+                              </rng:element>
+                            </rng:optional>
+                      
+                            <rng:optional>
+                              <rng:element name="DepartureDaysOfWeek">
+                      
+                                <rng:optional>
+                                  <rng:attribute name="Mon">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Tue">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Weds">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Thur">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Fri">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Sat">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Sun">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                      
+                              </rng:element>
+                            </rng:optional>
+                      
+                          </rng:element>
+                        </rng:optional>
+                    
+                        <rng:zeroOrMore>
+                          <rng:element name="Occupancy">
+                      
+                            <rng:attribute name="AgeQualifyingCode">
+                              <rng:choice>
+                                <rng:value>8</rng:value>
+                                <rng:value>10</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+
+                            <rng:optional>
+                              <rng:attribute name="MinAge">
+                                <rng:ref name="def_int_gt0"/>
+                              </rng:attribute>
+                            </rng:optional>
+
+                            <rng:optional>
+                              <rng:attribute name="MaxAge">
+                                <rng:ref name="def_int_gt0"/>
+                              </rng:attribute>
+                            </rng:optional>
+
+                            <rng:optional>
+                              <rng:attribute name="MinOccupancy">
+                                <rng:ref name="def_int_ge0"/>
+                              </rng:attribute>
+                            </rng:optional>
+
+                            <rng:optional>
+                              <rng:attribute name="MaxOccupancy">
+                                <rng:ref name="def_int_gt0"/>
+                              </rng:attribute>
+                            </rng:optional>
+ 
+                          </rng:element>
+                        </rng:zeroOrMore>
+                      
+                        <rng:optional>
+                          <rng:attribute name="MinAdvancedBookingOffset">
+                            <rng:data type="string">
+                              <rng:param name="pattern">P[0-9]+D</rng:param>
+                            </rng:data>
+                          </rng:attribute>
+                        </rng:optional>
+ 
+                        <rng:optional>
+                          <rng:attribute name="MaxAdvancedBookingOffset">
+                            <rng:data type="string">
+                              <rng:param name="pattern">P[0-9]+D</rng:param>
+                            </rng:data>
+                          </rng:attribute>
+                        </rng:optional>
+
+                       </rng:element>
+                    </rng:element>
+                  </rng:zeroOrMore>
+
+                  <rng:optional>
+                    <rng:element name="Discount">
+                
+                      <rng:attribute name="Percent">
+                        <rng:value type="string">100</rng:value>
+                      </rng:attribute>
+                      <rng:optional>
+                        <rng:attribute name="NightsRequired">
+                          <rng:ref name="def_int_gt0"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="NightsDiscounted">
+                          <rng:ref name="def_int_gt0"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="DiscountPattern">
+                          <rng:data type="string">
+                            <rng:param name="pattern">0*1*</rng:param>
+                          </rng:data>
+                        </rng:attribute>
+                      </rng:optional>
+                
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:element name="Guests">
+
+                      <rng:element name="Guest">
+
+                        <rng:attribute name="AgeQualifyingCode">
+                          <rng:ref name="def_int_gt0"/>
+                        </rng:attribute>
+                        <rng:attribute name="MaxAge">
+                          <rng:ref name="def_int_gt0"/>
+                        </rng:attribute>
+                        <rng:attribute name="MinCount">
+                          <rng:ref name="def_int_ge0"/>
+                        </rng:attribute>
+                        <rng:attribute name="FirstQualifyingPosition">
+                          <rng:choice>
+                            <rng:value>1</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                        <rng:attribute name="LastQualifyingPosition">
+                          <rng:ref name="def_int_gt0"/>
+                        </rng:attribute>
+
+                      </rng:element> 
+
+                    </rng:element> 
+                  </rng:optional>
+
+                </rng:element>  <!-- close Offer -->
+              </rng:oneOrMore>
+
+            </rng:element>  <!-- close Offers -->
+          </rng:optional>
+
+          <!-- RatePlans > RatePlan > Description {0,} (actually {0,5} but Relax-NG cannot do this) -->
+
+          <rng:zeroOrMore>
+            <rng:element name="Description">
+
+              <rng:oneOrMore>
+                <rng:choice>
+
+                  <rng:element name="ListItem">
+                    <rng:ref name="def_nonempty_string"/>
+                  </rng:element>
+                
+                  <rng:element name="Image">
+                    <rng:ref name="def_url_string"/>
+                  </rng:element>
+
+                  <rng:element name="Text">
+                    <rng:ref name="def_nonempty_string"/>
+                    <rng:attribute name="TextFormat">
+                      <rng:choice>
+                        <rng:value>PlainText</rng:value>
+                        <rng:value>HTML</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+                    <rng:optional>
+                      <rng:attribute name="Language">
+                        <rng:data type="language">
+                          <rng:param name="pattern">[a-z][a-z]</rng:param>
+                        </rng:data>
+                      </rng:attribute>
+                    </rng:optional>
+                  </rng:element>
+
+                  <rng:element name="URL">
+                    <rng:ref name="def_url_string"/>
+                  </rng:element>
+
+                </rng:choice>
+              </rng:oneOrMore>
+
+              <rng:attribute name="Name">
+                <rng:choice>
+                  <rng:value>title</rng:value>
+                  <rng:value>intro</rng:value>
+                  <rng:value>description</rng:value>
+                  <rng:value>gallery</rng:value>
+                  <rng:value>codelist</rng:value>
+                </rng:choice>
+              </rng:attribute>
+
+            </rng:element>
+          </rng:zeroOrMore>
+ 
+          <rng:optional>
+            <rng:attribute name="RatePlanNotifType">
+              <rng:choice>
+                <rng:value>Overlay</rng:value>
+                <rng:value>New</rng:value>
+                <rng:value>Remove</rng:value>
+              </rng:choice>
+            </rng:attribute>
+          </rng:optional>
+          <rng:optional>
+            <rng:attribute name="CurrencyCode">
+              <rng:choice>
+                <rng:value>EUR</rng:value>
+              </rng:choice>
+            </rng:attribute>
+          </rng:optional>
+          <rng:optional>
+            <rng:attribute name="RatePlanCode">
+              <rng:ref name="def_nonempty_string"/>
+            </rng:attribute>
+          </rng:optional>
+          <rng:optional>
+            <rng:attribute name="RatePlanType">
+              <rng:choice>
+                <rng:value>12</rng:value>
+              </rng:choice>
+            </rng:attribute>
+          </rng:optional>
+          <rng:optional>
+            <rng:attribute name="RatePlanCategory">
+              <rng:ref name="def_nonempty_string"/>
+            </rng:attribute>
+          </rng:optional>
+          <rng:optional>
+            <rng:attribute name="RatePlanID">
+              <rng:ref name="def_nonempty_string"/>
+            </rng:attribute>
+          </rng:optional>
+          <rng:optional>
+            <rng:attribute name="RatePlanQualifier">
+              <rng:ref name="def_bool"/>
+            </rng:attribute>
+          </rng:optional>
+
+        </rng:element>
+      </rng:oneOrMore>
+
+      <rng:oneOrMore>
+        <rng:choice>
+          <rng:attribute name="HotelCode">
+            <rng:ref name="def_nonempty_string"/>
+          </rng:attribute>
+          <rng:attribute name="HotelName">
+            <rng:ref name="def_nonempty_string"/>
+          </rng:attribute>
+        </rng:choice>
+      </rng:oneOrMore>
+
+    </rng:element>
+
+  </rng:define>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for success/advisory/warning/error responses                -->
+  <!-- ******************************************************************************* -->
+
+  <rng:define name="def_generic_response">
+    <rng:choice>
+
+      <!-- choice: Errors {1} -->
+
+      <rng:element name="Errors">
+    
+        <!-- Errors > Error {1,} -->
+
+        <rng:oneOrMore>
+          <rng:element name="Error">
+
+            <rng:attribute name="Type">
+              <rng:value type="string">13</rng:value>
+            </rng:attribute>
+            <rng:attribute name="Code">
+              <rng:ref name="def_int_gt0"/>
+            </rng:attribute>
+
+            <rng:text/>
+
+          </rng:element>
+        </rng:oneOrMore>
+
+      </rng:element>
+
+      <!-- choice: Success {1} + Warnings {0,1} -->
+
+      <rng:group>
+
+        <rng:element name="Success">
+          <rng:empty/>
+        </rng:element>
+
+        <rng:optional>
+          <rng:element name="Warnings">
+        
+            <!-- Warnings > Warning {1,} -->
+
+            <rng:oneOrMore>
+              <rng:element name="Warning">
+          
+                <rng:attribute name="Type">
+                  <rng:ref name="def_int_gt0"/>
+                </rng:attribute>
+
+                <rng:optional>
+                  <rng:attribute name="RecordID">
+                    <rng:ref name="def_nonempty_string"/>
+                  </rng:attribute>
+                </rng:optional>
+
+                <rng:text/>
+          
+              </rng:element>
+            </rng:oneOrMore>
+
+          </rng:element>
+        </rng:optional>
+
+      </rng:group>
+
+    </rng:choice>
+  </rng:define>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for recurring, simple types                                 -->
+  <!-- ******************************************************************************* -->
+
+  <!-- A generic non-empty string type. -->
+
+  <rng:define name="def_nonempty_string">
+    <rng:data type="string">
+      <rng:param name="minLength">1</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic string type containing an @ char, like an email address. -->
+
+  <rng:define name="def_email_string">
+    <rng:data type="string">
+      <rng:param name="pattern">\S+@\S+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic string type starting with http:// or https:// --> 
+
+  <rng:define name="def_url_string">
+    <rng:data type="string">
+      <rng:param name="pattern">https?://.+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- String type defining room category codes (like InvTypeCode)  -->
+
+  <rng:define name="def_invTypeCode_string">
+    <rng:data type="string">
+      <rng:param name="minLength">1</rng:param>
+      <rng:param name="maxLength">8</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic integer > 0 type. -->
+
+  <rng:define name="def_int_gt0">
+    <rng:data type="positiveInteger">
+      <rng:param name="pattern">[0-9]+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic integer >= 0 type. -->
+
+  <rng:define name="def_int_ge0">
+    <rng:data type="nonNegativeInteger">
+      <rng:param name="pattern">[0-9]+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic decimal >= 0 type. -->
+
+  <rng:define name="def_decimal_ge0">
+    <rng:data type="decimal">
+      <rng:param name="minInclusive">0.0</rng:param>
+      <rng:param name="pattern">[0-9]*\.?[0-9]*</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic decimal > 0 type. -->
+
+  <rng:define name="def_decimal_gt0">
+    <rng:data type="decimal">
+      <rng:param name="minExclusive">0.0</rng:param>
+      <rng:param name="pattern">[0-9]*\.?[0-9]*</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic date type. -->
+
+  <rng:define name="def_date">
+    <rng:data type="date">
+      <rng:param name="pattern">\S+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic datetime type. -->
+
+  <rng:define name="def_datetime">
+    <rng:data type="dateTime">
+      <rng:param name="pattern">\S+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic boolean type (1,true,0,false). -->
+
+  <rng:define name="def_bool">
+    <rng:data type="boolean">
+      <rng:param name="pattern">\S+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- Anything. -->
+
+  <rng:define name="def_anything">
+    <rng:interleave>
+      <rng:zeroOrMore>
+        <rng:element>
+          <rng:anyName/>
+          <rng:zeroOrMore>
+            <rng:ref name="def_anything"/>
+          </rng:zeroOrMore>
+          <rng:zeroOrMore>
+            <rng:ref name="def_any_attribute"/>
+          </rng:zeroOrMore>
+        </rng:element>
+      </rng:zeroOrMore>
+    <rng:text/>
+    </rng:interleave>
+  </rng:define>
+
+  <rng:define name="def_any_attribute">
+    <rng:attribute>
+      <rng:anyName/>
+    </rng:attribute>
+  </rng:define>
+
+</rng:grammar>
+

--- a/alpinebits-xml/impl/src/test/resources/schema/alpinebits-2017-10-invalid.xsd
+++ b/alpinebits-xml/impl/src/test/resources/schema/alpinebits-2017-10-invalid.xsd
@@ -1,0 +1,2406 @@
+!!!!Invalid XML, therefor invalid XSD
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2017-10
+     http://www.alpinebits.org/
+
+     W3C XML Schema file
+
+     changelog:
+
+    v. 2017-10  1.1 -  RatePlans:       RatePlans > RatePlan > Offers: allow only MinLOS and MaxLOS attributes (not the forward ones too)
+
+    v. 2017-10  1.0 -  FreeRooms:       OTA_HotelAvailNotifRQ -> UniqueID (added allowed value to attribute Type, by Luca Rainone)
+                       FreeRooms:       OTA_HotelAvailNotifRQ -> AvailStatusMessages -> ...  -> StatusApplicationControl (added new mandatory attribute BookingThreshold)
+
+                       GuestRequests:   OTA_ResRetrieveRS -> ReservationsList -> ... -> RatePlan (added element Commission)
+                       GuestRequests:   OTA_ResRetrieveRS -> ReservationsList -> ... -> CardNumber (added attributes EncryptedValue and EncryptionMethod) 
+                       GuestRequests:   OTA_ResRetrieveRS -> ReservationsList -> ... -> RoomStay > RoomTypes (made optional)
+
+                       SimplePackages section removed
+
+                       Inventory has become Inventory/Basic (Push) and Inventory/HotelInfo (Push):
+                                        OTA_HotelDescriptiveContentNotifRQ (major changes, one being that empty GuestRooms elements are now allowed by Luca Rainone)
+
+                       Inventory/Basic (Pull) and Inventory/HotelInfo (Pull) added
+ 
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> BookingRules -> ... -> LengthOfStay (added allowed values to attribute MinMaxMessageType)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Supplements -> Supplement (added element PrerequisiteInventory)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Supplements -> Supplement -> Description (major changes)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Offers -> Offer (major changes)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Description (major changes)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> ... -> BaseByGuestAmt (NumberOfGuests and Type are optional now to allow static rates)
+
+                       BaseRates section added
+
+    v. 2015-07b 1.4 - weaken the schema for Inventory (to prepare for upcoming release that will support Inventory deltas):
+
+                      - the RoomAmenityCode attribute becomes optional to allow empty Amenity elements 
+                      - the MultimediaDescription element can be empty
+
+    v. 2015-07b 1.3 - RatePlans > RatePlan > Description > TextFormat can now also be "HTML" (besides "PlainText")
+
+    v. 2015-07b 1.2 - added optional attributes RatePlanID and RatePlanQualifier to RatePlan
+                      for the new OTA_HotelRatePlanNotif_accept_RatePlanJoin capability
+
+    v. 2015-07b 1.1 - added def_invTypeCode_string type (string with up to 8 chars) used for the following attributes that identify room categories:
+
+                      FreeRooms:     OTA_HotelAvailNotifRQ -> AvailStatusMessages -> AvailStatusMessage -> StatusApplicationControl -> InvTypeCode
+                      GuestRequests: OTA_ResRetrieveRS -> ReservationList -> HotelReservation -> RoomStays -> RoomStay -> RoomTypes > RoomType -> RoomTypeCode
+                      Inventory:     OTA_HotelDescriptiveContentNotifRQ -> HotelDescriptiveContents -> HotelDescriptiveContent -> FacilityInfo -> GuestRooms -> GuestRoom -> Code
+                      RatePlan:      OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> BookingRules -> BookingRule -> Code
+                      RatePlan:      OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Rates -> Rate -> InvTypeCode
+
+                      (derived from Lukas Braun's pull request)
+
+    v. 2015-07b 1.0 - RatePlans > RatePlan > Rates > Rate > BaseByGuestAmts > AmountAfterTax
+                      must be > 0.0 (was: >= 0.0)
+
+     v. 2015-07 2.9 - Inventory: added a missing maxOccurs="unbounded" to the ImageItem
+
+     v. 2015-07 2.8 - Inventory: reconciled with the definitions given in the updated document
+
+     v. 2015-07 2.7 - changes to Inventory: removed the old Inventory, added MaxChildOccupancy to GuestRoom,
+                      made some of the attributes mandatory, formating changes
+
+     v. 2015-07 2.6 - made sub-elements of HotelReservation > ... > Customer > Address {0,1} optional
+
+     v. 2015-07 2.5 - added a choice of 'Modify' for ResStatusValue
+
+     v. 2015-07 2.4 - added MinCount attribute to Offer>>Guest
+
+     v. 2015-07 2.3 - changes to Supplement: a few attributes are removed and many attributes are made optional
+
+     v. 2015-07 2.2 - RatePlans/Supplements: changed format of description
+
+     v. 2015-07 2.1 - GuestRequests: ResGuests >> Customer: attributes Gender and Language are now optional
+
+     v. 2015-07 2.0 - allow Warnings in OTA_NotifReportRQ messages
+
+     v. 2015-07 1.9 - GuestRequests: use CardNumber -> PlainText instead of the Remark attribute of
+                      PaymentCard under Guarantee; add BasicPropertyInfo element at the end of the 
+                      ResGlobalInfo block for OTA-2015A compatiblity
+
+     v. 2015-07 1.8 - added section for New Inventory (exact name pending)
+
+     v. 2015-07 1.7 - allowed more than one HotelReservationID
+
+     v. 2015-07 1.6 - RatePlans: allow optional PrerequisiteInventory element under Supplement element
+
+     v. 2015-07 1.5 - Inventory: removed Amenities and added optional Room -> RoomTypeCode
+
+     v. 2015-07 1.4 - HotelReservationID -> ResID_Type is not limited to 13 anymore
+
+     v. 2015-07 1.3 - new section in RoomStays: Guarantee -> GuaranteesAccepted -> GuaranteeAccepted -> PaymentCard
+
+     v. 2015-07 1.2 - new section in ResGlobalInfo: Profiles -> ProfileInfo -> Profile -> CompanyInfo
+
+     v. 2015-07 1.1 - HotelReservation > RoomStays > RoomStay > RoomTypes > RoomType is now
+                      mandatory and has a new optional attribute RoomClassificationCode
+
+     v. 2015-07 1.0 - OTA_NotifReportRS besides Success, now also allows Error responses 
+
+     v. 2014-04 1.6 - [fixed] InvCode attribute in Supplement changed from def_int_ge0 to def_nonempty_string
+
+     v. 2014-04 1.5 - [strictness improvement] made NumberOfGuests attribute mandatory
+
+     v. 2014-04 1.4 - [fixed] RatePlans: optional Rate attributes RateTimeUnit and UnitMultiplier added
+
+     v. 2014-04 1.3 - [fixed] GuestRequests: ReservationsList can be empy
+
+     v. 2014-04 1.2 - follow-up to fix 1.1 that allowed empty AvailStatusMessages elements too
+                      (reverted)
+
+     v. 2014-04 1.1 - empty AvailStatusMessage elements in FreeRooms now allowed
+                      (see https://groups.google.com/d/msg/alpinebits/B-orBE9eJCk/rKyIYbNBFNoJ )
+                    - Version and TimeStamp also added to OTA_NotifReportRS 
+                      (see https://groups.google.com/d/msg/alpinebits/jwaPC3XAafo/yDDYCkpNPYEJ )
+
+     v. 2014-04 1.0 - major rewrite for 2014-04
+
+     previous changelogs:
+
+     v. 2013-04 1.0 - the XML schema is now flattened into this single file;
+                      some improvements by Martin;
+                      added optional RatePlanCode attribute to RatePlan;
+                      removed restrictions on the form of the ID attribute in UniqueID
+
+     W3C XML Schema for OTA_HotelAvailNotifRQ:
+     v. 2013-04 1.0 - added MessageContentCode attribute for delta messages
+     v. 2012-05 1.2 - changed Thu -> Thur and Wed -> Weds for OTA compatibility
+     v. 2012-05 1.1 - added optional TimeStamp attribute for OTA_HotelAvailNotifRQ to be compatible with AlpineBits 2011-11 documents
+     v. 2012-05 1.0
+      
+     W3C XML Schema for OTA_HotelAvailNotifRS:
+     v. 2013-04 1.0 - added warnings
+     v. 2012-05 1.0
+  
+     W3C XML Schema for OTA_ReadRQ:
+     v. 2012-05 1.0
+   
+     W3C XML Schema for OTA_ResRetrieveRS:
+     v. 2013-04 1.0 - simplified the definition of GuestCounts for XSD conformance,
+                      moved UniqueID and RatePlans elements to common to support schema flattening
+     v. 2012-05 1.0
+  
+     W3C XML Schema for OTA_HotelRatePlanNotifRQ:
+     v. 2013-04 1.0 - removed def_plaintext and simplified def_rate_plan to fix an issue with the parsing of the schema,
+                      moved UniqueID and RatePlans elements to common
+     v. 2012-05 1.2 - changed Thu -> Thur and Wed -> Weds for OTA compatibility
+     v. 2012-05 1.0
+  
+     W3C XML Schema for OTA_HotelRatePlanNotifRS:
+     v. 2013-04 1.0 - added warnings
+     v. 2012-05 1.0
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           targetNamespace="http://www.opentravel.org/OTA/2003/05"
+           xmlns="http://www.opentravel.org/OTA/2003/05">
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * FreeRooms                                                                     -->
+  <!-- ******************************************************************************* -->
+
+  <!-- FreeRooms: OTA_HotelAvailNotifRQ -->
+
+  <xs:element name="OTA_HotelAvailNotifRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <!-- UniqueID {0,1} -->
+
+        <xs:element name="UniqueID" minOccurs="0">
+          <xs:complexType>
+            <xs:attribute name="Type" use="required">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="16"/>
+                  <xs:enumeration value="35"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="ID" use="required" type="xs:string"/> <!-- an ID is required by OTA, we ignore the value -->
+            <xs:attribute name="Instance" use="required">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="CompleteSet"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+
+        <!-- AvailStatusMessages {1} -->
+
+        <xs:element name="AvailStatusMessages">
+          <xs:complexType>
+            <xs:sequence>
+
+              <!-- AvailStatusMessages > AvailStatusMessage (1,} -->
+              
+              <xs:element name="AvailStatusMessage" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <!-- AvailStatusMessages > AvailStatusMessage > StatusApplicationControl {0,1} -->
+
+                    <xs:element name="StatusApplicationControl" minOccurs="0">
+                      <xs:complexType>
+                        <xs:attribute name="Start"        use="required" type="def_date"/>
+                        <xs:attribute name="End"          use="required" type="def_date"/>
+                        <xs:attribute name="InvTypeCode"                 type="def_invTypeCode_string"/>
+                        <xs:attribute name="InvCode"                     type="def_nonempty_string"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                  </xs:sequence>
+                  <xs:attribute name="BookingLimitMessageType">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="SetLimit"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="BookingLimit" type="def_int_ge0"/>
+                  <xs:attribute name="BookingThreshold" type="def_int_ge0"/>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+            <xs:attribute name="HotelCode" type="def_nonempty_string"/>
+            <xs:attribute name="HotelName" type="def_nonempty_string"/>
+          </xs:complexType> 
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- FreeRooms: OTA_HotelAvailNotifRS -->
+
+  <xs:element name="OTA_HotelAvailNotifRS">
+    <xs:complexType>
+      <xs:group   ref="def_generic_response"/>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * GuestRequests                                                                 -->
+  <!-- ******************************************************************************* -->
+
+  <!-- GuestRequests: OTA_ReadRQ -->
+
+  <xs:element name="OTA_ReadRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <xs:element name="ReadRequests">
+          <xs:complexType>
+            <xs:sequence>
+
+              <xs:element name="HotelReadRequest">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <xs:element name="SelectionCriteria" minOccurs="0">
+                      <xs:complexType>
+                        <xs:attribute name="Start" use="required" type="def_datetime"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                  </xs:sequence>
+                  <xs:attribute name="HotelCode" type="def_nonempty_string"/> 
+                  <xs:attribute name="HotelName" type="def_nonempty_string"/>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- GuestRequests: OTA_ResRetrieveRS -->
+
+  <xs:element name="OTA_ResRetrieveRS">
+    <xs:complexType>
+
+      <xs:choice>
+
+        <!-- choice: Errors {1} -->
+
+        <xs:element name="Errors">
+          <xs:complexType>
+            <xs:sequence>
+   
+              <!-- Errors > Error {1,} -->
+   
+              <xs:element name="Error" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type" use="required">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="13"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="Code" use="required" type="def_int_ge0"/>
+                </xs:complexType>
+              </xs:element>
+   
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:sequence>
+
+          <!-- choice: Success {1} + ReservationsList {1} -->
+
+          <xs:element name="Success"/>
+
+          <xs:element name="ReservationsList">
+            <xs:complexType>
+              <xs:sequence>
+
+               <!-- HotelReservation {0,} -->
+ 
+                <xs:element name="HotelReservation" maxOccurs="unbounded" minOccurs="0">
+                  <xs:complexType>
+                    <xs:sequence>
+
+                      <!-- HotelReservation > UniqueID {1} -->
+
+                      <xs:element name="UniqueID">
+                        <xs:complexType>
+                          <xs:attribute name="Type" use="required">
+                            <xs:simpleType>
+                              <xs:restriction base="xs:string">
+                                <xs:enumeration value="14"/>
+                                <xs:enumeration value="15"/>
+                              </xs:restriction>
+                            </xs:simpleType>
+                          </xs:attribute>
+                          <xs:attribute name="ID" use="required" type="def_nonempty_string"/>
+                        </xs:complexType>
+                      </xs:element>
+
+                      <!-- HotelReservation > RoomStays {0,1} -->
+
+                      <xs:element name="RoomStays" minOccurs="0">
+                        <xs:complexType>
+                          <xs:sequence>
+
+                            <!-- HotelReservation > RoomStays > RoomStay {1,} -->
+
+                            <xs:element name="RoomStay" maxOccurs="unbounded">
+                              <xs:complexType>
+                                <xs:sequence>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > RoomTypes {0,1} -->
+
+                                  <xs:element name="RoomTypes" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:sequence>
+
+                                        <!-- HotelReservation > RoomStays > RoomStay > RoomTypes > RoomType {1} -->
+
+                                        <xs:element name="RoomType">
+                                          <xs:complexType>
+                                            <xs:attribute name="RoomTypeCode"           type="def_invTypeCode_string"/>
+                                            <xs:attribute name="RoomClassificationCode" type="def_int_ge0"/>
+                                          </xs:complexType>
+                                        </xs:element>
+
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > RatePlans {0,1} -->
+
+                                  <xs:element name="RatePlans" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:sequence>
+
+                                        <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan {1} -->
+
+                                        <xs:element name="RatePlan">
+                                          <xs:complexType>
+                                            <xs:sequence>
+
+                                              <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan > Commission {0,1} -->
+
+                                              <xs:element name="Commission" minOccurs="0">
+                                                <xs:complexType>
+                                                  <xs:sequence>
+                                                    <xs:element name="CommissionPayableAmount" minOccurs="0">
+                                                      <xs:complexType>
+                                                        <xs:attribute name="Amount" type="def_decimal_ge0"/>
+                                                        <xs:attribute name="CurrencyCode">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:enumeration value="EUR"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                      </xs:complexType>
+                                                    </xs:element>
+                                                  </xs:sequence>
+                                                  <xs:attribute name="Percent" type="def_int_ge0"/>
+                                                </xs:complexType>
+                                              </xs:element>
+
+                                              <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan > MealsIncluded {0,1} -->
+
+                                              <xs:element name="MealsIncluded" minOccurs="0">
+                                                <xs:complexType>
+                                                  <xs:attribute name="MealPlanIndicator" use="required">
+                                                    <xs:simpleType>
+                                                      <xs:restriction base="xs:string">
+                                                        <xs:enumeration value="1"/>
+                                                        <xs:enumeration value="true"/>
+                                                      </xs:restriction>
+                                                    </xs:simpleType>
+                                                  </xs:attribute>
+                                                  <xs:attribute name="MealPlanCodes" use="required">
+                                                    <xs:simpleType>
+                                                      <xs:restriction base="xs:string">
+                                                        <xs:enumeration value="1"/>
+                                                        <xs:enumeration value="3"/>
+                                                        <xs:enumeration value="10"/>
+                                                        <xs:enumeration value="12"/>
+                                                        <xs:enumeration value="14"/>
+                                                      </xs:restriction>
+                                                    </xs:simpleType>
+                                                  </xs:attribute>
+                                                </xs:complexType>
+                                              </xs:element>
+
+                                            </xs:sequence>
+                                            <xs:attribute name="RatePlanCode" type="def_nonempty_string"/>
+                                          </xs:complexType>
+                                        </xs:element>
+
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > GuestCounts {0,1} -->
+
+                                  <xs:element name="GuestCounts" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:sequence>
+
+                                        <!-- HotelReservation > RoomStays > RoomStay > GuestCounts > GuestCount {1,} -->
+
+                                        <xs:element name="GuestCount" maxOccurs="unbounded">
+                                          <xs:complexType>
+                                            <xs:attribute name="Count" use="required" type="def_int_gt0"/>
+                                            <xs:attribute name="Age"                  type="def_int_ge0"/>
+                                          </xs:complexType>
+                                        </xs:element>
+
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > TimeSpan {1} -->
+
+                                  <xs:element name="TimeSpan">
+                                    <xs:complexType>
+                                      <xs:sequence>
+
+                                        <!-- HotelReservation > RoomStays > RoomStay > TimeSpan > StartDateWindow {0,1} -->
+
+                                        <xs:element name="StartDateWindow" minOccurs="0">
+                                          <xs:complexType>
+                                            <xs:attribute name="EarliestDate" use="required" type="def_date"/>
+                                            <xs:attribute name="LatestDate"   use="required" type="def_date"/>
+                                          </xs:complexType>
+                                        </xs:element>
+
+                                      </xs:sequence>
+                                      <xs:attribute name="Start" type="def_date"/>
+                                      <xs:attribute name="End"   type="def_date"/>
+                                      <xs:attribute name="Duration">
+                                        <xs:simpleType>
+                                          <xs:restriction base="xs:string">
+                                            <xs:pattern value="P[0-9]+N"/>
+                                          </xs:restriction>
+                                        </xs:simpleType>
+                                      </xs:attribute>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > Guarantee {0,1} -->
+
+                                  <xs:element name="Guarantee" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="GuaranteesAccepted">
+                                          <xs:complexType>
+                                            <xs:sequence>
+                                              <xs:element name="GuaranteeAccepted">
+                                                <xs:complexType>
+                                                  <xs:sequence>
+                                      
+                                                    <xs:element name="PaymentCard">
+                                                      <xs:complexType>
+                                                        <xs:sequence>
+                                                          <xs:element name="CardHolderName" type="def_nonempty_string"/>
+
+                                                          <xs:element name="CardNumber">
+                                                            <xs:complexType>
+                                                              <xs:sequence>
+                                                                <xs:element name="PlainText" type="def_nonempty_string" minOccurs="0"/>
+                                                              </xs:sequence>
+                                                             <xs:attribute name="EncryptedValue" type="def_nonempty_string"/>
+                                                             <xs:attribute name="EncryptionMethod" type="def_nonempty_string"/>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                        </xs:sequence>
+                                                        <xs:attribute name="CardCode" use="required">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="[A-Z][A-Z]?"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                        <xs:attribute name="ExpireDate" use="required">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="[0-9][0-9][0-9][0-9]"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                      </xs:complexType>
+                                                    </xs:element>
+                                      
+                                                  </xs:sequence>
+                                                </xs:complexType>
+                                              </xs:element>
+                                            </xs:sequence>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > Total {0,1} -->
+
+                                  <xs:element name="Total" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:attribute name="AmountAfterTax" use="required" type="def_decimal_ge0"/>
+                                      <xs:attribute name="CurrencyCode"   use="required" type="def_nonempty_string"/>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+
+                      <!-- HotelReservation > ResGuests {0, 1} -->
+
+                      <xs:element name="ResGuests" minOccurs="0">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="ResGuest">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="Profiles">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="ProfileInfo">
+                                          <xs:complexType>
+                                            <xs:sequence>
+                                              <xs:element name="Profile">
+                                                <xs:complexType>
+                                                  <xs:sequence>
+
+                                                    <!-- HotelReservation > ... > Customer {1} -->
+
+                                                    <xs:element name="Customer">
+                                                      <xs:complexType>
+                                                        <xs:sequence>
+
+                                                          <!-- HotelReservation > ... > Customer > PersonName {1} -->
+
+                                                          <xs:element name="PersonName">
+                                                            <xs:complexType>
+                                                              <xs:sequence>
+                                                                <xs:element name="NamePrefix" minOccurs="0" type="def_nonempty_string"/>
+                                                                <xs:element name="GivenName"                type="def_nonempty_string"/>
+                                                                <xs:element name="Surname"                  type="def_nonempty_string"/>
+                                                                <xs:element name="NameTitle"  minOccurs="0" type="def_nonempty_string"/>
+                                                              </xs:sequence>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                          <!-- HotelReservation > ... > Customer > Telephone {0,} -->
+
+                                                          <xs:element name="Telephone" minOccurs="0" maxOccurs="unbounded">
+                                                            <xs:complexType>
+                                                              <xs:attribute name="PhoneTechType" use="required">
+                                                                <xs:simpleType>
+                                                                  <xs:restriction base="xs:string">
+                                                                    <xs:pattern value="(1|3|5)"/>
+                                                                  </xs:restriction>
+                                                                </xs:simpleType>
+                                                              </xs:attribute>
+                                                              <xs:attribute name="PhoneNumber" use="required">
+                                                                <xs:simpleType>
+                                                                  <xs:restriction base="xs:string">
+                                                                    <xs:pattern value="\+?[0-9]+"/>
+                                                                  </xs:restriction>
+                                                                </xs:simpleType>
+                                                              </xs:attribute>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                          <!-- HotelReservation > ... > Customer > Email {0,1} -->
+
+                                                          <xs:element name="Email" minOccurs="0">
+                                                            <xs:complexType>
+                                                              <xs:simpleContent>
+                                                                <xs:extension base="def_email_string"> 
+                                                                  <xs:attribute name="Remark">
+                                                                    <xs:simpleType>
+                                                                      <xs:restriction base="xs:string">
+                                                                        <xs:pattern value="newsletter:(no|yes)"/>
+                                                                      </xs:restriction>
+                                                                    </xs:simpleType>
+                                                                  </xs:attribute>
+                                                                </xs:extension>
+                                                              </xs:simpleContent>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                          <!-- HotelReservation > ... > Customer > Address {0,1} -->
+
+                                                          <xs:element name="Address" minOccurs="0">
+                                                            <xs:complexType>
+                                                              <xs:sequence>
+                                                                <xs:element name="AddressLine"  type="def_nonempty_string" minOccurs="0"/>
+                                                                <xs:element name="CityName"     type="def_nonempty_string" minOccurs="0"/>
+                                                                <xs:element name="PostalCode"   type="def_nonempty_string" minOccurs="0"/>
+                                                                <xs:element name="CountryName"  minOccurs="0">
+                                                                  <xs:complexType>
+                                                                    <xs:attribute name="Code" use="required">
+                                                                      <xs:simpleType>
+                                                                        <xs:restriction base="xs:string">
+                                                                          <xs:pattern value="[A-Z][A-Z]"/>
+                                                                        </xs:restriction>
+                                                                      </xs:simpleType>
+                                                                    </xs:attribute>
+                                                                  </xs:complexType>
+                                                                </xs:element>
+                                                              </xs:sequence>
+                                                              <xs:attribute name="Remark">
+                                                                <xs:simpleType>
+                                                                  <xs:restriction base="xs:string">
+                                                                    <xs:pattern value="catalog:(no|yes)"/>
+                                                                  </xs:restriction>
+                                                                </xs:simpleType>
+                                                              </xs:attribute>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                        </xs:sequence>
+                                                        <xs:attribute name="Gender">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="(Unknown|Male|Female)"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                        <xs:attribute name="BirthDate" type="def_date"/>
+                                                        <xs:attribute name="Language">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:language">
+                                                              <xs:pattern value="[a-z][a-z]"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                      </xs:complexType>
+                                                    </xs:element>
+
+                                                  </xs:sequence>
+                                                </xs:complexType>
+                                              </xs:element>
+                                            </xs:sequence>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+
+                      <!-- HotelReservation > ResGlobalInfo {0,1} -->
+
+                      <xs:element name="ResGlobalInfo" minOccurs="0">
+                        <xs:complexType>
+                          <xs:sequence>
+
+                            <!-- HotelReservation > ResGlobalInfo > Comments {0,1} -->
+
+                            <xs:element name="Comments" minOccurs="0">
+                              <xs:complexType>
+                                <xs:sequence>
+
+                                 <!-- HotelReservation > ResGlobalInfo > Comments {1,2} -->
+
+                                  <xs:element name="Comment" maxOccurs="2">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:choice>
+
+                                          <xs:element name="ListItem" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                              <xs:simpleContent>
+                                                <xs:extension base="def_nonempty_string">
+                                                  <xs:attribute name="ListItem" use="required" type="def_int_ge0"/>
+                                                  <xs:attribute name="Language" use="required">
+                                                    <xs:simpleType>
+                                                      <xs:restriction base="xs:language">
+                                                        <xs:pattern value="[a-z][a-z]"/>
+                                                      </xs:restriction>
+                                                    </xs:simpleType>
+                                                  </xs:attribute>
+                                                </xs:extension>
+                                              </xs:simpleContent>
+                                            </xs:complexType>
+                                          </xs:element>
+
+                                          <xs:element name="Text" minOccurs="0" type="def_nonempty_string"/>
+
+                                        </xs:choice>
+                                      </xs:sequence>
+                                      <xs:attribute name="Name" use="required">
+                                        <xs:simpleType>
+                                          <xs:restriction base="xs:string">
+                                            <xs:enumeration value="included services"/>
+                                            <xs:enumeration value="customer comment"/>
+                                          </xs:restriction>
+                                        </xs:simpleType>
+                                      </xs:attribute>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+
+                            <!-- HotelReservation > ResGlobalInfo > CancelPenalties {0,1} -->
+
+                            <xs:element name="CancelPenalties" minOccurs="0">
+                              <xs:complexType>        
+                                <xs:sequence>         
+                                  <xs:element name="CancelPenalty">
+                                    <xs:complexType>  
+                                      <xs:sequence>   
+                                        <xs:element name="PenaltyDescription">
+                                          <xs:complexType>
+                                            <xs:sequence>
+                                              <xs:element name="Text" type="def_nonempty_string"/>
+                                            </xs:sequence>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>  
+                                    </xs:complexType> 
+                                  </xs:element>       
+                                </xs:sequence>        
+                              </xs:complexType>       
+                            </xs:element>             
+
+                            <!-- HotelReservation > ResGlobalInfo > HotelReservationIDs {0,1} -->
+
+                            <xs:element name="HotelReservationIDs" minOccurs="0">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="HotelReservationID" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                      <xs:attribute name="ResID_Type" use="required" type="def_int_gt0"/>
+                                      <xs:attribute name="ResID_Value"               type="def_nonempty_string"/>
+                                      <xs:attribute name="ResID_Source"              type="def_nonempty_string"/>
+                                      <xs:attribute name="ResID_SourceContext"       type="def_nonempty_string"/>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+
+                            <!-- HotelReservation > ResGlobalInfo > Profiles {0,1} -->
+
+                            <xs:element name="Profiles" minOccurs="0">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="ProfileInfo">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="Profile">
+                                          <xs:complexType>
+                                            <xs:sequence>
+                                              <xs:element name="CompanyInfo">
+                                                <xs:complexType>
+                                                  <xs:sequence>
+
+                                                    <xs:element name="CompanyName">
+                                                      <xs:complexType>
+                                                        <xs:simpleContent>
+                                                          <xs:extension base="def_nonempty_string"> 
+                                                            <xs:attribute name="Code"        use="required" type="def_nonempty_string"/>
+                                                            <xs:attribute name="CodeContext" use="required" type="def_nonempty_string"/>
+                                                          </xs:extension>
+                                                        </xs:simpleContent>
+                                                      </xs:complexType>
+                                                    </xs:element>
+
+                                                    <xs:element name="AddressInfo" minOccurs="0">
+                                                      <xs:complexType>
+                                                        <xs:sequence>
+                                                          <xs:element name="AddressLine"  type="def_nonempty_string"/>
+                                                          <xs:element name="CityName"     type="def_nonempty_string"/>
+                                                          <xs:element name="PostalCode"   type="def_nonempty_string"/>
+                                                          <xs:element name="CountryName">
+                                                            <xs:complexType>
+                                                              <xs:attribute name="Code" use="required">
+                                                                <xs:simpleType>
+                                                                  <xs:restriction base="xs:string">
+                                                                    <xs:pattern value="[A-Z][A-Z]"/>
+                                                                  </xs:restriction>
+                                                                </xs:simpleType>
+                                                              </xs:attribute>
+                                                            </xs:complexType>
+                                                          </xs:element>
+                                                        </xs:sequence>
+                                                      </xs:complexType>
+                                                    </xs:element>
+
+                                                    <xs:element name="TelephoneInfo" minOccurs="0">
+                                                      <xs:complexType>
+                                                        <xs:attribute name="PhoneTechType" use="required">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="(1|3|5)"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                        <xs:attribute name="PhoneNumber" use="required">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="\+?[0-9]+"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                      </xs:complexType>
+                                                    </xs:element>
+
+                                                    <xs:element name="Email" minOccurs="0" type="def_nonempty_string"/>
+
+                                                  </xs:sequence>
+                                                </xs:complexType>
+                                              </xs:element>
+                                            </xs:sequence>
+                                            <xs:attribute name="ProfileType" use="required">
+                                              <xs:simpleType>
+                                                <xs:restriction base="xs:string">
+                                                  <xs:enumeration value="4"/>
+                                                </xs:restriction>
+                                              </xs:simpleType>
+                                            </xs:attribute>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+
+                            <xs:element name="BasicPropertyInfo"/>
+
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+
+                    </xs:sequence>
+                    <xs:attribute name="CreateDateTime" use="required" type="def_datetime"/>
+                    <xs:attribute name="ResStatus"      use="required">
+                      <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                          <xs:enumeration value="Requested"/>
+                          <xs:enumeration value="Reserved"/>
+                          <xs:enumeration value="Cancelled"/>
+                          <xs:enumeration value="Modify"/>
+                        </xs:restriction>
+                      </xs:simpleType>
+                    </xs:attribute>
+                  </xs:complexType>
+                </xs:element>
+
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+
+        </xs:sequence>
+
+      </xs:choice>
+
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- GuestRequests: OTA_NotifReportRQ -->
+
+  <xs:element name="OTA_NotifReportRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <xs:element name="Success"/>
+
+        <xs:element name="Warnings" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Warning" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type"     use="required" type="def_int_gt0"/>
+                  <xs:attribute name="Code"     use="required" type="def_int_gt0"/>
+                  <xs:attribute name="RecordID" use="required" type="def_nonempty_string"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="NotifDetails" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+
+              <xs:element name="HotelNotifReport">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <xs:element name="HotelReservations">
+                      <xs:complexType>
+                        <xs:sequence>
+
+                          <xs:element name="HotelReservation" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:sequence>
+
+                                <xs:element name="UniqueID">
+                                  <xs:complexType>
+                                    <xs:attribute name="Type" use="required">
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="14"/>
+                                          <xs:enumeration value="15"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:attribute>
+                                    <xs:attribute name="ID" use="required" type="def_nonempty_string"/>
+                                  </xs:complexType>
+                                </xs:element>
+                 
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- GuestRequests: OTA_NotifReportRS -->
+
+  <xs:element name="OTA_NotifReportRS">
+    <xs:complexType>
+
+      <xs:choice>
+
+        <!-- choice: Errors {1} -->
+
+        <xs:element name="Errors">
+          <xs:complexType>
+            <xs:sequence>
+   
+              <!-- Errors > Error {1,} -->
+   
+              <xs:element name="Error" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type" use="required">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="13"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="Code" use="required" type="def_int_ge0"/>
+                </xs:complexType>
+              </xs:element>
+   
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <!-- choice: Success {1} -->
+
+        <xs:sequence>
+          <xs:element name="Success"/>
+        </xs:sequence>
+
+      </xs:choice>
+
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+
+    </xs:complexType>
+  </xs:element>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * Inventory/Basic (Push) and Inventory/HotelInfo (Push)                         -->
+  <!-- ******************************************************************************* -->
+
+  <!-- Inventory: OTA_HotelDescriptiveContentNotifRQ -->
+
+  <xs:element name="OTA_HotelDescriptiveContentNotifRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <xs:group ref="def_hoteldescriptivecontents"/>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required" />
+      <xs:attribute name="TimeStamp" />
+    </xs:complexType>
+  </xs:element>
+
+  <!-- Inventory: OTA_HotelDescriptiveContentNotifRS -->
+  
+  <xs:element name="OTA_HotelDescriptiveContentNotifRS">
+    <xs:complexType>
+      <xs:group ref="def_generic_response"/>
+      <xs:attribute name="Version" use="required" />
+      <xs:attribute name="TimeStamp" />
+    </xs:complexType>
+  </xs:element>
+ 
+
+  <!-- ******************************************************************************* -->
+  <!-- * Inventory/Basic (Pull) and Inventory/HotelInfo (Pull)                         -->
+  <!-- ******************************************************************************* -->
+
+  <!-- Inventory: OTA_HotelDescriptiveInfoRQ -->
+
+  <xs:element name="OTA_HotelDescriptiveInfoRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <xs:element name="HotelDescriptiveInfos" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+
+              <xs:element name="HotelDescriptiveInfo" maxOccurs="1">
+                <xs:complexType>
+                  <xs:attribute name="HotelCode" type="def_nonempty_string"/>
+                  <xs:attribute name="HotelName" type="def_nonempty_string"/>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required" />
+      <xs:attribute name="TimeStamp" />
+    </xs:complexType>
+  </xs:element>
+
+  <!-- Inventory: OTA_HotelDescriptiveInfoRS -->
+  
+  <xs:element name="OTA_HotelDescriptiveInfoRS"> 
+    <xs:complexType>
+
+      <xs:choice>
+
+        <!-- choice: Errors {1} -->
+
+        <xs:element name="Errors">
+          <xs:complexType>
+            <xs:sequence>
+   
+              <!-- Errors > Error {1,} -->
+   
+              <xs:element name="Error" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type" use="required">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="13"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="Code" use="required" type="def_int_ge0"/>
+                </xs:complexType>
+              </xs:element>
+   
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <!-- choice: Success {1} + HotelDescriptiveContents {1} -->
+
+        <xs:sequence>
+          <xs:element name="Success"/>
+          <xs:group ref="def_hoteldescriptivecontents"/>
+        </xs:sequence>
+
+      </xs:choice>
+
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+
+    </xs:complexType>
+  </xs:element>
+
+ 
+  <!-- ******************************************************************************* -->
+  <!-- * RatePlans                                                                     -->
+  <!-- ******************************************************************************* -->
+
+  <!-- RatePlans: OTA_HotelRatePlanNotifRQ -->
+
+  <xs:element name="OTA_HotelRatePlanNotifRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <!-- UniqueID {0,1} -->
+
+        <xs:element name="UniqueID" minOccurs="0">
+          <xs:complexType>
+            <xs:attribute name="Type" use="required">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="16"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="ID" use="required" type="xs:string"/> <!-- an ID is required by OTA, we ignore the value -->
+            <xs:attribute name="Instance" use="required">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="CompleteSet"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+
+        <!-- RatePlans {1} -->
+
+        <xs:group ref="def_rateplans"/>
+ 
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- RatePlans: OTA_HotelRatePlanNotifRS -->
+
+  <xs:element name="OTA_HotelRatePlanNotifRS">
+    <xs:complexType>
+      <xs:group   ref="def_generic_response"/>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * BaseRates                                                                     -->
+  <!-- ******************************************************************************* -->
+
+  <!-- BaseRates: OTA_HotelRatePlanRQ -->
+
+  <xs:element name="OTA_HotelRatePlanRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <!-- RatePlans {1} -->
+ 
+        <xs:element name="RatePlans">
+          <xs:complexType>
+            <xs:sequence>
+
+              <!-- RatePlans > RatePlan {1} -->
+
+              <xs:element name="RatePlan">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <xs:choice maxOccurs="unbounded">
+
+                      <xs:element name="DateRange">
+                        <xs:complexType>
+                          <xs:attribute name="Start" type="def_date"/>
+                          <xs:attribute name="End"   type="def_date"/>
+                        </xs:complexType>
+                      </xs:element>
+
+                      <xs:element name="RatePlanCandidates">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="RatePlanCandidate" maxOccurs="unbounded">
+                              <xs:complexType>
+                                <xs:attribute name="RatePlanCode" type="def_nonempty_string"/>
+                                <xs:attribute name="RatePlanID" type="def_nonempty_string"/>
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+
+                      <xs:element name="HotelRef">
+                        <xs:complexType>
+                          <xs:attribute name="HotelCode" type="def_nonempty_string"/>
+                          <xs:attribute name="HotelName" type="def_nonempty_string"/>
+                        </xs:complexType>
+                      </xs:element>
+
+                    </xs:choice>
+
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+
+    </xs:complexType>
+  </xs:element>
+
+  <!-- BaseRates: OTA_HotelRatePlanRS -->
+
+  <xs:element name="OTA_HotelRatePlanRS">
+    <xs:complexType>
+
+      <xs:choice>
+
+        <!-- choice: Errors {1} -->
+
+        <xs:element name="Errors">
+          <xs:complexType>
+            <xs:sequence>
+   
+              <!-- Errors > Error {1,} -->
+   
+              <xs:element name="Error" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type" use="required">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="13"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="Code" use="required" type="def_int_ge0"/>
+                </xs:complexType>
+              </xs:element>
+   
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <!-- choice: Success {1} + RatePlans {1} -->
+
+        <xs:sequence>
+          <xs:element name="Success"/>
+          <xs:group ref="def_rateplans"/>
+        </xs:sequence>
+
+      </xs:choice>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+
+    </xs:complexType>
+  </xs:element>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for HotelDescriptiveContents element as used                -->
+  <!-- * in the Inventory types                                                        -->
+  <!-- ******************************************************************************* -->
+
+  <xs:group name="def_hoteldescriptivecontents">
+    <xs:sequence>
+
+        <xs:element name="HotelDescriptiveContents" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+
+              <xs:element name="HotelDescriptiveContent" maxOccurs="1">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <!-- HotelInfo -->
+                    <xs:element name="HotelInfo" minOccurs="0" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                        <xs:anyAttribute processContents="lax"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                    <!-- FacilityInfo -->
+                    <xs:element name="FacilityInfo" minOccurs="0" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+
+                          <xs:element name="GuestRooms" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:sequence>
+
+                                <xs:element name="GuestRoom" minOccurs="0" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:sequence>
+
+                                      <xs:element name="TypeRoom" minOccurs="0">
+                                        <xs:complexType>
+                                          <xs:attribute name="StandardOccupancy"      type="def_int_gt0" />
+                                          <xs:attribute name="RoomClassificationCode" type="def_int_ge0" />
+                                          <xs:attribute name="RoomID"                 type="def_nonempty_string" />
+                                          <xs:attribute name="Size"                   type="def_int_ge0" />
+                                        </xs:complexType>
+                                      </xs:element>
+
+                                      <xs:element name="Amenities" minOccurs="0">
+                                        <xs:complexType>
+                                          <xs:sequence>
+
+                                            <xs:element name="Amenity" maxOccurs="unbounded">
+                                              <xs:complexType>
+                                                <xs:attribute name="RoomAmenityCode" type="def_int_gt0"/>
+                                              </xs:complexType>
+                                            </xs:element>
+
+                                          </xs:sequence>
+                                        </xs:complexType>
+                                      </xs:element>
+
+                                      <xs:element name="MultimediaDescriptions" minOccurs="0">
+                                        <xs:complexType>
+                                          <xs:sequence>
+
+                                            <xs:element name="MultimediaDescription" maxOccurs="unbounded" minOccurs="0">
+                                              <xs:complexType>
+                                                <xs:choice>
+
+                                                  <xs:element name="TextItems" minOccurs="0">
+                                                    <xs:complexType>
+                                                      <xs:sequence>
+
+                                                        <xs:element name="TextItem">
+                                                          <xs:complexType>
+                                                            <xs:sequence>
+
+                                                              <xs:element name="Description" maxOccurs="unbounded">
+                                                                <xs:complexType>
+                                                                  <xs:simpleContent>
+                                                                    <xs:extension base="def_nonempty_string">
+                                                                      <xs:attribute name="TextFormat" use="required">
+                                                                        <xs:simpleType>
+                                                                          <xs:restriction base="xs:string">
+                                                                            <xs:enumeration value="PlainText"/>
+                                                                          </xs:restriction>
+                                                                        </xs:simpleType>
+                                                                      </xs:attribute>
+                                                                      <xs:attribute name="Language" use="required">
+                                                                        <xs:simpleType>
+                                                                          <xs:restriction base="xs:language">
+                                                                            <xs:pattern value="[a-z][a-z]"/>
+                                                                          </xs:restriction>
+                                                                        </xs:simpleType>
+                                                                      </xs:attribute>
+                                                                    </xs:extension>
+                                                                  </xs:simpleContent>
+                                                                </xs:complexType>
+                                                              </xs:element>
+
+                                                            </xs:sequence>
+                                                          </xs:complexType>
+                                                        </xs:element>
+
+                                                      </xs:sequence>
+                                                    </xs:complexType>
+                                                  </xs:element>
+
+                                                  <xs:element name="ImageItems" minOccurs="0">
+                                                    <xs:complexType>
+                                                      <xs:sequence>
+
+                                                        <xs:element name="ImageItem" maxOccurs="unbounded">
+                                                          <xs:complexType>
+                                                            <xs:sequence>
+
+                                                              <xs:element name="ImageFormat">
+                                                                <xs:complexType>
+                                                                  <xs:sequence>
+                                                                    <xs:element name="URL" type="def_url_string" />
+                                                                  </xs:sequence>
+                                                                  <xs:attribute name="CopyrightNotice" type="def_nonempty_string" />
+                                                                </xs:complexType>
+                                                              </xs:element>
+
+                                                              <xs:element name="Description" minOccurs="0" maxOccurs="unbounded">
+                                                                <xs:complexType>
+                                                                  <xs:simpleContent>
+                                                                    <xs:extension base="def_nonempty_string">
+                                                                      <xs:attribute name="TextFormat" use="required">
+                                                                        <xs:simpleType>
+                                                                          <xs:restriction base="xs:string">
+                                                                            <xs:enumeration value="PlainText"/>
+                                                                          </xs:restriction>
+                                                                        </xs:simpleType>
+                                                                      </xs:attribute>
+                                                                      <xs:attribute name="Language" use="required">
+                                                                        <xs:simpleType>
+                                                                          <xs:restriction base="xs:language">
+                                                                            <xs:pattern value="[a-z][a-z]"/>
+                                                                          </xs:restriction>
+                                                                        </xs:simpleType>
+                                                                      </xs:attribute>
+                                                                    </xs:extension>
+                                                                  </xs:simpleContent>
+                                                                </xs:complexType>
+                                                              </xs:element>
+
+                                                            </xs:sequence>
+                                                            <xs:attribute name="Category" use="required" type="def_int_gt0" />
+                                                          </xs:complexType>
+                                                        </xs:element>
+
+                                                      </xs:sequence>
+                                                    </xs:complexType>
+                                                  </xs:element>
+
+                                                </xs:choice>
+                                                <xs:attribute name="InfoCode">
+                                                  <xs:simpleType>
+                                                    <xs:restriction base="def_int_gt0">
+                                                      <xs:enumeration value="1"/>
+                                                      <xs:enumeration value="23"/>
+                                                      <xs:enumeration value="25"/>
+                                                    </xs:restriction>
+                                                  </xs:simpleType>
+                                                </xs:attribute>
+                                              </xs:complexType>
+                                            </xs:element>
+
+                                          </xs:sequence>
+                                        </xs:complexType>
+                                      </xs:element>
+
+                                    </xs:sequence>
+                                    <xs:attribute name="Code"              use="required" type="def_invTypeCode_string" />
+                                    <xs:attribute name="MaxOccupancy"                     type="def_int_gt0" />
+                                    <xs:attribute name="MinOccupancy"                     type="def_int_gt0" />
+                                    <xs:attribute name="MaxChildOccupancy"                type="def_int_gt0" />
+                                    <xs:attribute name="ID"                               type="def_invTypeCode_string" />
+                                  </xs:complexType>
+                                </xs:element>
+
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+
+                    <!-- Policies -->
+                    <xs:element name="Policies" minOccurs="0" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                        <xs:anyAttribute processContents="lax"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                    <!-- AffiliationInfo -->
+                    <xs:element name="AffiliationInfo" minOccurs="0" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                        <xs:anyAttribute processContents="lax"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                    <!-- ContactInfos -->
+                    <xs:element name="ContactInfos" minOccurs="0" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                        <xs:anyAttribute processContents="lax"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                  </xs:sequence>
+                  <xs:attribute name="HotelCityCode" type="def_nonempty_string" />
+                  <xs:attribute name="HotelCode" type="def_nonempty_string" />
+                  <xs:attribute name="HotelName" type="def_nonempty_string" />
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+    </xs:sequence>
+  </xs:group>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for RatePlans element as used                               -->
+  <!-- * in RatePlans and BaseRates                                                    -->
+  <!-- ******************************************************************************* -->
+
+  <xs:group name="def_rateplans">
+
+    <xs:sequence>
+      <xs:element name="RatePlans">
+        <xs:complexType>
+          <xs:sequence>
+
+            <!-- RatePlans > RatePlan {1,} -->
+
+            <xs:element name="RatePlan" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+
+                  <!-- RatePlans > RatePlan > BookingRules {0,1} -->
+
+                  <xs:element name="BookingRules" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+
+                        <xs:element name="BookingRule" maxOccurs="unbounded">
+                          <xs:complexType>
+                            <xs:sequence>
+
+                              <xs:element name="LengthsOfStay" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+
+                                    <xs:element name="LengthOfStay" maxOccurs="unbounded">
+                                      <xs:complexType>
+                                        <xs:attribute name="Time" use="required" type="def_decimal_ge0"/>
+                                        <xs:attribute name="TimeUnit" use="required">
+                                          <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                              <xs:enumeration value="Day"/>
+                                            </xs:restriction>
+                                          </xs:simpleType>
+                                        </xs:attribute>
+                                        <xs:attribute name="MinMaxMessageType" use="required">
+                                          <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                              <xs:enumeration value="SetMinLOS"/>
+                                              <xs:enumeration value="SetForwardMinStay"/>
+                                              <xs:enumeration value="SetMaxLOS"/>
+                                              <xs:enumeration value="SetForwardMaxStay"/>
+                                            </xs:restriction>
+                                          </xs:simpleType>
+                                        </xs:attribute>
+                                      </xs:complexType>
+                                    </xs:element>
+
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="DOW_Restrictions" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ArrivalDaysOfWeek" minOccurs="0">
+                                      <xs:complexType>
+                                        <xs:attribute name="Mon"  type="def_bool"/>
+                                        <xs:attribute name="Tue"  type="def_bool"/>
+                                        <xs:attribute name="Weds" type="def_bool"/>
+                                        <xs:attribute name="Thur" type="def_bool"/>
+                                        <xs:attribute name="Fri"  type="def_bool"/>
+                                        <xs:attribute name="Sat"  type="def_bool"/>
+                                        <xs:attribute name="Sun"  type="def_bool"/>
+                                      </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="DepartureDaysOfWeek" minOccurs="0">
+                                      <xs:complexType>
+                                        <xs:attribute name="Mon"  type="def_bool"/>
+                                        <xs:attribute name="Tue"  type="def_bool"/>
+                                        <xs:attribute name="Weds" type="def_bool"/>
+                                        <xs:attribute name="Thur" type="def_bool"/>
+                                        <xs:attribute name="Fri"  type="def_bool"/>
+                                        <xs:attribute name="Sat"  type="def_bool"/>
+                                        <xs:attribute name="Sun"  type="def_bool"/>
+                                      </xs:complexType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="RestrictionStatus" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:attribute name="Restriction">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="Master"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                  <xs:attribute name="Status">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="Open"/>
+                                        <xs:enumeration value="Close"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                </xs:complexType>
+                              </xs:element>
+
+                            </xs:sequence>
+                            <xs:attribute name="CodeContext">
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:enumeration value="ROOMTYPE"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:attribute>
+                            <xs:attribute name="Code"  type="def_invTypeCode_string"/>
+                            <xs:attribute name="Start" type="def_date"/>
+                            <xs:attribute name="End"   type="def_date"/>
+                          </xs:complexType>
+                        </xs:element>
+
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+
+                  <!-- RatePlans > RatePlan > Rates {0,1} -->
+
+                  <xs:element name="Rates" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+
+                        <xs:element name="Rate" maxOccurs="unbounded">
+                          <xs:complexType>
+                            <xs:sequence>
+
+                              <xs:element name="BaseByGuestAmts" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+
+                                    <xs:element name="BaseByGuestAmt" maxOccurs="unbounded">
+                                      <xs:complexType>
+                                        <xs:attribute name="NumberOfGuests" type="def_int_gt0"/>
+                                        <xs:attribute name="AmountAfterTax" type="def_decimal_gt0"/>
+                                        <xs:attribute name="CurrencyCode">
+                                          <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                              <xs:enumeration value="EUR"/>
+                                            </xs:restriction>
+                                          </xs:simpleType>
+                                        </xs:attribute>
+                                        <xs:attribute name="Type">
+                                          <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                              <xs:enumeration value="7"/>
+                                              <xs:enumeration value="25"/>
+                                            </xs:restriction>
+                                          </xs:simpleType>
+                                        </xs:attribute>
+                                        <xs:attribute name="AgeQualifyingCode" type="def_int_gt0"/>
+                                      </xs:complexType>
+                                    </xs:element>
+
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="AdditionalGuestAmounts" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+
+                                    <xs:element name="AdditionalGuestAmount" maxOccurs="unbounded">
+                                      <xs:complexType>
+                                        <xs:attribute name="Amount"            type="def_decimal_ge0"/>
+                                        <xs:attribute name="AgeQualifyingCode" type="def_int_gt0"/>
+                                        <xs:attribute name="MinAge"            type="def_int_gt0"/>
+                                        <xs:attribute name="MaxAge"            type="def_int_gt0"/>
+                                      </xs:complexType>
+                                    </xs:element>
+
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="RateDescription" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+
+                                    <xs:element name="ListItem" maxOccurs="unbounded">
+                                      <xs:complexType>                    
+                                         <xs:simpleContent>                
+                                           <xs:extension base="def_nonempty_string">
+                                             <xs:attribute name="ListItem" use="required" type="def_int_ge0"/>
+                                             <xs:attribute name="Language" use="required">
+                                               <xs:simpleType>             
+                                                 <xs:restriction base="xs:language">
+                                                   <xs:pattern value="[a-z][a-z]"/>
+                                                 </xs:restriction>         
+                                               </xs:simpleType>            
+                                             </xs:attribute>               
+                                           </xs:extension>                 
+                                         </xs:simpleContent>               
+                                       </xs:complexType>                   
+                                    </xs:element>
+     
+                                  </xs:sequence>
+                                    <xs:attribute name="Name" use="required">
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="included services"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:attribute>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="MealsIncluded" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:attribute name="Breakfast" type="def_bool"/>
+                                  <xs:attribute name="Lunch"     type="def_bool"/>
+                                  <xs:attribute name="Dinner"    type="def_bool"/>
+                                  <xs:attribute name="MealPlanCodes">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="1"/>
+                                        <xs:enumeration value="3"/>
+                                        <xs:enumeration value="10"/>
+                                        <xs:enumeration value="12"/>
+                                        <xs:enumeration value="14"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                  <xs:attribute name="MealPlanIndicator">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="1"/>
+                                        <xs:enumeration value="true"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                </xs:complexType>
+                              </xs:element>
+                      
+                            </xs:sequence>
+                            <xs:attribute name="MinGuestApplicable" type="def_int_gt0"/>
+                            <xs:attribute name="Start"              type="def_date"/>
+                            <xs:attribute name="End"                type="def_date"/>
+                            <xs:attribute name="RateTimeUnit">
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:enumeration value="Day"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:attribute>
+                            <xs:attribute name="UnitMultiplier"     type="def_int_gt0"/>
+                            <xs:attribute name="Mon"                type="def_bool"/>
+                            <xs:attribute name="Tue"                type="def_bool"/>
+                            <xs:attribute name="Weds"               type="def_bool"/>
+                            <xs:attribute name="Thur"               type="def_bool"/>
+                            <xs:attribute name="Fri"                type="def_bool"/>
+                            <xs:attribute name="Sat"                type="def_bool"/>
+                            <xs:attribute name="Sun"                type="def_bool"/>
+                            <xs:attribute name="Duration">
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:pattern value="P[0-9]+N"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:attribute>
+                            <xs:attribute name="InvTypeCode" type="def_invTypeCode_string"/>
+
+                          </xs:complexType>
+                        </xs:element>
+                      
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+
+                  <!-- RatePlans > RatePlan > Supplements {0,1} -->
+
+                  <xs:element name="Supplements" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+
+                        <xs:element name="Supplement" maxOccurs="unbounded">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:choice>
+                                <xs:element name="PrerequisiteInventory" minOccurs="0" maxOccurs="1">
+                                  <xs:complexType>
+                                      <xs:attribute name="InvCode" use="required" type="def_nonempty_string"/>
+                                      <xs:attribute name="InvType" use="required">
+                                        <xs:simpleType>
+                                          <xs:restriction base="xs:string">
+                                            <xs:enumeration value="ALPINEBITSDOW"/>
+                                            <xs:enumeration value="ROOMTYPE"/>
+                                          </xs:restriction>
+                                        </xs:simpleType>
+                                      </xs:attribute>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:choice>
+                              <!-- RatePlans > RatePlan > Supplements > Supplement > Description {0,5} -->
+                      
+                              <xs:element name="Description" minOccurs="0" maxOccurs="5">
+                                <xs:complexType>
+                                  <xs:sequence>
+                      
+                                    <xs:choice maxOccurs="unbounded">
+                      
+                                      <xs:element name="ListItem" type="def_nonempty_string"/>
+                      
+                                      <xs:element name="Image" type="def_url_string"/>
+                      
+                                      <xs:element name="Text">
+                                        <xs:complexType>                    
+                                           <xs:simpleContent>                
+                                             <xs:extension base="def_nonempty_string">
+                                               <xs:attribute name="TextFormat" use="required">
+                                                 <xs:simpleType>             
+                                                   <xs:restriction base="xs:string">
+                                                     <xs:enumeration value="PlainText"/>
+                                                     <xs:enumeration value="HTML"/> 
+                                                   </xs:restriction>         
+                                                 </xs:simpleType>            
+                                               </xs:attribute>               
+                                               <xs:attribute name="Language">
+                                                 <xs:simpleType>             
+                                                   <xs:restriction base="xs:language">
+                                                     <xs:pattern value="[a-z][a-z]"/>
+                                                   </xs:restriction>         
+                                                 </xs:simpleType>            
+                                               </xs:attribute>               
+                                             </xs:extension>                 
+                                           </xs:simpleContent>               
+                                         </xs:complexType>                   
+                                      </xs:element>
+                                  
+                                      <xs:element name="URL" type="def_url_string"/>
+                      
+                                    </xs:choice>
+                      
+                                  </xs:sequence>
+                      
+                                  <xs:attribute name="Name" use="required">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="title"/>
+                                        <xs:enumeration value="intro"/>
+                                        <xs:enumeration value="description"/>
+                                        <xs:enumeration value="gallery"/>
+                                        <xs:enumeration value="codelist"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                </xs:complexType>
+                              </xs:element>
+
+                            </xs:sequence>
+
+                            <xs:attribute name="AddToBasicRateIndicator">
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:enumeration value="1"/>
+                                  <xs:enumeration value="true"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:attribute>
+
+                            <xs:attribute name="ChargeTypeCode">
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:enumeration value="1"/>
+                                  <xs:enumeration value="12"/>
+                                  <xs:enumeration value="18"/>
+                                  <xs:enumeration value="19"/>
+                                  <xs:enumeration value="20"/>
+                                  <xs:enumeration value="21"/>
+                                  <xs:enumeration value="24"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:attribute>
+
+                            <xs:attribute name="Amount" type="def_decimal_ge0"/>
+
+                            <xs:attribute name="InvType" use="required">
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:enumeration value="EXTRA"/>
+                                  <xs:enumeration value="ALPINEBITSEXTRA"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:attribute>
+
+                            <xs:attribute name="InvCode" type="def_nonempty_string" use="required"/>
+
+                            <xs:attribute name="MandatoryIndicator" type="def_bool"/>
+
+                            <xs:attribute name="Start" type="def_date"/>
+                            <xs:attribute name="End"   type="def_date"/>
+
+                          </xs:complexType>
+                        </xs:element>  <!-- close Supplement -->
+
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+
+                  <!-- RatePlans > RatePlan > Offers {0,1} -->
+
+                  <xs:element name="Offers" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+
+                        <xs:element name="Offer" maxOccurs="3">
+                          <xs:complexType>
+                            <xs:sequence>
+
+                              <xs:element name="OfferRules" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+
+                                    <xs:element name="OfferRule" minOccurs="0">
+                                      <xs:complexType>
+                                        <xs:sequence>
+                                  
+                                          <xs:element name="LengthsOfStay" minOccurs="0">
+                                            <xs:complexType>
+                                              <xs:sequence>
+                                  
+                                                <xs:element name="LengthOfStay" maxOccurs="unbounded">
+                                                  <xs:complexType>
+                                                    <xs:attribute name="Time" use="required" type="def_decimal_ge0"/>
+                                                    <xs:attribute name="TimeUnit" use="required">
+                                                      <xs:simpleType>
+                                                        <xs:restriction base="xs:string">
+                                                          <xs:enumeration value="Day"/>
+                                                        </xs:restriction>
+                                                      </xs:simpleType>
+                                                    </xs:attribute>
+                                                    <xs:attribute name="MinMaxMessageType" use="required">
+                                                      <xs:simpleType>
+                                                        <xs:restriction base="xs:string">
+                                                          <xs:enumeration value="SetMinLOS"/>
+                                                          <xs:enumeration value="SetMaxLOS"/>
+                                                          <xs:enumeration value=""/>
+                                                        </xs:restriction>
+                                                      </xs:simpleType>
+                                                    </xs:attribute>
+                                                  </xs:complexType>
+                                                </xs:element>
+                                  
+                                              </xs:sequence>
+                                            </xs:complexType>
+                                          </xs:element>
+                                  
+                                          <xs:element name="DOW_Restrictions" minOccurs="0">
+                                            <xs:complexType>
+                                              <xs:sequence>
+                                                <xs:element name="ArrivalDaysOfWeek" minOccurs="0">
+                                                  <xs:complexType>
+                                                    <xs:attribute name="Mon"  type="def_bool"/>
+                                                    <xs:attribute name="Tue"  type="def_bool"/>
+                                                    <xs:attribute name="Weds" type="def_bool"/>
+                                                    <xs:attribute name="Thur" type="def_bool"/>
+                                                    <xs:attribute name="Fri"  type="def_bool"/>
+                                                    <xs:attribute name="Sat"  type="def_bool"/>
+                                                    <xs:attribute name="Sun"  type="def_bool"/>
+                                                  </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="DepartureDaysOfWeek" minOccurs="0">
+                                                  <xs:complexType>
+                                                    <xs:attribute name="Mon"  type="def_bool"/>
+                                                    <xs:attribute name="Tue"  type="def_bool"/>
+                                                    <xs:attribute name="Weds" type="def_bool"/>
+                                                    <xs:attribute name="Thur" type="def_bool"/>
+                                                    <xs:attribute name="Fri"  type="def_bool"/>
+                                                    <xs:attribute name="Sat"  type="def_bool"/>
+                                                    <xs:attribute name="Sun"  type="def_bool"/>
+                                                  </xs:complexType>
+                                                </xs:element>
+                                              </xs:sequence>
+                                            </xs:complexType>
+                                          </xs:element>
+                                  
+                                          <xs:element name="Occupancy" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                              <xs:attribute name="AgeQualifyingCode" use="required">
+                                                <xs:simpleType>
+                                                  <xs:restriction base="xs:string">
+                                                    <xs:enumeration value="8"/>
+                                                    <xs:enumeration value="10"/>
+                                                  </xs:restriction>
+                                                </xs:simpleType>
+                                              </xs:attribute>
+                                              <xs:attribute name="MinAge" type="def_int_gt0"/>
+                                              <xs:attribute name="MaxAge" type="def_int_gt0"/>
+                                              <xs:attribute name="MinOccupancy" type="def_int_ge0"/>
+                                              <xs:attribute name="MaxOccupancy" type="def_int_gt0"/>
+                                            </xs:complexType>
+                                          </xs:element>
+                                  
+                                        </xs:sequence>
+                                  
+                                        <xs:attribute name="MinAdvancedBookingOffset">
+                                          <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                              <xs:pattern value="P[0-9]+D"/>
+                                            </xs:restriction>
+                                          </xs:simpleType>
+                                        </xs:attribute>
+                                        <xs:attribute name="MaxAdvancedBookingOffset">
+                                          <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                              <xs:pattern value="P[0-9]+D"/>
+                                            </xs:restriction>
+                                          </xs:simpleType>
+                                        </xs:attribute>
+                                  
+                                      </xs:complexType>
+                                    </xs:element>
+
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="Discount" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:attribute name="Percent" use="required">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="100"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                  <xs:attribute name="NightsRequired"   type="def_int_gt0"/>
+                                  <xs:attribute name="NightsDiscounted" type="def_int_gt0"/>
+                                  <xs:attribute name="DiscountPattern">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:pattern value="0*1*"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="Guests" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+
+                                    <xs:element name="Guest">
+                                      <xs:complexType>
+                                        <xs:attribute name="AgeQualifyingCode" use="required" type="def_int_gt0"/>
+                                        <xs:attribute name="MaxAge"            use="required" type="def_int_gt0"/>
+                                        <xs:attribute name="MinCount"          use="required" type="def_int_ge0"/>
+                                          <xs:attribute name="FirstQualifyingPosition" use="required">
+                                            <xs:simpleType>
+                                              <xs:restriction base="xs:string">
+                                                <xs:enumeration value="1"/>
+                                              </xs:restriction>
+                                            </xs:simpleType>
+                                          </xs:attribute>
+                                          <xs:attribute name="LastQualifyingPosition" use="required" type="def_int_gt0"/>
+                                      </xs:complexType>
+                                    </xs:element>
+
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+
+                  <!-- RatePlans > RatePlan > Description {0,5} -->
+
+                  <xs:element name="Description" minOccurs="0" maxOccurs="5">
+                    <xs:complexType>
+                      <xs:sequence>
+
+                        <xs:choice maxOccurs="unbounded">
+
+                          <xs:element name="ListItem" type="def_nonempty_string"/>
+
+                          <xs:element name="Image" type="def_url_string"/>
+
+                          <xs:element name="Text">
+                            <xs:complexType>                    
+                               <xs:simpleContent>                
+                                 <xs:extension base="def_nonempty_string">
+                                   <xs:attribute name="TextFormat" use="required">
+                                     <xs:simpleType>             
+                                       <xs:restriction base="xs:string">
+                                         <xs:enumeration value="PlainText"/>
+                                         <xs:enumeration value="HTML"/> 
+                                       </xs:restriction>         
+                                     </xs:simpleType>            
+                                   </xs:attribute>               
+                                   <xs:attribute name="Language">
+                                     <xs:simpleType>             
+                                       <xs:restriction base="xs:language">
+                                         <xs:pattern value="[a-z][a-z]"/>
+                                       </xs:restriction>         
+                                     </xs:simpleType>            
+                                   </xs:attribute>               
+                                 </xs:extension>                 
+                               </xs:simpleContent>               
+                             </xs:complexType>                   
+                          </xs:element>
+                      
+                          <xs:element name="URL" type="def_url_string"/>
+
+                        </xs:choice>
+
+                      </xs:sequence>
+
+                      <xs:attribute name="Name" use="required">
+                        <xs:simpleType>
+                          <xs:restriction base="xs:string">
+                            <xs:enumeration value="title"/>
+                            <xs:enumeration value="intro"/>
+                            <xs:enumeration value="description"/>
+                            <xs:enumeration value="gallery"/>
+                            <xs:enumeration value="codelist"/>
+                          </xs:restriction>
+                        </xs:simpleType>
+                      </xs:attribute>
+                    </xs:complexType>
+                  </xs:element>
+
+                </xs:sequence>
+                <xs:attribute name="Start" type="def_date"/>
+                <xs:attribute name="End"   type="def_date"/>
+                <xs:attribute name="RatePlanNotifType">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                      <xs:enumeration value="Overlay"/>
+                      <xs:enumeration value="New"/>
+                      <xs:enumeration value="Remove"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="CurrencyCode">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                      <xs:enumeration value="EUR"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="RatePlanCode" type="def_nonempty_string"/>
+                <xs:attribute name="RatePlanType">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                      <xs:enumeration value="12"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:attribute>                
+                <xs:attribute name="RatePlanCategory" type="def_nonempty_string"/>
+                <xs:attribute name="RatePlanID" type="def_nonempty_string"/>
+                <xs:attribute name="RatePlanQualifier" type="def_bool"/>
+              </xs:complexType>
+            </xs:element> <!-- close RatePlan -->
+
+          </xs:sequence>
+          <xs:attribute name="HotelCode" type="def_nonempty_string"/>
+          <xs:attribute name="HotelName" type="def_nonempty_string"/>
+        </xs:complexType>
+
+      </xs:element>
+
+    </xs:sequence>
+
+  </xs:group>
+
+   
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for success/advisory/warning/error responses                -->
+  <!-- ******************************************************************************* -->
+
+  <xs:group name="def_generic_response">
+    <xs:choice>
+
+      <!-- choice: Errors {1} -->
+
+      <xs:element name="Errors">
+        <xs:complexType>
+          <xs:sequence>
+
+            <!-- Errors > Error {1,} -->
+
+            <xs:element name="Error" maxOccurs="unbounded">
+              <xs:complexType mixed="true">
+                <xs:attribute name="Type" use="required">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                      <xs:enumeration value="13"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="Code" use="required" type="def_int_gt0"/>
+              </xs:complexType>
+            </xs:element>
+
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+      <!-- choice: Success {1} + Warnings {0,1} -->
+
+      <xs:sequence>
+
+        <xs:element name="Success"/>
+
+        <xs:element name="Warnings" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+
+            <!-- Warnings > Warning {1,} -->
+
+              <xs:element name="Warning" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type"     use="required" type="def_int_gt0"/>
+                  <xs:attribute name="RecordID"                type="def_nonempty_string"/>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+
+    </xs:choice>
+  </xs:group>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for recurring, simple types                                 -->
+  <!-- ******************************************************************************* -->
+
+  <!-- A generic non-empty string type. -->
+
+  <xs:simpleType name="def_nonempty_string">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic string type containing an @ char, like an email address -->
+
+  <xs:simpleType name="def_email_string">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\S+@\S+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- String type defining room category codes (like InvTypeCode)  -->
+
+  <xs:simpleType name="def_invTypeCode_string">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+      <xs:maxLength value="8"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic string type starting with http:// or https:// -->
+
+  <xs:simpleType name="def_url_string">
+    <xs:restriction base="xs:anyURI">
+      <xs:pattern value="https?://.+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+  <!-- A generic integer > 0 type. -->
+
+  <xs:simpleType name="def_int_gt0">
+    <xs:restriction base="xs:positiveInteger">
+      <xs:pattern value="[0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic integer >= 0 type. -->
+
+  <xs:simpleType name="def_int_ge0">
+    <xs:restriction base="xs:nonNegativeInteger">
+      <xs:pattern value="[0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic decimal >= 0 type. -->
+
+  <xs:simpleType name="def_decimal_ge0">
+    <xs:restriction base="xs:decimal">
+      <xs:minInclusive value="0.0"/>
+      <xs:pattern value="[0-9]*\.?[0-9]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic decimal > 0 type. -->
+
+  <xs:simpleType name="def_decimal_gt0">
+    <xs:restriction base="xs:decimal">
+      <xs:minExclusive value="0.0"/>
+      <xs:pattern value="[0-9]*\.?[0-9]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic date type. -->
+
+  <xs:simpleType name="def_date">
+    <xs:restriction base="xs:date">
+      <xs:pattern value="\S+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic datetime type. -->
+
+  <xs:simpleType name="def_datetime">
+    <xs:restriction base="xs:dateTime">
+      <xs:pattern value="\S+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic boolean type (1,true,0,false). -->
+
+  <xs:simpleType name="def_bool">
+    <xs:restriction base="xs:boolean">
+      <xs:pattern value="\S+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+</xs:schema>

--- a/alpinebits-xml/impl/src/test/resources/schema/alpinebits-2017-10.rng
+++ b/alpinebits-xml/impl/src/test/resources/schema/alpinebits-2017-10.rng
@@ -1,0 +1,2821 @@
+<?xml version="1.0"?>
+
+<!--
+     AlpineBits 2017-10
+     http://www.alpinebits.org/
+
+     Relax-NG grammar file
+
+     changelog:
+
+    v. 2017-10  1.3 -  Inventory common type def_hoteldescriptivecontents -> FacilityInfo -> ... -> MultimediaDescription (allow one or more ImageItem elements for InfoCode="23")
+
+    v. 2017-10  1.2 -  FreeRooms:       OTA_HotelAvailNotifRQ -> AvailStatusMessages -> ...  -> StatusApplicationControl (make BookingThreshold not mandatory)
+
+    v. 2017-10  1.1 -  RatePlans:       RatePlans > RatePlan > Offers: allow only MinLOS and MaxLOS attributes (not the forward ones too)
+
+    v. 2017-10  1.0 -  FreeRooms:       OTA_HotelAvailNotifRQ -> UniqueID (added allowed value to attribute Type, by Luca Rainone)
+                       FreeRooms:       OTA_HotelAvailNotifRQ -> AvailStatusMessages -> ...  -> StatusApplicationControl (added new mandatory attribute BookingThreshold)
+
+                       GuestRequests:   OTA_ResRetrieveRS -> ReservationsList -> ... -> RatePlan (added element Commission)
+                       GuestRequests:   OTA_ResRetrieveRS -> ReservationsList -> ... -> CardNumber (added attributes EncryptedValue and EncryptionMethod) 
+                       GuestRequests:   OTA_ResRetrieveRS -> ReservationsList -> ... -> RoomStay > RoomTypes (made optional)
+
+                       SimplePackages section removed
+
+                       Inventory has become Inventory/Basic (Push) and Inventory/HotelInfo (Push):
+                                        OTA_HotelDescriptiveContentNotifRQ (major changes, one being that empty GuestRooms elements are now allowed by Luca Rainone)
+
+                       Inventory/Basic (Pull) and Inventory/HotelInfo (Pull) added
+ 
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> BookingRules -> ... -> LengthOfStay (added allowed values to attribute MinMaxMessageType)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Supplements -> Supplement (added element PrerequisiteInventory)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Supplements -> Supplement -> Description (major changes)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Offers -> Offer (major changes)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Description (major changes)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> ... -> BaseByGuestAmt (NumberOfGuests and Type are optional now to allow static rates)
+
+                       BaseRates section added
+
+    v. 2015-07b 1.4 - weaken the schema for Inventory (to prepare for upcoming release that will support Inventory deltas):
+
+                      - the RoomAmenityCode attribute becomes optional to allow empty Amenity elements 
+                      - the MultimediaDescription element can be empty
+
+    v. 2015-07b 1.3 - RatePlans > RatePlan > Description > TextFormat can now also be "HTML" (besides "PlainText")
+
+    v. 2015-07b 1.2 - added optional attributes RatePlanID and RatePlanQualifier to RatePlan
+                      for the new OTA_HotelRatePlanNotif_accept_RatePlanJoin capability
+
+    v. 2015-07b 1.1 - added def_invTypeCode_string type (string with up to 8 chars) used for the following attributes that identify room categories:
+
+                      FreeRooms:     OTA_HotelAvailNotifRQ -> AvailStatusMessages -> AvailStatusMessage -> StatusApplicationControl -> InvTypeCode
+                      GuestRequests: OTA_ResRetrieveRS -> ReservationList -> HotelReservation -> RoomStays -> RoomStay -> RoomTypes > RoomType -> RoomTypeCode
+                      Inventory:     OTA_HotelDescriptiveContentNotifRQ -> HotelDescriptiveContents -> HotelDescriptiveContent -> FacilityInfo -> GuestRooms -> GuestRoom -> Code
+                      RatePlan:      OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> BookingRules -> BookingRule -> Code
+                      RatePlan:      OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Rates -> Rate -> InvTypeCode
+
+    v. 2015-07b 1.0 - RatePlans > RatePlan > Rates > Rate > BaseByGuestAmts > AmountAfterTax
+                      must be > 0.0 (was: >= 0.0)
+
+     v. 2015-07 2.8 - Inventory: fixed the checks for the HotelDescriptiveContent attributes
+
+     v. 2015-07 2.7 - Inventory: reconciled with the definitions given in the updated document
+
+     v. 2015-07 2.6 - added section for New Inventory (exact name pending)
+
+     v. 2015-07 2.5 - made sub-elements of HotelReservation > ... > Customer > Address {0,1} optional
+
+     v. 2015-07 2.4 - added a choice of 'Modify' for ResStatusValue
+
+     v. 2015-07 2.3 - added MinCount attribute to Offer>>Guest
+
+     v. 2015-07 2.2 - changes to Supplement: a few attributes are removed and many attributes are made optional
+
+     v. 2015-07 2.1 - RatePlans/Supplements: changed format of description
+
+     v. 2015-07 2.0 - GuestRequests: ResGuests >> Customer: attributes Gender and Language are now optional
+
+     v. 2015-07 1.9 - allow Warnings in OTA_NotifReportRQ messages
+
+     v. 2015-07 1.8 - GuestRequests: use CardNumber -> PlainText instead of the Remark attribute of
+                      PaymentCard under Guarantee; add BasicPropertyInfo element at the end of the 
+                      ResGlobalInfo block for OTA-2015A compatiblity
+
+     v. 2015-07 1.7 - allowed more than one HotelReservationID
+
+     v. 2015-07 1.6 - RatePlans: allow optional PrerequisiteInventory element under Supplement element
+
+     v. 2015-07 1.5 - Inventory: removed Amenities and added optional Room -> RoomTypeCode
+
+     v. 2015-07 1.4 - HotelReservationID -> ResID_Type is not limited to 13 anymore
+
+     v. 2015-07 1.3 - new section in RoomStays: Guarantee -> GuaranteesAccepted -> GuaranteeAccepted -> PaymentCard
+
+     v. 2015-07 1.2 - new section in ResGlobalInfo: Profiles -> ProfileInfo -> Profile -> CompanyInfo
+
+     v. 2015-07 1.1 - HotelReservation > RoomStays > RoomStay > RoomTypes > RoomType is now
+                      mandatory and has a new optional attribute RoomClassificationCode
+
+     v. 2015-07 1.0 - OTA_NotifReportRS besides Success, now also allows Error responses 
+
+     v. 2014-04 1.5 - [fixed] InvCode attribute in Supplement changed from def_int_ge0 to def_nonempty_string
+
+     v. 2014-04 1.4 - [strictness improvement] made BaseByGuestAmt->NumberOfGuests attribute mandatory for
+                      RatePlans and SimplePackages, made BaseByGuestAmt->Type attribute mandatory for RatePlans
+
+     v. 2014-04 1.3 - [improvement] RatePlans: remove RatePlan->Rate attributes that are not allowed
+                      (problem inherited from the xsd version where Rate is shared with SimplePackages
+
+     v. 2014-04 1.2 - [fixed] RatePlans: optional Rate attributes RateTimeUnit and UnitMultiplier added
+
+     v. 2014-04 1.1 - [fixed] GuestRequests: Email->Remark is an optional attribute
+                    - [fixed] GuestRequests: ReservationsList can be empty
+
+     v. 2014-04 1.0 - complete rewrite for 2014-04
+
+-->
+
+<rng:grammar     xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        ns="http://www.opentravel.org/OTA/2003/05"
+           datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+
+  <rng:start>
+    <rng:choice>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * FreeRooms                                                                     -->
+      <!-- ******************************************************************************* -->
+
+      <!-- FreeRooms: OTA_HotelAvailNotifRQ -->
+
+      <rng:element name="OTA_HotelAvailNotifRQ">
+
+        <!-- UniqueID {0,1} -->
+
+        <rng:optional>
+          <rng:element name="UniqueID">
+
+            <rng:attribute name="Type">
+              <rng:choice>
+                <rng:value type="string">16</rng:value>
+                <rng:value type="string">35</rng:value>
+              </rng:choice>
+            </rng:attribute>
+            <rng:attribute name="ID"/> <!-- an ID is required by OTA, we ignore the value -->
+            <rng:attribute name="Instance">
+              <rng:value type="string">CompleteSet</rng:value>
+            </rng:attribute>
+
+          </rng:element>
+        </rng:optional>
+
+         <!-- AvailStatusMessages {1} -->
+
+        <rng:element name="AvailStatusMessages">
+
+          <rng:oneOrMore>
+            <rng:choice>
+              <rng:attribute name="HotelCode">
+                <rng:ref name="def_nonempty_string"/>
+              </rng:attribute>
+              <rng:attribute name="HotelName">
+                <rng:ref name="def_nonempty_string"/>
+              </rng:attribute>
+            </rng:choice>
+          </rng:oneOrMore>
+
+          <!-- AvailStatusMessages > AvailStatusMessage (1,} -->
+
+          <rng:oneOrMore>
+            <rng:element name="AvailStatusMessage">
+
+              <!-- AvailStatusMessage is either empty or has
+                 attributes BookingLimit, BookingLimitMessageType, BookingThreshold (optional)
+                 and contains one StatusApplicationControl element -->
+
+              <rng:optional>
+
+                <rng:element name="StatusApplicationControl">
+
+                  <rng:attribute name="Start">
+                    <rng:ref name="def_date"/>
+                  </rng:attribute>
+                  <rng:attribute name="End">
+                    <rng:ref name="def_date"/>
+                  </rng:attribute>
+                  <rng:attribute name="InvTypeCode">
+                    <rng:ref name="def_invTypeCode_string"/>
+                  </rng:attribute>
+                  <rng:optional>
+                    <rng:attribute name="InvCode">
+                      <rng:ref name="def_nonempty_string"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                </rng:element>
+
+                <rng:attribute name="BookingLimit">
+                  <rng:ref name="def_int_ge0"/>
+                </rng:attribute>
+                <rng:optional>
+                  <rng:attribute name="BookingThreshold">
+                    <rng:ref name="def_int_ge0"/>
+                  </rng:attribute>
+                </rng:optional>
+                <rng:attribute name="BookingLimitMessageType">
+                  <rng:value type="string">SetLimit</rng:value>
+                </rng:attribute>
+
+              </rng:optional>
+
+            </rng:element>
+          </rng:oneOrMore>
+
+        </rng:element>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- FreeRooms: OTA_HotelAvailNotifRQ -->
+
+      <rng:element name="OTA_HotelAvailNotifRS">
+
+        <rng:ref name="def_generic_response"/>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * GuestRequests                                                                 -->
+      <!-- ******************************************************************************* -->
+
+      <!-- GuestRequests: OTA_ReadRQ -->
+
+      <rng:element name="OTA_ReadRQ">
+
+        <rng:element name="ReadRequests">
+    
+          <rng:element name="HotelReadRequest">
+        
+            <rng:optional>
+              <rng:element name="SelectionCriteria">
+          
+                <rng:attribute name="Start">
+                  <rng:ref name="def_datetime"/>
+                </rng:attribute>
+          
+              </rng:element>
+            </rng:optional>
+
+            <rng:oneOrMore>
+              <rng:choice>
+                <rng:attribute name="HotelCode">
+                  <rng:ref name="def_nonempty_string"/>
+                </rng:attribute>
+                <rng:attribute name="HotelName">
+                  <rng:ref name="def_nonempty_string"/>
+                </rng:attribute>
+              </rng:choice>
+            </rng:oneOrMore>
+
+          </rng:element>
+
+        </rng:element>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+  
+      </rng:element>
+
+      <!-- GuestRequests: OTA_ResRetrieveRS -->
+
+      <rng:element name="OTA_ResRetrieveRS">
+        <rng:choice>
+
+          <!-- choice: Errors {1} -->
+
+          <rng:element name="Errors">
+
+            <!-- Errors > Error {1,} -->
+
+            <rng:oneOrMore>
+              <rng:element name="Error">
+
+                <rng:attribute name="Type">
+                  <rng:value type="string">13</rng:value>
+                </rng:attribute>
+                <rng:attribute name="Code">
+                  <rng:ref name="def_int_ge0"/>
+                </rng:attribute>
+
+                <rng:text/>
+
+              </rng:element>
+
+            </rng:oneOrMore>
+          </rng:element>
+
+          <!-- choice: Success {1} + ReservationsList {1} -->
+
+          <rng:group>
+
+            <rng:element name="Success">
+              <rng:empty/>
+            </rng:element>
+
+            <rng:element name="ReservationsList">
+
+              <!-- HotelReservation {0,} -->
+
+              <rng:zeroOrMore>
+                <rng:element name="HotelReservation">
+
+                  <!-- HotelReservation > UniqueID {1} -->
+
+                  <rng:element name="UniqueID">
+
+                    <rng:attribute name="Type">
+                      <rng:choice>
+                        <rng:value>14</rng:value>
+                        <rng:value>15</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+
+                    <rng:attribute name="ID">
+                      <rng:ref name="def_nonempty_string"/>
+                    </rng:attribute>
+
+                  </rng:element>
+
+                  <!-- HotelReservation > RoomStays {0,1} -->
+
+                  <rng:optional>
+                    <rng:element name="RoomStays">
+
+                      <!-- HotelReservation > RoomStays > RoomStay {1,} -->
+
+                      <rng:oneOrMore>
+                        <rng:element name="RoomStay">
+
+                          <!-- HotelReservation > RoomStays > RoomStay > RoomTypes {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="RoomTypes">
+
+                              <!-- HotelReservation > RoomStays > RoomStay > RoomTypes > RoomType {1} -->
+
+                              <rng:element name="RoomType">
+                                <rng:optional>
+                                  <rng:attribute name="RoomTypeCode">
+                                    <rng:ref name="def_invTypeCode_string"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="RoomClassificationCode">
+                                    <rng:ref name="def_int_ge0"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                              </rng:element>
+                         
+                            </rng:element>
+                          </rng:optional>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > RatePlans {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="RatePlans">
+
+                              <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan {1} -->
+
+                              <rng:element name="RatePlan">
+
+                                <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan > Commission {0,1} -->
+
+                                <rng:optional>
+                                  <rng:element name="Commission">
+                                    <rng:choice>
+
+                                      <!-- Commission has either attribute "Percent" ... -->
+
+                                      <rng:attribute name="Percent">
+                                        <rng:ref name="def_int_ge0"/>
+                                      </rng:attribute>
+
+                                      <!-- ... or subelement "CommissionPayableAmount" -->
+
+                                      <rng:element name="CommissionPayableAmount">
+                                        <rng:attribute name="Amount">
+                                          <rng:ref name="def_decimal_ge0"/>
+                                        </rng:attribute>
+                                        <rng:attribute name="CurrencyCode">
+                                          <rng:choice>
+                                            <rng:value>EUR</rng:value>
+                                          </rng:choice>
+                                        </rng:attribute>
+                                      </rng:element>
+
+                                    </rng:choice>
+                                  </rng:element>
+                                </rng:optional>
+
+                                <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan > MealsIncluded {0,1} -->
+
+                                <rng:optional>
+                                  <rng:element name="MealsIncluded">
+
+                                    <rng:attribute name="MealPlanIndicator">
+                                      <rng:choice>
+                                        <rng:value>1</rng:value>
+                                        <rng:value>true</rng:value>
+                                      </rng:choice>
+                                    </rng:attribute>
+                                    <rng:attribute name="MealPlanCodes">
+                                      <rng:choice>
+                                        <rng:value>1</rng:value>
+                                        <rng:value>3</rng:value>
+                                        <rng:value>10</rng:value>
+                                        <rng:value>12</rng:value>
+                                        <rng:value>14</rng:value>
+                                      </rng:choice>
+                                    </rng:attribute>
+
+                                  </rng:element>
+                                </rng:optional>
+
+                                <rng:optional>
+                                  <rng:attribute name="RatePlanCode">
+                                    <rng:ref name="def_nonempty_string"/>
+                                  </rng:attribute>
+                                </rng:optional>
+
+                              </rng:element>
+
+                            </rng:element>
+
+                          </rng:optional>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > GuestCounts {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="GuestCounts">
+
+                              <!-- HotelReservation > RoomStays > RoomStay > GuestCounts > GuestCount {1,} -->
+
+                              <rng:oneOrMore>
+                                <rng:element name="GuestCount">
+
+                                  <rng:attribute name="Count">
+                                    <rng:ref name="def_int_gt0"/>
+                                  </rng:attribute>
+                                  <rng:optional>
+                                    <rng:attribute name="Age">
+                                      <rng:ref name="def_int_ge0"/>
+                                    </rng:attribute>
+                                  </rng:optional>
+
+                                </rng:element>
+                              </rng:oneOrMore>
+
+                            </rng:element>
+                          </rng:optional>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > TimeSpan {1} -->
+
+                          <rng:element name="TimeSpan">
+
+                            <!-- HotelReservation > RoomStays > RoomStay > TimeSpan > StartDateWindow {0,1} -->
+
+                            <rng:optional>
+                              <rng:element name="StartDateWindow">
+
+                                <rng:attribute name="EarliestDate">
+                                  <rng:ref name="def_date"/>
+                                </rng:attribute>
+                                <rng:attribute name="LatestDate">
+                                  <rng:ref name="def_date"/>
+                                </rng:attribute>
+
+                              </rng:element>
+                            </rng:optional>
+
+                            <rng:optional>
+                              <rng:attribute name="Start">
+                                <rng:ref name="def_date"/>
+                              </rng:attribute>
+                            </rng:optional>
+                            <rng:optional>
+                              <rng:attribute name="End">
+                                <rng:ref name="def_date"/>
+                              </rng:attribute>
+                            </rng:optional>
+                            <rng:optional>
+                              <rng:attribute name="Duration">
+                                <rng:data type="string">
+                                  <rng:param name="pattern">P[0-9]+N</rng:param>
+                                </rng:data>
+                              </rng:attribute>
+                            </rng:optional>
+
+                          </rng:element>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > Guarantee {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="Guarantee">
+                              <rng:element name="GuaranteesAccepted">
+                                <rng:element name="GuaranteeAccepted">
+
+                                  <rng:element name="PaymentCard">
+
+                                    <rng:attribute name="CardCode">
+                                      <rng:data type="string">
+                                        <rng:param name="pattern">[A-Z][A-Z]?</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+                                    <rng:attribute name="ExpireDate">
+                                      <rng:data type="string">
+                                        <rng:param name="pattern">[0-9][0-9][0-9][0-9]</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+
+                                    <rng:element name="CardHolderName">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:element>
+
+                                    <rng:element name="CardNumber">
+
+                                      <rng:choice>
+
+                                        <rng:element name="PlainText">
+                                          <rng:ref name="def_nonempty_string"/>
+                                        </rng:element>
+
+                                        <rng:group>
+                                          <rng:attribute name="EncryptedValue">
+                                            <rng:ref name="def_nonempty_string"/>
+                                          </rng:attribute>
+                                          <rng:attribute name="EncryptionMethod">
+                                            <rng:ref name="def_nonempty_string"/>
+                                          </rng:attribute>
+                                        </rng:group>
+
+                                      </rng:choice>
+
+                                    </rng:element>
+
+                                  </rng:element>
+
+                                </rng:element>
+                              </rng:element>
+                            </rng:element>
+                          </rng:optional>
+
+                          <!-- HotelReservation > RoomStays > RoomStay > Total {0,1} -->
+
+                          <rng:optional>
+                            <rng:element name="Total">
+
+                              <rng:attribute name="AmountAfterTax">
+                                <rng:ref name="def_decimal_ge0"/>
+                              </rng:attribute>
+                              <rng:attribute name="CurrencyCode">
+                                <rng:ref name="def_nonempty_string"/>
+                              </rng:attribute>
+
+                            </rng:element>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:oneOrMore>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <!-- HotelReservation > ResGuests {0, 1} -->
+
+                  <rng:optional>
+                    <rng:element name="ResGuests">
+                      <rng:element name="ResGuest">
+                        <rng:element name="Profiles">
+                          <rng:element name="ProfileInfo">
+                            <rng:element name="Profile">
+
+                              <!-- HotelReservation > ... > Customer {1} -->
+
+                              <rng:element name="Customer">
+
+                                <!-- HotelReservation > ... > Customer > PersonName {1} -->
+
+                                <rng:element name="PersonName">
+
+                                  <rng:optional>
+                                    <rng:element name="NamePrefix">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:element>
+                                  </rng:optional>
+                                  <rng:element name="GivenName">
+                                    <rng:ref name="def_nonempty_string"/>
+                                  </rng:element>
+                                  <rng:element name="Surname">
+                                    <rng:ref name="def_nonempty_string"/>
+                                  </rng:element>
+                                  <rng:optional>
+                                    <rng:element name="NameTitle">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:element>
+
+                                  </rng:optional>
+                                </rng:element>
+
+                                <!-- HotelReservation > ... > Customer > Telephone {0,} -->
+
+                                <rng:zeroOrMore>
+                                  <rng:element name="Telephone">
+
+                                    <rng:attribute name="PhoneTechType">
+                                      <rng:data type="string">
+                                        <rng:param name="pattern">(1|3|5)</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+                                    <rng:attribute name="PhoneNumber">
+                                      <rng:data type="string">
+                                        <rng:param name="pattern">\+?[0-9]+</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+
+                                  </rng:element>
+                                </rng:zeroOrMore>
+
+                                <!-- HotelReservation > ... > Customer > Email {0,1} -->
+
+                                <rng:optional>
+                                  <rng:element name="Email">
+                                    <rng:ref name="def_email_string"/>
+                                    <rng:optional>
+                                      <rng:attribute name="Remark">
+                                        <rng:data type="string">
+                                          <rng:param name="pattern">newsletter:(no|yes)</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                    </rng:optional>
+
+                                  </rng:element>
+                                </rng:optional>
+
+                                <!-- HotelReservation > ... > Customer > Address {0,1} -->
+
+                                <rng:optional>
+                                  <rng:element name="Address">
+
+                                    <rng:optional>
+                                      <rng:element name="AddressLine">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                    </rng:optional>
+
+                                    <rng:optional>
+                                      <rng:element name="CityName">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                    </rng:optional>
+
+                                    <rng:optional>
+                                      <rng:element name="PostalCode">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                    </rng:optional>
+
+                                    <rng:optional>
+                                      <rng:element name="CountryName">
+                                        <rng:attribute name="Code">
+                                          <rng:data type="string">
+                                            <rng:param name="pattern">[A-Z][A-Z]</rng:param>
+                                          </rng:data>
+                                        </rng:attribute>
+                                      </rng:element>
+                                    </rng:optional>
+
+                                    <rng:optional>
+                                      <rng:attribute name="Remark">
+                                        <rng:data type="string">
+                                          <rng:param name="pattern">catalog:(no|yes)</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                    </rng:optional>
+
+                                  </rng:element>
+                                </rng:optional>
+
+                                <rng:optional>
+                                  <rng:attribute name="Gender">
+                                    <rng:data type="string">
+                                      <rng:param name="pattern">(Unknown|Male|Female)</rng:param>
+                                    </rng:data>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="BirthDate">
+                                    <rng:ref name="def_date"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Language">
+                                    <rng:data type="language">
+                                      <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                    </rng:data>
+                                  </rng:attribute>
+                                </rng:optional>
+
+                              </rng:element>
+                            </rng:element>
+                          </rng:element>
+                        </rng:element>
+                      </rng:element>
+                    </rng:element>
+                  </rng:optional>
+
+                  <!-- HotelReservation > ResGlobalInfo {0,1} -->
+
+                  <rng:optional>
+                    <rng:element name="ResGlobalInfo">
+
+                      <!-- HotelReservation > ResGlobalInfo > Comments {0,1} -->
+
+                      <rng:optional>
+                        <rng:element name="Comments">
+
+                          <!-- HotelReservation > ResGlobalInfo > Comments {1,} (actually {1,2} but Relax-NG cannot do this) -->
+
+                          <rng:oneOrMore>
+                            <rng:element name="Comment">
+                         
+                              <rng:choice>
+                                <rng:zeroOrMore>
+                         
+                                  <rng:element name="ListItem">
+                                    <rng:ref name="def_nonempty_string"/>
+                                    <rng:attribute name="ListItem">
+                                      <rng:ref name="def_int_ge0"/>
+                                    </rng:attribute>
+                                    <rng:attribute name="Language">
+                                      <rng:data type="language">
+                                        <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                      </rng:data>
+                                    </rng:attribute>
+                         
+                                  </rng:element>
+                                </rng:zeroOrMore>
+                         
+                                <rng:optional>
+                                  <rng:element name="Text">
+                                    <rng:ref name="def_nonempty_string"/>
+                                  </rng:element>
+                                </rng:optional>
+                         
+                              </rng:choice>
+                         
+                              <rng:attribute name="Name">
+                                <rng:choice>
+                                  <rng:value>included services</rng:value>
+                                  <rng:value>customer comment</rng:value>
+                                </rng:choice>
+                              </rng:attribute>
+                         
+                            </rng:element>
+                          </rng:oneOrMore>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <!-- HotelReservation > ResGlobalInfo > CancelPenalties {0,1} -->
+
+                      <rng:optional>
+                        <rng:element name="CancelPenalties">
+                          <rng:element name="CancelPenalty">
+                            <rng:element name="PenaltyDescription">
+                              <rng:element name="Text">
+                                <rng:ref name="def_nonempty_string"/>
+                              </rng:element>
+                            </rng:element>
+                          </rng:element>
+                        </rng:element>
+                      </rng:optional>
+
+                      <!-- HotelReservation > ResGlobalInfo > HotelReservationIDs {0,1} -->
+
+                      <rng:optional>
+                        <rng:element name="HotelReservationIDs">
+
+                          <rng:oneOrMore>
+                            <rng:element name="HotelReservationID">
+                          
+                              <rng:attribute name="ResID_Type">
+                                  <rng:ref name="def_int_gt0"/>
+                              </rng:attribute>
+                              <rng:optional>
+                                <rng:attribute name="ResID_Value">
+                                  <rng:ref name="def_nonempty_string"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="ResID_Source">
+                                  <rng:ref name="def_nonempty_string"/>
+                                </rng:attribute>
+                              </rng:optional>
+                              <rng:optional>
+                                <rng:attribute name="ResID_SourceContext">
+                                  <rng:ref name="def_nonempty_string"/>
+                                </rng:attribute>
+                              </rng:optional>
+                          
+                            </rng:element>
+                          </rng:oneOrMore>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <!-- HotelReservation > ResGlobalInfo > Profiles {0,1} -->
+
+                      <rng:optional>
+                        <rng:element name="Profiles">
+                          <rng:element name="ProfileInfo">
+                            <rng:element name="Profile">
+                          
+                              <rng:attribute name="ProfileType">
+                                <rng:choice>
+                                  <rng:value>4</rng:value>
+                                </rng:choice>
+                              </rng:attribute>
+                          
+                              <rng:element name="CompanyInfo">
+                          
+                                  <rng:element name="CompanyName">
+                                    <rng:ref name="def_nonempty_string"/>
+                                    <rng:attribute name="Code">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:attribute>
+                                    <rng:attribute name="CodeContext">
+                                      <rng:ref name="def_nonempty_string"/>
+                                    </rng:attribute>
+                                  </rng:element>
+                          
+                                  <rng:optional>
+                                    <rng:element name="AddressInfo">
+                                      <rng:element name="AddressLine">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                      <rng:element name="CityName">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                      <rng:element name="PostalCode">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:element>
+                                      <rng:element name="CountryName">
+                                        <rng:attribute name="Code">
+                                          <rng:data type="string">
+                                            <rng:param name="pattern">[A-Z][A-Z]</rng:param>
+                                          </rng:data>
+                                        </rng:attribute>
+                                      </rng:element>
+                                    </rng:element>
+                                  </rng:optional>
+                          
+                                  <rng:optional>
+                                    <rng:element name="TelephoneInfo">
+                                      <rng:attribute name="PhoneTechType">
+                                        <rng:data type="string">
+                                          <rng:param name="pattern">(1|3|5)</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                      <rng:attribute name="PhoneNumber">
+                                        <rng:data type="string">
+                                          <rng:param name="pattern">\+?[0-9]+</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                    </rng:element>
+                                  </rng:optional>
+                                  <rng:optional>
+                                    <rng:element name="Email">
+                                      <rng:ref name="def_email_string"/>
+                                    </rng:element>
+                                  </rng:optional>
+                          
+                              </rng:element>
+                          
+                            </rng:element>
+                          </rng:element>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <rng:element name="BasicPropertyInfo">
+                        <rng:empty/>
+                      </rng:element>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:attribute name="CreateDateTime">
+                    <rng:ref name="def_datetime"/>
+                  </rng:attribute>
+                  <rng:attribute name="ResStatus">
+                    <rng:choice>
+                      <rng:value>Requested</rng:value>
+                      <rng:value>Reserved</rng:value>
+                      <rng:value>Cancelled</rng:value>
+                      <rng:value>Modify</rng:value>
+                    </rng:choice>
+                  </rng:attribute>
+
+                </rng:element>
+              </rng:zeroOrMore>
+
+            </rng:element>
+          </rng:group>
+
+        </rng:choice>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- GuestRequests: OTA_NotifReportRQ -->
+
+      <rng:element name="OTA_NotifReportRQ">
+
+        <rng:element name="Success">
+          <rng:empty/>
+        </rng:element>
+
+        <rng:optional>
+          <rng:element name="Warnings">
+        
+            <!-- Warnings > Warning {1,} -->
+
+            <rng:oneOrMore>
+              <rng:element name="Warning">
+          
+                <rng:attribute name="Type">
+                  <rng:ref name="def_int_gt0"/>
+                </rng:attribute>
+
+                <rng:attribute name="Code">
+                  <rng:ref name="def_int_gt0"/>
+                </rng:attribute>
+
+                  <rng:attribute name="RecordID">
+                    <rng:ref name="def_nonempty_string"/>
+                  </rng:attribute>
+
+                <rng:text/>
+          
+              </rng:element>
+            </rng:oneOrMore>
+
+          </rng:element>
+        </rng:optional>
+
+        <rng:optional>
+          <rng:element name="NotifDetails">
+
+            <rng:element name="HotelNotifReport">
+
+              <rng:element name="HotelReservations">
+
+                <rng:oneOrMore>
+                  <rng:element name="HotelReservation">
+
+                    <rng:element name="UniqueID">
+
+                      <rng:attribute name="Type">
+                        <rng:choice>
+                          <rng:value>14</rng:value>
+                          <rng:value>15</rng:value>
+                        </rng:choice>
+                      </rng:attribute>
+                      <rng:attribute name="ID">
+                        <rng:ref name="def_nonempty_string"/>
+                      </rng:attribute>
+
+                    </rng:element>
+
+                  </rng:element>
+                </rng:oneOrMore>
+
+              </rng:element>
+
+            </rng:element>
+
+          </rng:element>
+
+        </rng:optional>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- GuestRequests: OTA_NotifReportRS -->
+
+      <rng:element name="OTA_NotifReportRS">
+
+        <rng:choice>
+
+          <!-- choice: Errors {1} -->
+
+          <rng:element name="Errors">
+
+            <!-- Errors > Error {1,} -->
+
+            <rng:oneOrMore>
+              <rng:element name="Error">
+
+                <rng:attribute name="Type">
+                  <rng:value type="string">13</rng:value>
+                </rng:attribute>
+                <rng:attribute name="Code">
+                  <rng:ref name="def_int_ge0"/>
+                </rng:attribute>
+
+                <rng:text/>
+
+              </rng:element>
+
+            </rng:oneOrMore>
+
+          </rng:element>
+
+          <!-- choice: Success {1} -->
+
+          <rng:element name="Success">
+            <rng:empty/>
+          </rng:element>
+
+        </rng:choice>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+ 
+      </rng:element>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * Inventory/Basic (Push) and Inventory/HotelInfo (Push)                         -->
+      <!-- ******************************************************************************* -->
+
+      <!-- Inventory: OTA_HotelDescriptiveContentNotifRQ -->
+
+      <rng:element name="OTA_HotelDescriptiveContentNotifRQ">
+
+        <rng:ref name="def_hoteldescriptivecontents"/>
+        
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- Inventory: OTA_HotelDescriptiveContentNotifRS -->
+
+      <rng:element name="OTA_HotelDescriptiveContentNotifRS">
+
+        <rng:ref name="def_generic_response"/>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * Inventory/Basic (Pull) and Inventory/HotelInfo (Pull)                         -->
+      <!-- ******************************************************************************* -->
+
+      <!-- Inventory: OTA_HotelDescriptiveInfoRQ -->
+
+      <rng:element name="OTA_HotelDescriptiveInfoRQ">
+
+        <rng:element name="HotelDescriptiveInfos">
+
+          <rng:element name="HotelDescriptiveInfo">
+            <rng:oneOrMore>
+              <rng:choice>
+                <rng:attribute name="HotelCode">
+                  <rng:ref name="def_nonempty_string"/>
+                </rng:attribute>
+                <rng:attribute name="HotelName">
+                  <rng:ref name="def_nonempty_string"/>
+                </rng:attribute>
+              </rng:choice>
+            </rng:oneOrMore>
+          </rng:element>
+
+        </rng:element>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+       
+      <!-- Inventory: OTA_HotelDescriptiveInfoRS -->
+
+      <rng:element name="OTA_HotelDescriptiveInfoRS">
+
+        <rng:choice>
+
+          <!-- choice: Errors {1} -->
+       
+          <rng:element name="Errors">
+        
+            <!-- Errors > Error {1,} -->
+       
+            <rng:oneOrMore>
+              <rng:element name="Error">
+       
+                <rng:attribute name="Type">
+                  <rng:value type="string">13</rng:value>
+                </rng:attribute>
+                <rng:attribute name="Code">
+                  <rng:ref name="def_int_gt0"/>
+                </rng:attribute>
+       
+                <rng:text/>
+       
+              </rng:element>
+            </rng:oneOrMore>
+       
+          </rng:element>
+       
+          <!-- choice: Success {1} + HotelDescriptiveContents {1} -->
+       
+          <rng:group>
+       
+            <rng:element name="Success">
+              <rng:empty/>
+            </rng:element>
+       
+            <rng:ref name="def_hoteldescriptivecontents"/>
+      
+          </rng:group>
+
+        </rng:choice>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+ 
+      <!-- ******************************************************************************* -->
+      <!-- * RatePlans                                                                     -->
+      <!-- ******************************************************************************* -->
+
+      <!-- RatePlans: OTA_HotelRatePlanNotifRQ  --> 
+
+      <rng:element name="OTA_HotelRatePlanNotifRQ">
+
+        <!-- UniqueID {0,1} -->
+
+        <rng:optional>
+          <rng:element name="UniqueID">
+
+            <rng:attribute name="Type">
+              <rng:value type="string">16</rng:value>
+            </rng:attribute>
+            <rng:attribute name="ID"/> <!-- an ID is required by OTA, we ignore the value -->
+            <rng:attribute name="Instance">
+              <rng:value type="string">CompleteSet</rng:value>
+            </rng:attribute>
+
+          </rng:element>
+        </rng:optional>
+
+        <!-- RatePlans {1} -->
+
+        <rng:ref name="def_rateplans"/>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+      <!-- RatePlans: OTA_HotelRatePlanNotifRS -->
+
+      <rng:element name="OTA_HotelRatePlanNotifRS">
+
+        <rng:ref name="def_generic_response"/>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+
+
+      <!-- ******************************************************************************* -->
+      <!-- * BaseRates                                                                     -->
+      <!-- ******************************************************************************* -->
+
+      <!-- BaseRates: OTA_HotelRatePlanRQ --> 
+
+      <rng:element name="OTA_HotelRatePlanRQ">
+
+        <!-- RatePlans {1} -->
+
+        <rng:element name="RatePlans">
+
+          <!-- RatePlans > RatePlan {1} -->
+
+          <rng:element name="RatePlan">
+
+            <rng:oneOrMore>
+              <rng:choice>
+
+                <rng:element name="DateRange">
+                  <rng:optional>
+                    <rng:attribute name="Start">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="End">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+                </rng:element>
+
+                <rng:element name="RatePlanCandidates">
+                  <rng:oneOrMore>
+                    <rng:element name="RatePlanCandidate">
+                      <rng:optional>
+                         <rng:attribute name="RatePlanCode">
+                           <rng:ref name="def_nonempty_string"/>
+                         </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                         <rng:attribute name="RatePlanID">
+                           <rng:ref name="def_nonempty_string"/>
+                         </rng:attribute>
+                      </rng:optional>
+                    </rng:element>
+                  </rng:oneOrMore>
+                </rng:element>
+
+                <rng:element name="HotelRef">
+                  <rng:optional>
+                     <rng:attribute name="HotelCode">
+                       <rng:ref name="def_nonempty_string"/>
+                     </rng:attribute>
+                   </rng:optional>
+                  <rng:optional>
+                     <rng:attribute name="HotelName">
+                       <rng:ref name="def_nonempty_string"/>
+                     </rng:attribute>
+                  </rng:optional>
+                </rng:element>
+
+              </rng:choice>
+            </rng:oneOrMore>
+ 
+          </rng:element> <!-- close RatePlan -->
+
+        </rng:element> <!-- close RatePlans -->
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element> 
+
+      <!-- BaseRates: OTA_HotelRatePlanRS -->
+
+      <rng:element name="OTA_HotelRatePlanRS">
+
+        <rng:choice>
+
+          <!-- choice: Errors {1} -->
+       
+          <rng:element name="Errors">
+        
+            <!-- Errors > Error {1,} -->
+       
+            <rng:oneOrMore>
+              <rng:element name="Error">
+       
+                <rng:attribute name="Type">
+                  <rng:value type="string">13</rng:value>
+                </rng:attribute>
+                <rng:attribute name="Code">
+                  <rng:ref name="def_int_gt0"/>
+                </rng:attribute>
+       
+                <rng:text/>
+       
+              </rng:element>
+            </rng:oneOrMore>
+       
+          </rng:element>
+       
+          <!-- choice: Success {1} + RatePlans {1} -->
+       
+          <rng:group>
+       
+            <rng:element name="Success">
+              <rng:empty/>
+            </rng:element>
+       
+            <rng:ref name="def_rateplans"/>
+      
+          </rng:group>
+
+        </rng:choice>
+
+        <rng:attribute name="Version"/>
+        <rng:optional>
+          <rng:attribute name="TimeStamp"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:attribute name="xsi:schemaLocation"/>
+        </rng:optional>
+
+      </rng:element>
+ 
+    </rng:choice>
+  </rng:start>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for HotelDescriptiveContents element as used                -->
+  <!-- * in the Inventory types                                                        -->
+  <!-- ******************************************************************************* -->
+
+  <rng:define name="def_hoteldescriptivecontents">
+
+    <rng:element name="HotelDescriptiveContents">
+
+      <rng:element name="HotelDescriptiveContent">
+
+          <!-- HotelInfo -->
+
+          <rng:optional>
+            <rng:element name="HotelInfo">
+              <rng:zeroOrMore>
+                <rng:ref name="def_anything"/>
+              </rng:zeroOrMore>
+              <rng:zeroOrMore>
+                <rng:ref name="def_any_attribute"/>
+              </rng:zeroOrMore>
+            </rng:element>
+          </rng:optional>
+
+          <!-- FacilityInfo --> 
+
+          <rng:optional>
+            <rng:element name="FacilityInfo">
+       
+                <rng:element name="GuestRooms">
+                  
+                  <rng:zeroOrMore>
+                    <rng:choice>
+       
+                      <!-- basic content + basic descriptions + optionally additional description -->
+                      <rng:element name="GuestRoom">
+       
+                        <rng:element name="TypeRoom">
+                          <rng:optional>
+                            <rng:attribute name="StandardOccupancy">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="RoomClassificationCode">
+                              <rng:ref name="def_int_ge0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="RoomID">
+                              <rng:ref name="def_nonempty_string"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Size">
+                              <rng:ref name="def_int_ge0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                        </rng:element>
+       
+                        <rng:optional>
+                          <rng:element name="Amenities">
+                            <rng:oneOrMore>
+                              <rng:element name="Amenity">
+                                  <rng:optional>
+                                    <rng:attribute name="RoomAmenityCode">
+                                      <rng:ref name="def_int_gt0"/>
+                                    </rng:attribute>
+                                  </rng:optional>
+                              </rng:element>
+                            </rng:oneOrMore>
+                          </rng:element>
+                        </rng:optional>
+       
+                        <rng:optional>
+                          <rng:element name="MultimediaDescriptions">
+       
+                            <rng:oneOrMore>
+       
+                              <rng:choice>
+       
+                                <!-- basic description: Long name + Description -->
+                                <rng:element name="MultimediaDescription">
+       
+                                  <rng:optional>
+                                    <rng:element name="TextItems">
+                                      <rng:element name="TextItem">
+                                        <rng:zeroOrMore>
+                                          <rng:element name="Description">
+                                            <rng:ref name="def_nonempty_string"/>
+                                            <rng:attribute name="TextFormat">
+                                              <rng:choice>
+                                                <rng:value>PlainText</rng:value>
+                                              </rng:choice>
+                                            </rng:attribute>
+                                            <rng:attribute name="Language">
+                                              <rng:data type="language">
+                                                <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                              </rng:data>
+                                            </rng:attribute>
+                                          </rng:element>
+                                        </rng:zeroOrMore>
+                                      </rng:element>
+                                    </rng:element>
+                                  </rng:optional>
+       
+                                  <rng:optional>
+                                    <rng:attribute name="InfoCode">
+                                      <rng:choice>
+                                        <rng:value>1</rng:value>
+                                        <rng:value>25</rng:value>
+                                      </rng:choice>
+                                    </rng:attribute>
+                                  </rng:optional>
+       
+                                </rng:element>
+       
+                                <!-- basic description: Pictures -->
+                                <rng:element name="MultimediaDescription">
+       
+                                  <rng:optional>
+                                    <rng:element name="ImageItems">
+
+                                      <rng:oneOrMore>
+                                        <rng:element name="ImageItem">
+                                          <rng:element name="ImageFormat">
+                                            <rng:element name="URL">
+                                              <rng:ref name="def_url_string"/>
+                                            </rng:element>
+                                            <rng:optional>
+                                              <rng:attribute name="CopyrightNotice">
+                                                <rng:ref name="def_nonempty_string"/>
+                                              </rng:attribute>
+                                            </rng:optional>
+                                          </rng:element>
+                                      
+                                          <rng:zeroOrMore>
+                                            <rng:element name="Description">
+                                              <rng:ref name="def_nonempty_string"/>
+                                              <rng:attribute name="TextFormat">
+                                                <rng:choice>
+                                                  <rng:value>PlainText</rng:value>
+                                                </rng:choice>
+                                              </rng:attribute>
+                                              <rng:attribute name="Language">
+                                                <rng:data type="language">
+                                                  <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                                </rng:data>
+                                              </rng:attribute>
+                                            </rng:element>
+                                          </rng:zeroOrMore>
+                                      
+                                          <rng:attribute name="Category">
+                                            <rng:ref name="def_int_gt0"/>
+                                          </rng:attribute>
+
+                                        </rng:element>
+                                      </rng:oneOrMore>
+
+                                    </rng:element>
+                                  </rng:optional>
+       
+                                  <rng:optional>
+                                    <rng:attribute name="InfoCode">
+                                      <rng:choice>
+                                        <rng:value>23</rng:value>
+                                      </rng:choice>
+                                    </rng:attribute>
+                                  </rng:optional>
+       
+                                </rng:element>
+       
+                                <!-- additional description -->
+                                <rng:element name="MultimediaDescription">
+       
+                                  <rng:optional>
+                                    <rng:element name="ImageItems">
+                                  
+                                      <rng:oneOrMore>
+                                        <rng:element name="ImageItem">
+                                          <rng:element name="ImageFormat">
+                                            <rng:element name="URL">
+                                              <rng:ref name="def_url_string"/>
+                                            </rng:element>
+                                            <rng:optional>
+                                              <rng:attribute name="CopyrightNotice">
+                                                <rng:ref name="def_nonempty_string"/>
+                                              </rng:attribute>
+                                            </rng:optional>
+                                          </rng:element>
+                                  
+                                          <rng:zeroOrMore>
+                                            <rng:element name="Description">
+                                              <rng:ref name="def_nonempty_string"/>
+                                              <rng:attribute name="TextFormat">
+                                                <rng:choice>
+                                                  <rng:value>PlainText</rng:value>
+                                                </rng:choice>
+                                              </rng:attribute>
+                                              <rng:attribute name="Language">
+                                                <rng:data type="language">
+                                                  <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                                </rng:data>
+                                              </rng:attribute>
+                                            </rng:element>
+                                          </rng:zeroOrMore>
+                                  
+                                          <rng:attribute name="Category">
+                                            <rng:ref name="def_int_gt0"/>
+                                          </rng:attribute>
+                                        </rng:element>
+                                      </rng:oneOrMore>
+                                  
+                                    </rng:element>
+                                  </rng:optional>
+       
+                                </rng:element>
+       
+                              </rng:choice>
+                            </rng:oneOrMore>
+       
+                          </rng:element>
+                        </rng:optional>
+       
+                        <rng:attribute name="Code">
+                          <rng:ref name="def_invTypeCode_string"/>
+                        </rng:attribute>
+                        <rng:optional>
+                          <rng:attribute name="MaxOccupancy">
+                            <rng:ref name="def_int_gt0"/>
+                          </rng:attribute>
+                        </rng:optional>
+                        <rng:optional>
+                          <rng:attribute name="MinOccupancy">
+                            <rng:ref name="def_int_gt0"/>
+                          </rng:attribute>
+                        </rng:optional>
+                        <rng:optional>
+                          <rng:attribute name="MaxChildOccupancy">
+                            <rng:ref name="def_int_gt0"/>
+                          </rng:attribute>
+                        </rng:optional>
+                        <rng:optional>
+                          <rng:attribute name="ID">
+                            <rng:ref name="def_invTypeCode_string"/>
+                          </rng:attribute>
+                        </rng:optional>
+
+                      </rng:element>
+       
+                      <!-- additional detail only -->
+                      <rng:element name="GuestRoom">
+       
+                        <rng:element name="MultimediaDescriptions">
+                          <rng:element name="MultimediaDescription">
+                            <rng:element name="ImageItems">
+       
+                              <rng:oneOrMore>
+                                <rng:element name="ImageItem">
+                                  <rng:element name="ImageFormat">
+                                    <rng:element name="URL">
+                                      <rng:ref name="def_url_string"/>
+                                    </rng:element>
+                                    <rng:optional>
+                                      <rng:attribute name="CopyrightNotice">
+                                        <rng:ref name="def_nonempty_string"/>
+                                      </rng:attribute>
+                                    </rng:optional>
+                                  </rng:element>
+       
+                                  <rng:zeroOrMore>
+                                    <rng:element name="Description">
+                                      <rng:ref name="def_nonempty_string"/>
+                                      <rng:attribute name="TextFormat">
+                                        <rng:choice>
+                                          <rng:value>PlainText</rng:value>
+                                        </rng:choice>
+                                      </rng:attribute>
+                                      <rng:attribute name="Language">
+                                        <rng:data type="language">
+                                          <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                        </rng:data>
+                                      </rng:attribute>
+                                    </rng:element>
+                                  </rng:zeroOrMore>
+       
+                                  <rng:attribute name="Category">
+                                    <rng:ref name="def_int_gt0"/>
+                                  </rng:attribute>
+                                </rng:element>
+                              </rng:oneOrMore>
+       
+                            </rng:element>
+                          </rng:element>
+                        </rng:element>
+       
+                      <rng:attribute name="Code">
+                        <rng:ref name="def_nonempty_string"/>
+                      </rng:attribute>
+                      </rng:element>
+       
+                      <!-- room list -->
+                      <rng:element name="GuestRoom">
+                        <rng:element name="TypeRoom">
+                          <rng:attribute name="RoomID">
+                            <rng:ref name="def_nonempty_string"/>
+                          </rng:attribute>
+                        </rng:element>
+                      <rng:attribute name="Code">
+                        <rng:ref name="def_nonempty_string"/>
+                      </rng:attribute>
+                      </rng:element>
+       
+                    </rng:choice>
+                  </rng:zeroOrMore>
+                  
+                </rng:element>
+            </rng:element>
+          </rng:optional>
+       
+          <!-- Policies -->
+
+          <rng:optional>
+            <rng:element name="Policies">
+              <rng:zeroOrMore>
+                <rng:ref name="def_anything"/>
+              </rng:zeroOrMore>
+              <rng:zeroOrMore>
+                <rng:ref name="def_any_attribute"/>
+              </rng:zeroOrMore>
+            </rng:element>
+          </rng:optional>
+
+          <!-- AffiliationInfo -->
+
+          <rng:optional>
+            <rng:element name="AffiliationInfo">
+              <rng:zeroOrMore>
+                <rng:ref name="def_anything"/>
+              </rng:zeroOrMore>
+              <rng:zeroOrMore>
+                <rng:ref name="def_any_attribute"/>
+              </rng:zeroOrMore>
+            </rng:element>
+          </rng:optional>
+
+
+          <!-- ContactInfos -->
+
+          <rng:optional>
+            <rng:element name="ContactInfos">
+              <rng:zeroOrMore>
+                <rng:ref name="def_anything"/>
+              </rng:zeroOrMore>
+              <rng:zeroOrMore>
+                <rng:ref name="def_any_attribute"/>
+              </rng:zeroOrMore>
+            </rng:element>
+          </rng:optional>
+
+        <rng:oneOrMore>
+          <rng:choice>
+            <rng:attribute name="HotelCode">
+              <rng:ref name="def_nonempty_string"/>
+            </rng:attribute>
+            <rng:attribute name="HotelName">
+              <rng:ref name="def_nonempty_string"/>
+            </rng:attribute>
+            <rng:attribute name="HotelCityCode">
+              <rng:ref name="def_nonempty_string"/>
+            </rng:attribute>
+          </rng:choice>
+        </rng:oneOrMore>
+
+      </rng:element>
+        
+    </rng:element>
+
+  </rng:define>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for RatePlans element as used                               -->
+  <!-- * in RatePlans and BaseRates                                                    -->
+  <!-- ******************************************************************************* -->
+
+  <rng:define name="def_rateplans">
+
+    <rng:element name="RatePlans">
+
+      <!-- RatePlans > RatePlan {1,} -->
+
+      <rng:oneOrMore>
+        <rng:element name="RatePlan">
+
+          <!-- RatePlans > RatePlan > BookingRules {0,1} -->
+
+          <rng:optional>
+            <rng:element name="BookingRules">
+
+              <rng:oneOrMore>
+                <rng:element name="BookingRule">
+
+                  <rng:optional>
+                    <rng:element name="LengthsOfStay">
+
+                      <rng:oneOrMore>
+                        <rng:element name="LengthOfStay">
+
+                          <rng:attribute name="Time">
+                            <rng:ref name="def_decimal_ge0"/>
+                          </rng:attribute>
+                          <rng:attribute name="TimeUnit">
+                            <rng:value type="string">Day</rng:value>
+                          </rng:attribute>
+                          <rng:attribute name="MinMaxMessageType">
+                            <rng:choice>
+                              <rng:value>SetMinLOS</rng:value>
+                              <rng:value>SetForwardMinStay</rng:value>
+                              <rng:value>SetMaxLOS</rng:value>
+                              <rng:value>SetForwardMaxStay</rng:value>
+                            </rng:choice>
+                          </rng:attribute>
+
+                        </rng:element>
+                      </rng:oneOrMore>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:element name="DOW_Restrictions">
+
+                      <rng:optional>
+                        <rng:element name="ArrivalDaysOfWeek">
+
+                          <rng:optional>
+                            <rng:attribute name="Mon">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Tue">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Weds">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Thur">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Fri">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Sat">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Sun">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:optional>
+
+                      <rng:optional>
+                        <rng:element name="DepartureDaysOfWeek">
+
+                          <rng:optional>
+                            <rng:attribute name="Mon">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Tue">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Weds">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Thur">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Fri">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Sat">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Sun">
+                              <rng:ref name="def_bool"/>
+                            </rng:attribute>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:optional>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:element name="RestrictionStatus">
+
+                      <rng:optional>
+                        <rng:attribute name="Restriction">
+                          <rng:choice>
+                            <rng:value>Master</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="Status">
+                          <rng:choice>
+                            <rng:value>Open</rng:value>
+                            <rng:value>Close</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:optional>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="CodeContext">
+                      <rng:choice>
+                        <rng:value>ROOMTYPE</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="Code">
+                      <rng:ref name="def_invTypeCode_string"/>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="Start">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="End">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+                </rng:element>
+              </rng:oneOrMore>
+
+            </rng:element>
+          </rng:optional>
+
+          <!-- RatePlans > RatePlan > Rates {0,1} -->
+
+          <rng:optional>
+            <rng:element name="Rates">
+
+              <rng:oneOrMore>
+                <rng:element name="Rate">
+
+                  <rng:optional>
+                    <rng:element name="BaseByGuestAmts">
+
+                      <rng:oneOrMore>
+                        <rng:element name="BaseByGuestAmt">
+
+                          <rng:optional>
+                            <rng:attribute name="NumberOfGuests">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="AmountAfterTax">
+                              <rng:ref name="def_decimal_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="CurrencyCode">
+                              <rng:choice>
+                                <rng:value>EUR</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="Type">
+                              <rng:choice>
+                                <rng:value>7</rng:value>
+                                <rng:value>25</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="AgeQualifyingCode">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:oneOrMore>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:element name="AdditionalGuestAmounts">
+
+                      <rng:oneOrMore>
+                        <rng:element name="AdditionalGuestAmount">
+
+                          <rng:optional>
+                            <rng:attribute name="Amount">
+                              <rng:ref name="def_decimal_ge0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="AgeQualifyingCode">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="MinAge">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+                          <rng:optional>
+                            <rng:attribute name="MaxAge">
+                              <rng:ref name="def_int_gt0"/>
+                            </rng:attribute>
+                          </rng:optional>
+
+                        </rng:element>
+                      </rng:oneOrMore>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:element name="MealsIncluded">
+
+                      <rng:optional>
+                        <rng:attribute name="MealPlanCodes">
+                          <rng:choice>
+                            <rng:value>1</rng:value>
+                            <rng:value>3</rng:value>
+                            <rng:value>10</rng:value>
+                            <rng:value>12</rng:value>
+                            <rng:value>14</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="MealPlanIndicator">
+                          <rng:choice>
+                            <rng:value>1</rng:value>
+                            <rng:value>true</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:optional>
+
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="Start">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="End">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="RateTimeUnit">
+                      <rng:choice>
+                        <rng:value type="string">Day</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="UnitMultiplier">
+                      <rng:ref name="def_int_gt0"/>
+                    </rng:attribute>
+                  </rng:optional>
+                  <rng:optional>
+                    <rng:attribute name="InvTypeCode">
+                      <rng:ref name="def_invTypeCode_string"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                </rng:element>
+              </rng:oneOrMore>
+
+            </rng:element>
+          </rng:optional>
+
+          <!-- RatePlans > RatePlan > Supplements {0,1} -->
+
+          <rng:optional>
+            <rng:element name="Supplements">
+
+              <rng:oneOrMore>
+                <rng:element name="Supplement">
+
+                  <rng:optional>
+                    <rng:choice>
+                      <rng:element name="PrerequisiteInventory">
+                        <rng:attribute name="InvCode">
+                          <rng:data type="string">
+                              <rng:param name="pattern">[01]{7}</rng:param>
+                            </rng:data>
+                        </rng:attribute>
+                        <rng:attribute name="InvType">
+                          <rng:choice>
+                            <rng:value>ALPINEBITSDOW</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:element>
+                      <rng:element name="PrerequisiteInventory">
+                        <rng:attribute name="InvCode">
+                          <rng:ref name="def_invTypeCode_string"/>
+                        </rng:attribute>
+                        <rng:attribute name="InvType">
+                          <rng:choice>
+                            <rng:value>ROOMTYPE</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                      </rng:element>
+                    </rng:choice>
+                  </rng:optional>
+
+                  <!-- RatePlans > RatePlan > Supplements > Supplement > Description {0,} (actually {0,5} but Relax-NG cannot do this) -->
+           
+                  <rng:zeroOrMore>
+                    <rng:element name="Description">
+           
+                      <rng:oneOrMore>
+                        <rng:choice>
+           
+                          <rng:element name="ListItem">
+                            <rng:ref name="def_nonempty_string"/>
+                          </rng:element>
+                        
+                          <rng:element name="Image">
+                            <rng:ref name="def_url_string"/>
+                          </rng:element>
+           
+                          <rng:element name="Text">
+                            <rng:ref name="def_nonempty_string"/>
+                            <rng:attribute name="TextFormat">
+                              <rng:choice>
+                                <rng:value>PlainText</rng:value>
+                                <rng:value>HTML</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+                            <rng:optional>
+                              <rng:attribute name="Language">
+                                <rng:data type="language">
+                                  <rng:param name="pattern">[a-z][a-z]</rng:param>
+                                </rng:data>
+                              </rng:attribute>
+                            </rng:optional>
+                          </rng:element>
+           
+                          <rng:element name="URL">
+                            <rng:ref name="def_url_string"/>
+                          </rng:element>
+           
+                        </rng:choice>
+                      </rng:oneOrMore>
+           
+                      <rng:attribute name="Name">
+                        <rng:choice>
+                          <rng:value>title</rng:value>
+                          <rng:value>intro</rng:value>
+                          <rng:value>description</rng:value>
+                          <rng:value>gallery</rng:value>
+                          <rng:value>codelist</rng:value>
+                        </rng:choice>
+                      </rng:attribute>
+           
+                    </rng:element>
+                  </rng:zeroOrMore>
+
+                  <rng:optional>
+                    <rng:attribute name="AddToBasicRateIndicator">
+                      <rng:choice>
+                        <rng:value>1</rng:value>
+                        <rng:value>true</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="ChargeTypeCode">
+                      <rng:choice>
+                        <rng:value>1</rng:value>
+                        <rng:value>12</rng:value>
+                        <rng:value>18</rng:value>
+                        <rng:value>19</rng:value>
+                        <rng:value>20</rng:value>
+                        <rng:value>21</rng:value>
+                        <rng:value>24</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+                  </rng:optional>
+               
+                  <rng:optional>
+                    <rng:attribute name="Amount">
+                      <rng:ref name="def_decimal_ge0"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="InvType">
+                      <rng:choice>
+                        <rng:value>EXTRA</rng:value>
+                        <rng:value>ALPINEBITSEXTRA</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="InvCode">
+                      <rng:ref name="def_nonempty_string"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="MandatoryIndicator">
+                      <rng:ref name="def_bool"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="Start">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:attribute name="End">
+                      <rng:ref name="def_date"/>
+                    </rng:attribute>
+                  </rng:optional>
+
+                </rng:element>
+              </rng:oneOrMore>
+
+            </rng:element>
+          </rng:optional>
+
+          <!-- RatePlans > RatePlan > Offers {0,1}  -->
+
+          <rng:optional>
+            <rng:element name="Offers">
+
+              <rng:oneOrMore>
+                <rng:element name="Offer">
+
+                  <rng:zeroOrMore>
+                    <rng:element name="OfferRules">
+
+                      <rng:element name="OfferRule">
+
+                        <rng:optional>
+                          <rng:element name="LengthsOfStay">
+                      
+                            <rng:oneOrMore>
+                              <rng:element name="LengthOfStay">
+                      
+                                <rng:attribute name="Time">
+                                  <rng:ref name="def_decimal_ge0"/>
+                                </rng:attribute>
+                                <rng:attribute name="TimeUnit">
+                                  <rng:value type="string">Day</rng:value>
+                                </rng:attribute>
+                                <rng:attribute name="MinMaxMessageType">
+                                  <rng:choice>
+                                    <rng:value>SetMinLOS</rng:value>
+                                    <rng:value>SetMaxLOS</rng:value>
+                                  </rng:choice>
+                                </rng:attribute>
+                      
+                              </rng:element>
+                            </rng:oneOrMore>
+                      
+                          </rng:element>
+                        </rng:optional>
+                      
+                        <rng:optional>
+                          <rng:element name="DOW_Restrictions">
+                      
+                            <rng:optional>
+                              <rng:element name="ArrivalDaysOfWeek">
+                      
+                                <rng:optional>
+                                  <rng:attribute name="Mon">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Tue">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Weds">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Thur">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Fri">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Sat">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Sun">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                      
+                              </rng:element>
+                            </rng:optional>
+                      
+                            <rng:optional>
+                              <rng:element name="DepartureDaysOfWeek">
+                      
+                                <rng:optional>
+                                  <rng:attribute name="Mon">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Tue">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Weds">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Thur">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Fri">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Sat">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                                <rng:optional>
+                                  <rng:attribute name="Sun">
+                                    <rng:ref name="def_bool"/>
+                                  </rng:attribute>
+                                </rng:optional>
+                      
+                              </rng:element>
+                            </rng:optional>
+                      
+                          </rng:element>
+                        </rng:optional>
+                    
+                        <rng:zeroOrMore>
+                          <rng:element name="Occupancy">
+                      
+                            <rng:attribute name="AgeQualifyingCode">
+                              <rng:choice>
+                                <rng:value>8</rng:value>
+                                <rng:value>10</rng:value>
+                              </rng:choice>
+                            </rng:attribute>
+
+                            <rng:optional>
+                              <rng:attribute name="MinAge">
+                                <rng:ref name="def_int_gt0"/>
+                              </rng:attribute>
+                            </rng:optional>
+
+                            <rng:optional>
+                              <rng:attribute name="MaxAge">
+                                <rng:ref name="def_int_gt0"/>
+                              </rng:attribute>
+                            </rng:optional>
+
+                            <rng:optional>
+                              <rng:attribute name="MinOccupancy">
+                                <rng:ref name="def_int_ge0"/>
+                              </rng:attribute>
+                            </rng:optional>
+
+                            <rng:optional>
+                              <rng:attribute name="MaxOccupancy">
+                                <rng:ref name="def_int_gt0"/>
+                              </rng:attribute>
+                            </rng:optional>
+ 
+                          </rng:element>
+                        </rng:zeroOrMore>
+                      
+                        <rng:optional>
+                          <rng:attribute name="MinAdvancedBookingOffset">
+                            <rng:data type="string">
+                              <rng:param name="pattern">P[0-9]+D</rng:param>
+                            </rng:data>
+                          </rng:attribute>
+                        </rng:optional>
+ 
+                        <rng:optional>
+                          <rng:attribute name="MaxAdvancedBookingOffset">
+                            <rng:data type="string">
+                              <rng:param name="pattern">P[0-9]+D</rng:param>
+                            </rng:data>
+                          </rng:attribute>
+                        </rng:optional>
+
+                       </rng:element>
+                    </rng:element>
+                  </rng:zeroOrMore>
+
+                  <rng:optional>
+                    <rng:element name="Discount">
+                
+                      <rng:attribute name="Percent">
+                        <rng:value type="string">100</rng:value>
+                      </rng:attribute>
+                      <rng:optional>
+                        <rng:attribute name="NightsRequired">
+                          <rng:ref name="def_int_gt0"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="NightsDiscounted">
+                          <rng:ref name="def_int_gt0"/>
+                        </rng:attribute>
+                      </rng:optional>
+                      <rng:optional>
+                        <rng:attribute name="DiscountPattern">
+                          <rng:data type="string">
+                            <rng:param name="pattern">0*1*</rng:param>
+                          </rng:data>
+                        </rng:attribute>
+                      </rng:optional>
+                
+                    </rng:element>
+                  </rng:optional>
+
+                  <rng:optional>
+                    <rng:element name="Guests">
+
+                      <rng:element name="Guest">
+
+                        <rng:attribute name="AgeQualifyingCode">
+                          <rng:ref name="def_int_gt0"/>
+                        </rng:attribute>
+                        <rng:attribute name="MaxAge">
+                          <rng:ref name="def_int_gt0"/>
+                        </rng:attribute>
+                        <rng:attribute name="MinCount">
+                          <rng:ref name="def_int_ge0"/>
+                        </rng:attribute>
+                        <rng:attribute name="FirstQualifyingPosition">
+                          <rng:choice>
+                            <rng:value>1</rng:value>
+                          </rng:choice>
+                        </rng:attribute>
+                        <rng:attribute name="LastQualifyingPosition">
+                          <rng:ref name="def_int_gt0"/>
+                        </rng:attribute>
+
+                      </rng:element> 
+
+                    </rng:element> 
+                  </rng:optional>
+
+                </rng:element>  <!-- close Offer -->
+              </rng:oneOrMore>
+
+            </rng:element>  <!-- close Offers -->
+          </rng:optional>
+
+          <!-- RatePlans > RatePlan > Description {0,} (actually {0,5} but Relax-NG cannot do this) -->
+
+          <rng:zeroOrMore>
+            <rng:element name="Description">
+
+              <rng:oneOrMore>
+                <rng:choice>
+
+                  <rng:element name="ListItem">
+                    <rng:ref name="def_nonempty_string"/>
+                  </rng:element>
+                
+                  <rng:element name="Image">
+                    <rng:ref name="def_url_string"/>
+                  </rng:element>
+
+                  <rng:element name="Text">
+                    <rng:ref name="def_nonempty_string"/>
+                    <rng:attribute name="TextFormat">
+                      <rng:choice>
+                        <rng:value>PlainText</rng:value>
+                        <rng:value>HTML</rng:value>
+                      </rng:choice>
+                    </rng:attribute>
+                    <rng:optional>
+                      <rng:attribute name="Language">
+                        <rng:data type="language">
+                          <rng:param name="pattern">[a-z][a-z]</rng:param>
+                        </rng:data>
+                      </rng:attribute>
+                    </rng:optional>
+                  </rng:element>
+
+                  <rng:element name="URL">
+                    <rng:ref name="def_url_string"/>
+                  </rng:element>
+
+                </rng:choice>
+              </rng:oneOrMore>
+
+              <rng:attribute name="Name">
+                <rng:choice>
+                  <rng:value>title</rng:value>
+                  <rng:value>intro</rng:value>
+                  <rng:value>description</rng:value>
+                  <rng:value>gallery</rng:value>
+                  <rng:value>codelist</rng:value>
+                </rng:choice>
+              </rng:attribute>
+
+            </rng:element>
+          </rng:zeroOrMore>
+ 
+          <rng:optional>
+            <rng:attribute name="RatePlanNotifType">
+              <rng:choice>
+                <rng:value>Overlay</rng:value>
+                <rng:value>New</rng:value>
+                <rng:value>Remove</rng:value>
+              </rng:choice>
+            </rng:attribute>
+          </rng:optional>
+          <rng:optional>
+            <rng:attribute name="CurrencyCode">
+              <rng:choice>
+                <rng:value>EUR</rng:value>
+              </rng:choice>
+            </rng:attribute>
+          </rng:optional>
+          <rng:optional>
+            <rng:attribute name="RatePlanCode">
+              <rng:ref name="def_nonempty_string"/>
+            </rng:attribute>
+          </rng:optional>
+          <rng:optional>
+            <rng:attribute name="RatePlanType">
+              <rng:choice>
+                <rng:value>12</rng:value>
+              </rng:choice>
+            </rng:attribute>
+          </rng:optional>
+          <rng:optional>
+            <rng:attribute name="RatePlanCategory">
+              <rng:ref name="def_nonempty_string"/>
+            </rng:attribute>
+          </rng:optional>
+          <rng:optional>
+            <rng:attribute name="RatePlanID">
+              <rng:ref name="def_nonempty_string"/>
+            </rng:attribute>
+          </rng:optional>
+          <rng:optional>
+            <rng:attribute name="RatePlanQualifier">
+              <rng:ref name="def_bool"/>
+            </rng:attribute>
+          </rng:optional>
+
+        </rng:element>
+      </rng:oneOrMore>
+
+      <rng:oneOrMore>
+        <rng:choice>
+          <rng:attribute name="HotelCode">
+            <rng:ref name="def_nonempty_string"/>
+          </rng:attribute>
+          <rng:attribute name="HotelName">
+            <rng:ref name="def_nonempty_string"/>
+          </rng:attribute>
+        </rng:choice>
+      </rng:oneOrMore>
+
+    </rng:element>
+
+  </rng:define>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for success/advisory/warning/error responses                -->
+  <!-- ******************************************************************************* -->
+
+  <rng:define name="def_generic_response">
+    <rng:choice>
+
+      <!-- choice: Errors {1} -->
+
+      <rng:element name="Errors">
+    
+        <!-- Errors > Error {1,} -->
+
+        <rng:oneOrMore>
+          <rng:element name="Error">
+
+            <rng:attribute name="Type">
+              <rng:value type="string">13</rng:value>
+            </rng:attribute>
+            <rng:attribute name="Code">
+              <rng:ref name="def_int_gt0"/>
+            </rng:attribute>
+
+            <rng:text/>
+
+          </rng:element>
+        </rng:oneOrMore>
+
+      </rng:element>
+
+      <!-- choice: Success {1} + Warnings {0,1} -->
+
+      <rng:group>
+
+        <rng:element name="Success">
+          <rng:empty/>
+        </rng:element>
+
+        <rng:optional>
+          <rng:element name="Warnings">
+        
+            <!-- Warnings > Warning {1,} -->
+
+            <rng:oneOrMore>
+              <rng:element name="Warning">
+          
+                <rng:attribute name="Type">
+                  <rng:ref name="def_int_gt0"/>
+                </rng:attribute>
+
+                <rng:optional>
+                  <rng:attribute name="RecordID">
+                    <rng:ref name="def_nonempty_string"/>
+                  </rng:attribute>
+                </rng:optional>
+
+                <rng:text/>
+          
+              </rng:element>
+            </rng:oneOrMore>
+
+          </rng:element>
+        </rng:optional>
+
+      </rng:group>
+
+    </rng:choice>
+  </rng:define>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for recurring, simple types                                 -->
+  <!-- ******************************************************************************* -->
+
+  <!-- A generic non-empty string type. -->
+
+  <rng:define name="def_nonempty_string">
+    <rng:data type="string">
+      <rng:param name="minLength">1</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic string type containing an @ char, like an email address. -->
+
+  <rng:define name="def_email_string">
+    <rng:data type="string">
+      <rng:param name="pattern">\S+@\S+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic string type starting with http:// or https:// --> 
+
+  <rng:define name="def_url_string">
+    <rng:data type="string">
+      <rng:param name="pattern">https?://.+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- String type defining room category codes (like InvTypeCode)  -->
+
+  <rng:define name="def_invTypeCode_string">
+    <rng:data type="string">
+      <rng:param name="minLength">1</rng:param>
+      <rng:param name="maxLength">8</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic integer > 0 type. -->
+
+  <rng:define name="def_int_gt0">
+    <rng:data type="positiveInteger">
+      <rng:param name="pattern">[0-9]+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic integer >= 0 type. -->
+
+  <rng:define name="def_int_ge0">
+    <rng:data type="nonNegativeInteger">
+      <rng:param name="pattern">[0-9]+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic decimal >= 0 type. -->
+
+  <rng:define name="def_decimal_ge0">
+    <rng:data type="decimal">
+      <rng:param name="minInclusive">0.0</rng:param>
+      <rng:param name="pattern">[0-9]*\.?[0-9]*</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic decimal > 0 type. -->
+
+  <rng:define name="def_decimal_gt0">
+    <rng:data type="decimal">
+      <rng:param name="minExclusive">0.0</rng:param>
+      <rng:param name="pattern">[0-9]*\.?[0-9]*</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic date type. -->
+
+  <rng:define name="def_date">
+    <rng:data type="date">
+      <rng:param name="pattern">\S+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic datetime type. -->
+
+  <rng:define name="def_datetime">
+    <rng:data type="dateTime">
+      <rng:param name="pattern">\S+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- A generic boolean type (1,true,0,false). -->
+
+  <rng:define name="def_bool">
+    <rng:data type="boolean">
+      <rng:param name="pattern">\S+</rng:param>
+    </rng:data>
+  </rng:define>
+
+  <!-- Anything. -->
+
+  <rng:define name="def_anything">
+    <rng:interleave>
+      <rng:zeroOrMore>
+        <rng:element>
+          <rng:anyName/>
+          <rng:zeroOrMore>
+            <rng:ref name="def_anything"/>
+          </rng:zeroOrMore>
+          <rng:zeroOrMore>
+            <rng:ref name="def_any_attribute"/>
+          </rng:zeroOrMore>
+        </rng:element>
+      </rng:zeroOrMore>
+    <rng:text/>
+    </rng:interleave>
+  </rng:define>
+
+  <rng:define name="def_any_attribute">
+    <rng:attribute>
+      <rng:anyName/>
+    </rng:attribute>
+  </rng:define>
+
+</rng:grammar>
+

--- a/alpinebits-xml/impl/src/test/resources/schema/alpinebits-2017-10.xsd
+++ b/alpinebits-xml/impl/src/test/resources/schema/alpinebits-2017-10.xsd
@@ -1,0 +1,2405 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+     AlpineBits 2017-10
+     http://www.alpinebits.org/
+
+     W3C XML Schema file
+
+     changelog:
+
+    v. 2017-10  1.1 -  RatePlans:       RatePlans > RatePlan > Offers: allow only MinLOS and MaxLOS attributes (not the forward ones too)
+
+    v. 2017-10  1.0 -  FreeRooms:       OTA_HotelAvailNotifRQ -> UniqueID (added allowed value to attribute Type, by Luca Rainone)
+                       FreeRooms:       OTA_HotelAvailNotifRQ -> AvailStatusMessages -> ...  -> StatusApplicationControl (added new mandatory attribute BookingThreshold)
+
+                       GuestRequests:   OTA_ResRetrieveRS -> ReservationsList -> ... -> RatePlan (added element Commission)
+                       GuestRequests:   OTA_ResRetrieveRS -> ReservationsList -> ... -> CardNumber (added attributes EncryptedValue and EncryptionMethod) 
+                       GuestRequests:   OTA_ResRetrieveRS -> ReservationsList -> ... -> RoomStay > RoomTypes (made optional)
+
+                       SimplePackages section removed
+
+                       Inventory has become Inventory/Basic (Push) and Inventory/HotelInfo (Push):
+                                        OTA_HotelDescriptiveContentNotifRQ (major changes, one being that empty GuestRooms elements are now allowed by Luca Rainone)
+
+                       Inventory/Basic (Pull) and Inventory/HotelInfo (Pull) added
+ 
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> BookingRules -> ... -> LengthOfStay (added allowed values to attribute MinMaxMessageType)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Supplements -> Supplement (added element PrerequisiteInventory)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Supplements -> Supplement -> Description (major changes)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Offers -> Offer (major changes)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Description (major changes)
+                       RatePlans:       OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> ... -> BaseByGuestAmt (NumberOfGuests and Type are optional now to allow static rates)
+
+                       BaseRates section added
+
+    v. 2015-07b 1.4 - weaken the schema for Inventory (to prepare for upcoming release that will support Inventory deltas):
+
+                      - the RoomAmenityCode attribute becomes optional to allow empty Amenity elements 
+                      - the MultimediaDescription element can be empty
+
+    v. 2015-07b 1.3 - RatePlans > RatePlan > Description > TextFormat can now also be "HTML" (besides "PlainText")
+
+    v. 2015-07b 1.2 - added optional attributes RatePlanID and RatePlanQualifier to RatePlan
+                      for the new OTA_HotelRatePlanNotif_accept_RatePlanJoin capability
+
+    v. 2015-07b 1.1 - added def_invTypeCode_string type (string with up to 8 chars) used for the following attributes that identify room categories:
+
+                      FreeRooms:     OTA_HotelAvailNotifRQ -> AvailStatusMessages -> AvailStatusMessage -> StatusApplicationControl -> InvTypeCode
+                      GuestRequests: OTA_ResRetrieveRS -> ReservationList -> HotelReservation -> RoomStays -> RoomStay -> RoomTypes > RoomType -> RoomTypeCode
+                      Inventory:     OTA_HotelDescriptiveContentNotifRQ -> HotelDescriptiveContents -> HotelDescriptiveContent -> FacilityInfo -> GuestRooms -> GuestRoom -> Code
+                      RatePlan:      OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> BookingRules -> BookingRule -> Code
+                      RatePlan:      OTA_HotelRatePlanNotifRQ -> RatePlans -> RatePlan -> Rates -> Rate -> InvTypeCode
+
+                      (derived from Lukas Braun's pull request)
+
+    v. 2015-07b 1.0 - RatePlans > RatePlan > Rates > Rate > BaseByGuestAmts > AmountAfterTax
+                      must be > 0.0 (was: >= 0.0)
+
+     v. 2015-07 2.9 - Inventory: added a missing maxOccurs="unbounded" to the ImageItem
+
+     v. 2015-07 2.8 - Inventory: reconciled with the definitions given in the updated document
+
+     v. 2015-07 2.7 - changes to Inventory: removed the old Inventory, added MaxChildOccupancy to GuestRoom,
+                      made some of the attributes mandatory, formating changes
+
+     v. 2015-07 2.6 - made sub-elements of HotelReservation > ... > Customer > Address {0,1} optional
+
+     v. 2015-07 2.5 - added a choice of 'Modify' for ResStatusValue
+
+     v. 2015-07 2.4 - added MinCount attribute to Offer>>Guest
+
+     v. 2015-07 2.3 - changes to Supplement: a few attributes are removed and many attributes are made optional
+
+     v. 2015-07 2.2 - RatePlans/Supplements: changed format of description
+
+     v. 2015-07 2.1 - GuestRequests: ResGuests >> Customer: attributes Gender and Language are now optional
+
+     v. 2015-07 2.0 - allow Warnings in OTA_NotifReportRQ messages
+
+     v. 2015-07 1.9 - GuestRequests: use CardNumber -> PlainText instead of the Remark attribute of
+                      PaymentCard under Guarantee; add BasicPropertyInfo element at the end of the 
+                      ResGlobalInfo block for OTA-2015A compatiblity
+
+     v. 2015-07 1.8 - added section for New Inventory (exact name pending)
+
+     v. 2015-07 1.7 - allowed more than one HotelReservationID
+
+     v. 2015-07 1.6 - RatePlans: allow optional PrerequisiteInventory element under Supplement element
+
+     v. 2015-07 1.5 - Inventory: removed Amenities and added optional Room -> RoomTypeCode
+
+     v. 2015-07 1.4 - HotelReservationID -> ResID_Type is not limited to 13 anymore
+
+     v. 2015-07 1.3 - new section in RoomStays: Guarantee -> GuaranteesAccepted -> GuaranteeAccepted -> PaymentCard
+
+     v. 2015-07 1.2 - new section in ResGlobalInfo: Profiles -> ProfileInfo -> Profile -> CompanyInfo
+
+     v. 2015-07 1.1 - HotelReservation > RoomStays > RoomStay > RoomTypes > RoomType is now
+                      mandatory and has a new optional attribute RoomClassificationCode
+
+     v. 2015-07 1.0 - OTA_NotifReportRS besides Success, now also allows Error responses 
+
+     v. 2014-04 1.6 - [fixed] InvCode attribute in Supplement changed from def_int_ge0 to def_nonempty_string
+
+     v. 2014-04 1.5 - [strictness improvement] made NumberOfGuests attribute mandatory
+
+     v. 2014-04 1.4 - [fixed] RatePlans: optional Rate attributes RateTimeUnit and UnitMultiplier added
+
+     v. 2014-04 1.3 - [fixed] GuestRequests: ReservationsList can be empy
+
+     v. 2014-04 1.2 - follow-up to fix 1.1 that allowed empty AvailStatusMessages elements too
+                      (reverted)
+
+     v. 2014-04 1.1 - empty AvailStatusMessage elements in FreeRooms now allowed
+                      (see https://groups.google.com/d/msg/alpinebits/B-orBE9eJCk/rKyIYbNBFNoJ )
+                    - Version and TimeStamp also added to OTA_NotifReportRS 
+                      (see https://groups.google.com/d/msg/alpinebits/jwaPC3XAafo/yDDYCkpNPYEJ )
+
+     v. 2014-04 1.0 - major rewrite for 2014-04
+
+     previous changelogs:
+
+     v. 2013-04 1.0 - the XML schema is now flattened into this single file;
+                      some improvements by Martin;
+                      added optional RatePlanCode attribute to RatePlan;
+                      removed restrictions on the form of the ID attribute in UniqueID
+
+     W3C XML Schema for OTA_HotelAvailNotifRQ:
+     v. 2013-04 1.0 - added MessageContentCode attribute for delta messages
+     v. 2012-05 1.2 - changed Thu -> Thur and Wed -> Weds for OTA compatibility
+     v. 2012-05 1.1 - added optional TimeStamp attribute for OTA_HotelAvailNotifRQ to be compatible with AlpineBits 2011-11 documents
+     v. 2012-05 1.0
+      
+     W3C XML Schema for OTA_HotelAvailNotifRS:
+     v. 2013-04 1.0 - added warnings
+     v. 2012-05 1.0
+  
+     W3C XML Schema for OTA_ReadRQ:
+     v. 2012-05 1.0
+   
+     W3C XML Schema for OTA_ResRetrieveRS:
+     v. 2013-04 1.0 - simplified the definition of GuestCounts for XSD conformance,
+                      moved UniqueID and RatePlans elements to common to support schema flattening
+     v. 2012-05 1.0
+  
+     W3C XML Schema for OTA_HotelRatePlanNotifRQ:
+     v. 2013-04 1.0 - removed def_plaintext and simplified def_rate_plan to fix an issue with the parsing of the schema,
+                      moved UniqueID and RatePlans elements to common
+     v. 2012-05 1.2 - changed Thu -> Thur and Wed -> Weds for OTA compatibility
+     v. 2012-05 1.0
+  
+     W3C XML Schema for OTA_HotelRatePlanNotifRS:
+     v. 2013-04 1.0 - added warnings
+     v. 2012-05 1.0
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           targetNamespace="http://www.opentravel.org/OTA/2003/05"
+           xmlns="http://www.opentravel.org/OTA/2003/05">
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * FreeRooms                                                                     -->
+  <!-- ******************************************************************************* -->
+
+  <!-- FreeRooms: OTA_HotelAvailNotifRQ -->
+
+  <xs:element name="OTA_HotelAvailNotifRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <!-- UniqueID {0,1} -->
+
+        <xs:element name="UniqueID" minOccurs="0">
+          <xs:complexType>
+            <xs:attribute name="Type" use="required">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="16"/>
+                  <xs:enumeration value="35"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="ID" use="required" type="xs:string"/> <!-- an ID is required by OTA, we ignore the value -->
+            <xs:attribute name="Instance" use="required">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="CompleteSet"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+
+        <!-- AvailStatusMessages {1} -->
+
+        <xs:element name="AvailStatusMessages">
+          <xs:complexType>
+            <xs:sequence>
+
+              <!-- AvailStatusMessages > AvailStatusMessage (1,} -->
+              
+              <xs:element name="AvailStatusMessage" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <!-- AvailStatusMessages > AvailStatusMessage > StatusApplicationControl {0,1} -->
+
+                    <xs:element name="StatusApplicationControl" minOccurs="0">
+                      <xs:complexType>
+                        <xs:attribute name="Start"        use="required" type="def_date"/>
+                        <xs:attribute name="End"          use="required" type="def_date"/>
+                        <xs:attribute name="InvTypeCode"                 type="def_invTypeCode_string"/>
+                        <xs:attribute name="InvCode"                     type="def_nonempty_string"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                  </xs:sequence>
+                  <xs:attribute name="BookingLimitMessageType">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="SetLimit"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="BookingLimit" type="def_int_ge0"/>
+                  <xs:attribute name="BookingThreshold" type="def_int_ge0"/>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+            <xs:attribute name="HotelCode" type="def_nonempty_string"/>
+            <xs:attribute name="HotelName" type="def_nonempty_string"/>
+          </xs:complexType> 
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- FreeRooms: OTA_HotelAvailNotifRS -->
+
+  <xs:element name="OTA_HotelAvailNotifRS">
+    <xs:complexType>
+      <xs:group   ref="def_generic_response"/>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * GuestRequests                                                                 -->
+  <!-- ******************************************************************************* -->
+
+  <!-- GuestRequests: OTA_ReadRQ -->
+
+  <xs:element name="OTA_ReadRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <xs:element name="ReadRequests">
+          <xs:complexType>
+            <xs:sequence>
+
+              <xs:element name="HotelReadRequest">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <xs:element name="SelectionCriteria" minOccurs="0">
+                      <xs:complexType>
+                        <xs:attribute name="Start" use="required" type="def_datetime"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                  </xs:sequence>
+                  <xs:attribute name="HotelCode" type="def_nonempty_string"/> 
+                  <xs:attribute name="HotelName" type="def_nonempty_string"/>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- GuestRequests: OTA_ResRetrieveRS -->
+
+  <xs:element name="OTA_ResRetrieveRS">
+    <xs:complexType>
+
+      <xs:choice>
+
+        <!-- choice: Errors {1} -->
+
+        <xs:element name="Errors">
+          <xs:complexType>
+            <xs:sequence>
+   
+              <!-- Errors > Error {1,} -->
+   
+              <xs:element name="Error" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type" use="required">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="13"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="Code" use="required" type="def_int_ge0"/>
+                </xs:complexType>
+              </xs:element>
+   
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:sequence>
+
+          <!-- choice: Success {1} + ReservationsList {1} -->
+
+          <xs:element name="Success"/>
+
+          <xs:element name="ReservationsList">
+            <xs:complexType>
+              <xs:sequence>
+
+               <!-- HotelReservation {0,} -->
+ 
+                <xs:element name="HotelReservation" maxOccurs="unbounded" minOccurs="0">
+                  <xs:complexType>
+                    <xs:sequence>
+
+                      <!-- HotelReservation > UniqueID {1} -->
+
+                      <xs:element name="UniqueID">
+                        <xs:complexType>
+                          <xs:attribute name="Type" use="required">
+                            <xs:simpleType>
+                              <xs:restriction base="xs:string">
+                                <xs:enumeration value="14"/>
+                                <xs:enumeration value="15"/>
+                              </xs:restriction>
+                            </xs:simpleType>
+                          </xs:attribute>
+                          <xs:attribute name="ID" use="required" type="def_nonempty_string"/>
+                        </xs:complexType>
+                      </xs:element>
+
+                      <!-- HotelReservation > RoomStays {0,1} -->
+
+                      <xs:element name="RoomStays" minOccurs="0">
+                        <xs:complexType>
+                          <xs:sequence>
+
+                            <!-- HotelReservation > RoomStays > RoomStay {1,} -->
+
+                            <xs:element name="RoomStay" maxOccurs="unbounded">
+                              <xs:complexType>
+                                <xs:sequence>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > RoomTypes {0,1} -->
+
+                                  <xs:element name="RoomTypes" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:sequence>
+
+                                        <!-- HotelReservation > RoomStays > RoomStay > RoomTypes > RoomType {1} -->
+
+                                        <xs:element name="RoomType">
+                                          <xs:complexType>
+                                            <xs:attribute name="RoomTypeCode"           type="def_invTypeCode_string"/>
+                                            <xs:attribute name="RoomClassificationCode" type="def_int_ge0"/>
+                                          </xs:complexType>
+                                        </xs:element>
+
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > RatePlans {0,1} -->
+
+                                  <xs:element name="RatePlans" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:sequence>
+
+                                        <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan {1} -->
+
+                                        <xs:element name="RatePlan">
+                                          <xs:complexType>
+                                            <xs:sequence>
+
+                                              <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan > Commission {0,1} -->
+
+                                              <xs:element name="Commission" minOccurs="0">
+                                                <xs:complexType>
+                                                  <xs:sequence>
+                                                    <xs:element name="CommissionPayableAmount" minOccurs="0">
+                                                      <xs:complexType>
+                                                        <xs:attribute name="Amount" type="def_decimal_ge0"/>
+                                                        <xs:attribute name="CurrencyCode">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:enumeration value="EUR"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                      </xs:complexType>
+                                                    </xs:element>
+                                                  </xs:sequence>
+                                                  <xs:attribute name="Percent" type="def_int_ge0"/>
+                                                </xs:complexType>
+                                              </xs:element>
+
+                                              <!-- HotelReservation > RoomStays > RoomStay > RatePlans > RatePlan > MealsIncluded {0,1} -->
+
+                                              <xs:element name="MealsIncluded" minOccurs="0">
+                                                <xs:complexType>
+                                                  <xs:attribute name="MealPlanIndicator" use="required">
+                                                    <xs:simpleType>
+                                                      <xs:restriction base="xs:string">
+                                                        <xs:enumeration value="1"/>
+                                                        <xs:enumeration value="true"/>
+                                                      </xs:restriction>
+                                                    </xs:simpleType>
+                                                  </xs:attribute>
+                                                  <xs:attribute name="MealPlanCodes" use="required">
+                                                    <xs:simpleType>
+                                                      <xs:restriction base="xs:string">
+                                                        <xs:enumeration value="1"/>
+                                                        <xs:enumeration value="3"/>
+                                                        <xs:enumeration value="10"/>
+                                                        <xs:enumeration value="12"/>
+                                                        <xs:enumeration value="14"/>
+                                                      </xs:restriction>
+                                                    </xs:simpleType>
+                                                  </xs:attribute>
+                                                </xs:complexType>
+                                              </xs:element>
+
+                                            </xs:sequence>
+                                            <xs:attribute name="RatePlanCode" type="def_nonempty_string"/>
+                                          </xs:complexType>
+                                        </xs:element>
+
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > GuestCounts {0,1} -->
+
+                                  <xs:element name="GuestCounts" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:sequence>
+
+                                        <!-- HotelReservation > RoomStays > RoomStay > GuestCounts > GuestCount {1,} -->
+
+                                        <xs:element name="GuestCount" maxOccurs="unbounded">
+                                          <xs:complexType>
+                                            <xs:attribute name="Count" use="required" type="def_int_gt0"/>
+                                            <xs:attribute name="Age"                  type="def_int_ge0"/>
+                                          </xs:complexType>
+                                        </xs:element>
+
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > TimeSpan {1} -->
+
+                                  <xs:element name="TimeSpan">
+                                    <xs:complexType>
+                                      <xs:sequence>
+
+                                        <!-- HotelReservation > RoomStays > RoomStay > TimeSpan > StartDateWindow {0,1} -->
+
+                                        <xs:element name="StartDateWindow" minOccurs="0">
+                                          <xs:complexType>
+                                            <xs:attribute name="EarliestDate" use="required" type="def_date"/>
+                                            <xs:attribute name="LatestDate"   use="required" type="def_date"/>
+                                          </xs:complexType>
+                                        </xs:element>
+
+                                      </xs:sequence>
+                                      <xs:attribute name="Start" type="def_date"/>
+                                      <xs:attribute name="End"   type="def_date"/>
+                                      <xs:attribute name="Duration">
+                                        <xs:simpleType>
+                                          <xs:restriction base="xs:string">
+                                            <xs:pattern value="P[0-9]+N"/>
+                                          </xs:restriction>
+                                        </xs:simpleType>
+                                      </xs:attribute>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > Guarantee {0,1} -->
+
+                                  <xs:element name="Guarantee" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="GuaranteesAccepted">
+                                          <xs:complexType>
+                                            <xs:sequence>
+                                              <xs:element name="GuaranteeAccepted">
+                                                <xs:complexType>
+                                                  <xs:sequence>
+                                      
+                                                    <xs:element name="PaymentCard">
+                                                      <xs:complexType>
+                                                        <xs:sequence>
+                                                          <xs:element name="CardHolderName" type="def_nonempty_string"/>
+
+                                                          <xs:element name="CardNumber">
+                                                            <xs:complexType>
+                                                              <xs:sequence>
+                                                                <xs:element name="PlainText" type="def_nonempty_string" minOccurs="0"/>
+                                                              </xs:sequence>
+                                                             <xs:attribute name="EncryptedValue" type="def_nonempty_string"/>
+                                                             <xs:attribute name="EncryptionMethod" type="def_nonempty_string"/>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                        </xs:sequence>
+                                                        <xs:attribute name="CardCode" use="required">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="[A-Z][A-Z]?"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                        <xs:attribute name="ExpireDate" use="required">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="[0-9][0-9][0-9][0-9]"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                      </xs:complexType>
+                                                    </xs:element>
+                                      
+                                                  </xs:sequence>
+                                                </xs:complexType>
+                                              </xs:element>
+                                            </xs:sequence>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                  <!-- HotelReservation > RoomStays > RoomStay > Total {0,1} -->
+
+                                  <xs:element name="Total" minOccurs="0">
+                                    <xs:complexType>
+                                      <xs:attribute name="AmountAfterTax" use="required" type="def_decimal_ge0"/>
+                                      <xs:attribute name="CurrencyCode"   use="required" type="def_nonempty_string"/>
+                                    </xs:complexType>
+                                  </xs:element>
+
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+
+                      <!-- HotelReservation > ResGuests {0, 1} -->
+
+                      <xs:element name="ResGuests" minOccurs="0">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="ResGuest">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="Profiles">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="ProfileInfo">
+                                          <xs:complexType>
+                                            <xs:sequence>
+                                              <xs:element name="Profile">
+                                                <xs:complexType>
+                                                  <xs:sequence>
+
+                                                    <!-- HotelReservation > ... > Customer {1} -->
+
+                                                    <xs:element name="Customer">
+                                                      <xs:complexType>
+                                                        <xs:sequence>
+
+                                                          <!-- HotelReservation > ... > Customer > PersonName {1} -->
+
+                                                          <xs:element name="PersonName">
+                                                            <xs:complexType>
+                                                              <xs:sequence>
+                                                                <xs:element name="NamePrefix" minOccurs="0" type="def_nonempty_string"/>
+                                                                <xs:element name="GivenName"                type="def_nonempty_string"/>
+                                                                <xs:element name="Surname"                  type="def_nonempty_string"/>
+                                                                <xs:element name="NameTitle"  minOccurs="0" type="def_nonempty_string"/>
+                                                              </xs:sequence>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                          <!-- HotelReservation > ... > Customer > Telephone {0,} -->
+
+                                                          <xs:element name="Telephone" minOccurs="0" maxOccurs="unbounded">
+                                                            <xs:complexType>
+                                                              <xs:attribute name="PhoneTechType" use="required">
+                                                                <xs:simpleType>
+                                                                  <xs:restriction base="xs:string">
+                                                                    <xs:pattern value="(1|3|5)"/>
+                                                                  </xs:restriction>
+                                                                </xs:simpleType>
+                                                              </xs:attribute>
+                                                              <xs:attribute name="PhoneNumber" use="required">
+                                                                <xs:simpleType>
+                                                                  <xs:restriction base="xs:string">
+                                                                    <xs:pattern value="\+?[0-9]+"/>
+                                                                  </xs:restriction>
+                                                                </xs:simpleType>
+                                                              </xs:attribute>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                          <!-- HotelReservation > ... > Customer > Email {0,1} -->
+
+                                                          <xs:element name="Email" minOccurs="0">
+                                                            <xs:complexType>
+                                                              <xs:simpleContent>
+                                                                <xs:extension base="def_email_string"> 
+                                                                  <xs:attribute name="Remark">
+                                                                    <xs:simpleType>
+                                                                      <xs:restriction base="xs:string">
+                                                                        <xs:pattern value="newsletter:(no|yes)"/>
+                                                                      </xs:restriction>
+                                                                    </xs:simpleType>
+                                                                  </xs:attribute>
+                                                                </xs:extension>
+                                                              </xs:simpleContent>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                          <!-- HotelReservation > ... > Customer > Address {0,1} -->
+
+                                                          <xs:element name="Address" minOccurs="0">
+                                                            <xs:complexType>
+                                                              <xs:sequence>
+                                                                <xs:element name="AddressLine"  type="def_nonempty_string" minOccurs="0"/>
+                                                                <xs:element name="CityName"     type="def_nonempty_string" minOccurs="0"/>
+                                                                <xs:element name="PostalCode"   type="def_nonempty_string" minOccurs="0"/>
+                                                                <xs:element name="CountryName"  minOccurs="0">
+                                                                  <xs:complexType>
+                                                                    <xs:attribute name="Code" use="required">
+                                                                      <xs:simpleType>
+                                                                        <xs:restriction base="xs:string">
+                                                                          <xs:pattern value="[A-Z][A-Z]"/>
+                                                                        </xs:restriction>
+                                                                      </xs:simpleType>
+                                                                    </xs:attribute>
+                                                                  </xs:complexType>
+                                                                </xs:element>
+                                                              </xs:sequence>
+                                                              <xs:attribute name="Remark">
+                                                                <xs:simpleType>
+                                                                  <xs:restriction base="xs:string">
+                                                                    <xs:pattern value="catalog:(no|yes)"/>
+                                                                  </xs:restriction>
+                                                                </xs:simpleType>
+                                                              </xs:attribute>
+                                                            </xs:complexType>
+                                                          </xs:element>
+
+                                                        </xs:sequence>
+                                                        <xs:attribute name="Gender">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="(Unknown|Male|Female)"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                        <xs:attribute name="BirthDate" type="def_date"/>
+                                                        <xs:attribute name="Language">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:language">
+                                                              <xs:pattern value="[a-z][a-z]"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                      </xs:complexType>
+                                                    </xs:element>
+
+                                                  </xs:sequence>
+                                                </xs:complexType>
+                                              </xs:element>
+                                            </xs:sequence>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+
+                      <!-- HotelReservation > ResGlobalInfo {0,1} -->
+
+                      <xs:element name="ResGlobalInfo" minOccurs="0">
+                        <xs:complexType>
+                          <xs:sequence>
+
+                            <!-- HotelReservation > ResGlobalInfo > Comments {0,1} -->
+
+                            <xs:element name="Comments" minOccurs="0">
+                              <xs:complexType>
+                                <xs:sequence>
+
+                                 <!-- HotelReservation > ResGlobalInfo > Comments {1,2} -->
+
+                                  <xs:element name="Comment" maxOccurs="2">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:choice>
+
+                                          <xs:element name="ListItem" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                              <xs:simpleContent>
+                                                <xs:extension base="def_nonempty_string">
+                                                  <xs:attribute name="ListItem" use="required" type="def_int_ge0"/>
+                                                  <xs:attribute name="Language" use="required">
+                                                    <xs:simpleType>
+                                                      <xs:restriction base="xs:language">
+                                                        <xs:pattern value="[a-z][a-z]"/>
+                                                      </xs:restriction>
+                                                    </xs:simpleType>
+                                                  </xs:attribute>
+                                                </xs:extension>
+                                              </xs:simpleContent>
+                                            </xs:complexType>
+                                          </xs:element>
+
+                                          <xs:element name="Text" minOccurs="0" type="def_nonempty_string"/>
+
+                                        </xs:choice>
+                                      </xs:sequence>
+                                      <xs:attribute name="Name" use="required">
+                                        <xs:simpleType>
+                                          <xs:restriction base="xs:string">
+                                            <xs:enumeration value="included services"/>
+                                            <xs:enumeration value="customer comment"/>
+                                          </xs:restriction>
+                                        </xs:simpleType>
+                                      </xs:attribute>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+
+                            <!-- HotelReservation > ResGlobalInfo > CancelPenalties {0,1} -->
+
+                            <xs:element name="CancelPenalties" minOccurs="0">
+                              <xs:complexType>        
+                                <xs:sequence>         
+                                  <xs:element name="CancelPenalty">
+                                    <xs:complexType>  
+                                      <xs:sequence>   
+                                        <xs:element name="PenaltyDescription">
+                                          <xs:complexType>
+                                            <xs:sequence>
+                                              <xs:element name="Text" type="def_nonempty_string"/>
+                                            </xs:sequence>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>  
+                                    </xs:complexType> 
+                                  </xs:element>       
+                                </xs:sequence>        
+                              </xs:complexType>       
+                            </xs:element>             
+
+                            <!-- HotelReservation > ResGlobalInfo > HotelReservationIDs {0,1} -->
+
+                            <xs:element name="HotelReservationIDs" minOccurs="0">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="HotelReservationID" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                      <xs:attribute name="ResID_Type" use="required" type="def_int_gt0"/>
+                                      <xs:attribute name="ResID_Value"               type="def_nonempty_string"/>
+                                      <xs:attribute name="ResID_Source"              type="def_nonempty_string"/>
+                                      <xs:attribute name="ResID_SourceContext"       type="def_nonempty_string"/>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+
+                            <!-- HotelReservation > ResGlobalInfo > Profiles {0,1} -->
+
+                            <xs:element name="Profiles" minOccurs="0">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="ProfileInfo">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="Profile">
+                                          <xs:complexType>
+                                            <xs:sequence>
+                                              <xs:element name="CompanyInfo">
+                                                <xs:complexType>
+                                                  <xs:sequence>
+
+                                                    <xs:element name="CompanyName">
+                                                      <xs:complexType>
+                                                        <xs:simpleContent>
+                                                          <xs:extension base="def_nonempty_string"> 
+                                                            <xs:attribute name="Code"        use="required" type="def_nonempty_string"/>
+                                                            <xs:attribute name="CodeContext" use="required" type="def_nonempty_string"/>
+                                                          </xs:extension>
+                                                        </xs:simpleContent>
+                                                      </xs:complexType>
+                                                    </xs:element>
+
+                                                    <xs:element name="AddressInfo" minOccurs="0">
+                                                      <xs:complexType>
+                                                        <xs:sequence>
+                                                          <xs:element name="AddressLine"  type="def_nonempty_string"/>
+                                                          <xs:element name="CityName"     type="def_nonempty_string"/>
+                                                          <xs:element name="PostalCode"   type="def_nonempty_string"/>
+                                                          <xs:element name="CountryName">
+                                                            <xs:complexType>
+                                                              <xs:attribute name="Code" use="required">
+                                                                <xs:simpleType>
+                                                                  <xs:restriction base="xs:string">
+                                                                    <xs:pattern value="[A-Z][A-Z]"/>
+                                                                  </xs:restriction>
+                                                                </xs:simpleType>
+                                                              </xs:attribute>
+                                                            </xs:complexType>
+                                                          </xs:element>
+                                                        </xs:sequence>
+                                                      </xs:complexType>
+                                                    </xs:element>
+
+                                                    <xs:element name="TelephoneInfo" minOccurs="0">
+                                                      <xs:complexType>
+                                                        <xs:attribute name="PhoneTechType" use="required">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="(1|3|5)"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                        <xs:attribute name="PhoneNumber" use="required">
+                                                          <xs:simpleType>
+                                                            <xs:restriction base="xs:string">
+                                                              <xs:pattern value="\+?[0-9]+"/>
+                                                            </xs:restriction>
+                                                          </xs:simpleType>
+                                                        </xs:attribute>
+                                                      </xs:complexType>
+                                                    </xs:element>
+
+                                                    <xs:element name="Email" minOccurs="0" type="def_nonempty_string"/>
+
+                                                  </xs:sequence>
+                                                </xs:complexType>
+                                              </xs:element>
+                                            </xs:sequence>
+                                            <xs:attribute name="ProfileType" use="required">
+                                              <xs:simpleType>
+                                                <xs:restriction base="xs:string">
+                                                  <xs:enumeration value="4"/>
+                                                </xs:restriction>
+                                              </xs:simpleType>
+                                            </xs:attribute>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+
+                            <xs:element name="BasicPropertyInfo"/>
+
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+
+                    </xs:sequence>
+                    <xs:attribute name="CreateDateTime" use="required" type="def_datetime"/>
+                    <xs:attribute name="ResStatus"      use="required">
+                      <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                          <xs:enumeration value="Requested"/>
+                          <xs:enumeration value="Reserved"/>
+                          <xs:enumeration value="Cancelled"/>
+                          <xs:enumeration value="Modify"/>
+                        </xs:restriction>
+                      </xs:simpleType>
+                    </xs:attribute>
+                  </xs:complexType>
+                </xs:element>
+
+              </xs:sequence>
+            </xs:complexType>
+          </xs:element>
+
+        </xs:sequence>
+
+      </xs:choice>
+
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- GuestRequests: OTA_NotifReportRQ -->
+
+  <xs:element name="OTA_NotifReportRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <xs:element name="Success"/>
+
+        <xs:element name="Warnings" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Warning" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type"     use="required" type="def_int_gt0"/>
+                  <xs:attribute name="Code"     use="required" type="def_int_gt0"/>
+                  <xs:attribute name="RecordID" use="required" type="def_nonempty_string"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <xs:element name="NotifDetails" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+
+              <xs:element name="HotelNotifReport">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <xs:element name="HotelReservations">
+                      <xs:complexType>
+                        <xs:sequence>
+
+                          <xs:element name="HotelReservation" maxOccurs="unbounded">
+                            <xs:complexType>
+                              <xs:sequence>
+
+                                <xs:element name="UniqueID">
+                                  <xs:complexType>
+                                    <xs:attribute name="Type" use="required">
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="14"/>
+                                          <xs:enumeration value="15"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:attribute>
+                                    <xs:attribute name="ID" use="required" type="def_nonempty_string"/>
+                                  </xs:complexType>
+                                </xs:element>
+                 
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- GuestRequests: OTA_NotifReportRS -->
+
+  <xs:element name="OTA_NotifReportRS">
+    <xs:complexType>
+
+      <xs:choice>
+
+        <!-- choice: Errors {1} -->
+
+        <xs:element name="Errors">
+          <xs:complexType>
+            <xs:sequence>
+   
+              <!-- Errors > Error {1,} -->
+   
+              <xs:element name="Error" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type" use="required">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="13"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="Code" use="required" type="def_int_ge0"/>
+                </xs:complexType>
+              </xs:element>
+   
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <!-- choice: Success {1} -->
+
+        <xs:sequence>
+          <xs:element name="Success"/>
+        </xs:sequence>
+
+      </xs:choice>
+
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+
+    </xs:complexType>
+  </xs:element>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * Inventory/Basic (Push) and Inventory/HotelInfo (Push)                         -->
+  <!-- ******************************************************************************* -->
+
+  <!-- Inventory: OTA_HotelDescriptiveContentNotifRQ -->
+
+  <xs:element name="OTA_HotelDescriptiveContentNotifRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <xs:group ref="def_hoteldescriptivecontents"/>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required" />
+      <xs:attribute name="TimeStamp" />
+    </xs:complexType>
+  </xs:element>
+
+  <!-- Inventory: OTA_HotelDescriptiveContentNotifRS -->
+  
+  <xs:element name="OTA_HotelDescriptiveContentNotifRS">
+    <xs:complexType>
+      <xs:group ref="def_generic_response"/>
+      <xs:attribute name="Version" use="required" />
+      <xs:attribute name="TimeStamp" />
+    </xs:complexType>
+  </xs:element>
+ 
+
+  <!-- ******************************************************************************* -->
+  <!-- * Inventory/Basic (Pull) and Inventory/HotelInfo (Pull)                         -->
+  <!-- ******************************************************************************* -->
+
+  <!-- Inventory: OTA_HotelDescriptiveInfoRQ -->
+
+  <xs:element name="OTA_HotelDescriptiveInfoRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <xs:element name="HotelDescriptiveInfos" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+
+              <xs:element name="HotelDescriptiveInfo" maxOccurs="1">
+                <xs:complexType>
+                  <xs:attribute name="HotelCode" type="def_nonempty_string"/>
+                  <xs:attribute name="HotelName" type="def_nonempty_string"/>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required" />
+      <xs:attribute name="TimeStamp" />
+    </xs:complexType>
+  </xs:element>
+
+  <!-- Inventory: OTA_HotelDescriptiveInfoRS -->
+  
+  <xs:element name="OTA_HotelDescriptiveInfoRS"> 
+    <xs:complexType>
+
+      <xs:choice>
+
+        <!-- choice: Errors {1} -->
+
+        <xs:element name="Errors">
+          <xs:complexType>
+            <xs:sequence>
+   
+              <!-- Errors > Error {1,} -->
+   
+              <xs:element name="Error" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type" use="required">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="13"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="Code" use="required" type="def_int_ge0"/>
+                </xs:complexType>
+              </xs:element>
+   
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <!-- choice: Success {1} + HotelDescriptiveContents {1} -->
+
+        <xs:sequence>
+          <xs:element name="Success"/>
+          <xs:group ref="def_hoteldescriptivecontents"/>
+        </xs:sequence>
+
+      </xs:choice>
+
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+
+    </xs:complexType>
+  </xs:element>
+
+ 
+  <!-- ******************************************************************************* -->
+  <!-- * RatePlans                                                                     -->
+  <!-- ******************************************************************************* -->
+
+  <!-- RatePlans: OTA_HotelRatePlanNotifRQ -->
+
+  <xs:element name="OTA_HotelRatePlanNotifRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <!-- UniqueID {0,1} -->
+
+        <xs:element name="UniqueID" minOccurs="0">
+          <xs:complexType>
+            <xs:attribute name="Type" use="required">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="16"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="ID" use="required" type="xs:string"/> <!-- an ID is required by OTA, we ignore the value -->
+            <xs:attribute name="Instance" use="required">
+              <xs:simpleType>
+                <xs:restriction base="xs:string">
+                  <xs:enumeration value="CompleteSet"/>
+                </xs:restriction>
+              </xs:simpleType>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+
+        <!-- RatePlans {1} -->
+
+        <xs:group ref="def_rateplans"/>
+ 
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- RatePlans: OTA_HotelRatePlanNotifRS -->
+
+  <xs:element name="OTA_HotelRatePlanNotifRS">
+    <xs:complexType>
+      <xs:group   ref="def_generic_response"/>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+    </xs:complexType>
+  </xs:element>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * BaseRates                                                                     -->
+  <!-- ******************************************************************************* -->
+
+  <!-- BaseRates: OTA_HotelRatePlanRQ -->
+
+  <xs:element name="OTA_HotelRatePlanRQ">
+    <xs:complexType>
+      <xs:sequence>
+
+        <!-- RatePlans {1} -->
+ 
+        <xs:element name="RatePlans">
+          <xs:complexType>
+            <xs:sequence>
+
+              <!-- RatePlans > RatePlan {1} -->
+
+              <xs:element name="RatePlan">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <xs:choice maxOccurs="unbounded">
+
+                      <xs:element name="DateRange">
+                        <xs:complexType>
+                          <xs:attribute name="Start" type="def_date"/>
+                          <xs:attribute name="End"   type="def_date"/>
+                        </xs:complexType>
+                      </xs:element>
+
+                      <xs:element name="RatePlanCandidates">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="RatePlanCandidate" maxOccurs="unbounded">
+                              <xs:complexType>
+                                <xs:attribute name="RatePlanCode" type="def_nonempty_string"/>
+                                <xs:attribute name="RatePlanID" type="def_nonempty_string"/>
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+
+                      <xs:element name="HotelRef">
+                        <xs:complexType>
+                          <xs:attribute name="HotelCode" type="def_nonempty_string"/>
+                          <xs:attribute name="HotelName" type="def_nonempty_string"/>
+                        </xs:complexType>
+                      </xs:element>
+
+                    </xs:choice>
+
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+
+    </xs:complexType>
+  </xs:element>
+
+  <!-- BaseRates: OTA_HotelRatePlanRS -->
+
+  <xs:element name="OTA_HotelRatePlanRS">
+    <xs:complexType>
+
+      <xs:choice>
+
+        <!-- choice: Errors {1} -->
+
+        <xs:element name="Errors">
+          <xs:complexType>
+            <xs:sequence>
+   
+              <!-- Errors > Error {1,} -->
+   
+              <xs:element name="Error" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type" use="required">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:string">
+                        <xs:enumeration value="13"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="Code" use="required" type="def_int_ge0"/>
+                </xs:complexType>
+              </xs:element>
+   
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+        <!-- choice: Success {1} + RatePlans {1} -->
+
+        <xs:sequence>
+          <xs:element name="Success"/>
+          <xs:group ref="def_rateplans"/>
+        </xs:sequence>
+
+      </xs:choice>
+      <xs:attribute name="Version" use="required"/>
+      <xs:attribute name="TimeStamp"/>
+
+    </xs:complexType>
+  </xs:element>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for HotelDescriptiveContents element as used                -->
+  <!-- * in the Inventory types                                                        -->
+  <!-- ******************************************************************************* -->
+
+  <xs:group name="def_hoteldescriptivecontents">
+    <xs:sequence>
+
+        <xs:element name="HotelDescriptiveContents" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+
+              <xs:element name="HotelDescriptiveContent" maxOccurs="1">
+                <xs:complexType>
+                  <xs:sequence>
+
+                    <!-- HotelInfo -->
+                    <xs:element name="HotelInfo" minOccurs="0" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                        <xs:anyAttribute processContents="lax"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                    <!-- FacilityInfo -->
+                    <xs:element name="FacilityInfo" minOccurs="0" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+
+                          <xs:element name="GuestRooms" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:sequence>
+
+                                <xs:element name="GuestRoom" minOccurs="0" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:sequence>
+
+                                      <xs:element name="TypeRoom" minOccurs="0">
+                                        <xs:complexType>
+                                          <xs:attribute name="StandardOccupancy"      type="def_int_gt0" />
+                                          <xs:attribute name="RoomClassificationCode" type="def_int_ge0" />
+                                          <xs:attribute name="RoomID"                 type="def_nonempty_string" />
+                                          <xs:attribute name="Size"                   type="def_int_ge0" />
+                                        </xs:complexType>
+                                      </xs:element>
+
+                                      <xs:element name="Amenities" minOccurs="0">
+                                        <xs:complexType>
+                                          <xs:sequence>
+
+                                            <xs:element name="Amenity" maxOccurs="unbounded">
+                                              <xs:complexType>
+                                                <xs:attribute name="RoomAmenityCode" type="def_int_gt0"/>
+                                              </xs:complexType>
+                                            </xs:element>
+
+                                          </xs:sequence>
+                                        </xs:complexType>
+                                      </xs:element>
+
+                                      <xs:element name="MultimediaDescriptions" minOccurs="0">
+                                        <xs:complexType>
+                                          <xs:sequence>
+
+                                            <xs:element name="MultimediaDescription" maxOccurs="unbounded" minOccurs="0">
+                                              <xs:complexType>
+                                                <xs:choice>
+
+                                                  <xs:element name="TextItems" minOccurs="0">
+                                                    <xs:complexType>
+                                                      <xs:sequence>
+
+                                                        <xs:element name="TextItem">
+                                                          <xs:complexType>
+                                                            <xs:sequence>
+
+                                                              <xs:element name="Description" maxOccurs="unbounded">
+                                                                <xs:complexType>
+                                                                  <xs:simpleContent>
+                                                                    <xs:extension base="def_nonempty_string">
+                                                                      <xs:attribute name="TextFormat" use="required">
+                                                                        <xs:simpleType>
+                                                                          <xs:restriction base="xs:string">
+                                                                            <xs:enumeration value="PlainText"/>
+                                                                          </xs:restriction>
+                                                                        </xs:simpleType>
+                                                                      </xs:attribute>
+                                                                      <xs:attribute name="Language" use="required">
+                                                                        <xs:simpleType>
+                                                                          <xs:restriction base="xs:language">
+                                                                            <xs:pattern value="[a-z][a-z]"/>
+                                                                          </xs:restriction>
+                                                                        </xs:simpleType>
+                                                                      </xs:attribute>
+                                                                    </xs:extension>
+                                                                  </xs:simpleContent>
+                                                                </xs:complexType>
+                                                              </xs:element>
+
+                                                            </xs:sequence>
+                                                          </xs:complexType>
+                                                        </xs:element>
+
+                                                      </xs:sequence>
+                                                    </xs:complexType>
+                                                  </xs:element>
+
+                                                  <xs:element name="ImageItems" minOccurs="0">
+                                                    <xs:complexType>
+                                                      <xs:sequence>
+
+                                                        <xs:element name="ImageItem" maxOccurs="unbounded">
+                                                          <xs:complexType>
+                                                            <xs:sequence>
+
+                                                              <xs:element name="ImageFormat">
+                                                                <xs:complexType>
+                                                                  <xs:sequence>
+                                                                    <xs:element name="URL" type="def_url_string" />
+                                                                  </xs:sequence>
+                                                                  <xs:attribute name="CopyrightNotice" type="def_nonempty_string" />
+                                                                </xs:complexType>
+                                                              </xs:element>
+
+                                                              <xs:element name="Description" minOccurs="0" maxOccurs="unbounded">
+                                                                <xs:complexType>
+                                                                  <xs:simpleContent>
+                                                                    <xs:extension base="def_nonempty_string">
+                                                                      <xs:attribute name="TextFormat" use="required">
+                                                                        <xs:simpleType>
+                                                                          <xs:restriction base="xs:string">
+                                                                            <xs:enumeration value="PlainText"/>
+                                                                          </xs:restriction>
+                                                                        </xs:simpleType>
+                                                                      </xs:attribute>
+                                                                      <xs:attribute name="Language" use="required">
+                                                                        <xs:simpleType>
+                                                                          <xs:restriction base="xs:language">
+                                                                            <xs:pattern value="[a-z][a-z]"/>
+                                                                          </xs:restriction>
+                                                                        </xs:simpleType>
+                                                                      </xs:attribute>
+                                                                    </xs:extension>
+                                                                  </xs:simpleContent>
+                                                                </xs:complexType>
+                                                              </xs:element>
+
+                                                            </xs:sequence>
+                                                            <xs:attribute name="Category" use="required" type="def_int_gt0" />
+                                                          </xs:complexType>
+                                                        </xs:element>
+
+                                                      </xs:sequence>
+                                                    </xs:complexType>
+                                                  </xs:element>
+
+                                                </xs:choice>
+                                                <xs:attribute name="InfoCode">
+                                                  <xs:simpleType>
+                                                    <xs:restriction base="def_int_gt0">
+                                                      <xs:enumeration value="1"/>
+                                                      <xs:enumeration value="23"/>
+                                                      <xs:enumeration value="25"/>
+                                                    </xs:restriction>
+                                                  </xs:simpleType>
+                                                </xs:attribute>
+                                              </xs:complexType>
+                                            </xs:element>
+
+                                          </xs:sequence>
+                                        </xs:complexType>
+                                      </xs:element>
+
+                                    </xs:sequence>
+                                    <xs:attribute name="Code"              use="required" type="def_invTypeCode_string" />
+                                    <xs:attribute name="MaxOccupancy"                     type="def_int_gt0" />
+                                    <xs:attribute name="MinOccupancy"                     type="def_int_gt0" />
+                                    <xs:attribute name="MaxChildOccupancy"                type="def_int_gt0" />
+                                    <xs:attribute name="ID"                               type="def_invTypeCode_string" />
+                                  </xs:complexType>
+                                </xs:element>
+
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+
+                    <!-- Policies -->
+                    <xs:element name="Policies" minOccurs="0" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                        <xs:anyAttribute processContents="lax"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                    <!-- AffiliationInfo -->
+                    <xs:element name="AffiliationInfo" minOccurs="0" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                        <xs:anyAttribute processContents="lax"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                    <!-- ContactInfos -->
+                    <xs:element name="ContactInfos" minOccurs="0" maxOccurs="1">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:any processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                        <xs:anyAttribute processContents="lax"/>
+                      </xs:complexType>
+                    </xs:element>
+
+                  </xs:sequence>
+                  <xs:attribute name="HotelCityCode" type="def_nonempty_string" />
+                  <xs:attribute name="HotelCode" type="def_nonempty_string" />
+                  <xs:attribute name="HotelName" type="def_nonempty_string" />
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+    </xs:sequence>
+  </xs:group>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for RatePlans element as used                               -->
+  <!-- * in RatePlans and BaseRates                                                    -->
+  <!-- ******************************************************************************* -->
+
+  <xs:group name="def_rateplans">
+
+    <xs:sequence>
+      <xs:element name="RatePlans">
+        <xs:complexType>
+          <xs:sequence>
+
+            <!-- RatePlans > RatePlan {1,} -->
+
+            <xs:element name="RatePlan" maxOccurs="unbounded">
+              <xs:complexType>
+                <xs:sequence>
+
+                  <!-- RatePlans > RatePlan > BookingRules {0,1} -->
+
+                  <xs:element name="BookingRules" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+
+                        <xs:element name="BookingRule" maxOccurs="unbounded">
+                          <xs:complexType>
+                            <xs:sequence>
+
+                              <xs:element name="LengthsOfStay" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+
+                                    <xs:element name="LengthOfStay" maxOccurs="unbounded">
+                                      <xs:complexType>
+                                        <xs:attribute name="Time" use="required" type="def_decimal_ge0"/>
+                                        <xs:attribute name="TimeUnit" use="required">
+                                          <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                              <xs:enumeration value="Day"/>
+                                            </xs:restriction>
+                                          </xs:simpleType>
+                                        </xs:attribute>
+                                        <xs:attribute name="MinMaxMessageType" use="required">
+                                          <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                              <xs:enumeration value="SetMinLOS"/>
+                                              <xs:enumeration value="SetForwardMinStay"/>
+                                              <xs:enumeration value="SetMaxLOS"/>
+                                              <xs:enumeration value="SetForwardMaxStay"/>
+                                            </xs:restriction>
+                                          </xs:simpleType>
+                                        </xs:attribute>
+                                      </xs:complexType>
+                                    </xs:element>
+
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="DOW_Restrictions" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+                                    <xs:element name="ArrivalDaysOfWeek" minOccurs="0">
+                                      <xs:complexType>
+                                        <xs:attribute name="Mon"  type="def_bool"/>
+                                        <xs:attribute name="Tue"  type="def_bool"/>
+                                        <xs:attribute name="Weds" type="def_bool"/>
+                                        <xs:attribute name="Thur" type="def_bool"/>
+                                        <xs:attribute name="Fri"  type="def_bool"/>
+                                        <xs:attribute name="Sat"  type="def_bool"/>
+                                        <xs:attribute name="Sun"  type="def_bool"/>
+                                      </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="DepartureDaysOfWeek" minOccurs="0">
+                                      <xs:complexType>
+                                        <xs:attribute name="Mon"  type="def_bool"/>
+                                        <xs:attribute name="Tue"  type="def_bool"/>
+                                        <xs:attribute name="Weds" type="def_bool"/>
+                                        <xs:attribute name="Thur" type="def_bool"/>
+                                        <xs:attribute name="Fri"  type="def_bool"/>
+                                        <xs:attribute name="Sat"  type="def_bool"/>
+                                        <xs:attribute name="Sun"  type="def_bool"/>
+                                      </xs:complexType>
+                                    </xs:element>
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="RestrictionStatus" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:attribute name="Restriction">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="Master"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                  <xs:attribute name="Status">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="Open"/>
+                                        <xs:enumeration value="Close"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                </xs:complexType>
+                              </xs:element>
+
+                            </xs:sequence>
+                            <xs:attribute name="CodeContext">
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:enumeration value="ROOMTYPE"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:attribute>
+                            <xs:attribute name="Code"  type="def_invTypeCode_string"/>
+                            <xs:attribute name="Start" type="def_date"/>
+                            <xs:attribute name="End"   type="def_date"/>
+                          </xs:complexType>
+                        </xs:element>
+
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+
+                  <!-- RatePlans > RatePlan > Rates {0,1} -->
+
+                  <xs:element name="Rates" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+
+                        <xs:element name="Rate" maxOccurs="unbounded">
+                          <xs:complexType>
+                            <xs:sequence>
+
+                              <xs:element name="BaseByGuestAmts" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+
+                                    <xs:element name="BaseByGuestAmt" maxOccurs="unbounded">
+                                      <xs:complexType>
+                                        <xs:attribute name="NumberOfGuests" type="def_int_gt0"/>
+                                        <xs:attribute name="AmountAfterTax" type="def_decimal_gt0"/>
+                                        <xs:attribute name="CurrencyCode">
+                                          <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                              <xs:enumeration value="EUR"/>
+                                            </xs:restriction>
+                                          </xs:simpleType>
+                                        </xs:attribute>
+                                        <xs:attribute name="Type">
+                                          <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                              <xs:enumeration value="7"/>
+                                              <xs:enumeration value="25"/>
+                                            </xs:restriction>
+                                          </xs:simpleType>
+                                        </xs:attribute>
+                                        <xs:attribute name="AgeQualifyingCode" type="def_int_gt0"/>
+                                      </xs:complexType>
+                                    </xs:element>
+
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="AdditionalGuestAmounts" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+
+                                    <xs:element name="AdditionalGuestAmount" maxOccurs="unbounded">
+                                      <xs:complexType>
+                                        <xs:attribute name="Amount"            type="def_decimal_ge0"/>
+                                        <xs:attribute name="AgeQualifyingCode" type="def_int_gt0"/>
+                                        <xs:attribute name="MinAge"            type="def_int_gt0"/>
+                                        <xs:attribute name="MaxAge"            type="def_int_gt0"/>
+                                      </xs:complexType>
+                                    </xs:element>
+
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="RateDescription" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+
+                                    <xs:element name="ListItem" maxOccurs="unbounded">
+                                      <xs:complexType>                    
+                                         <xs:simpleContent>                
+                                           <xs:extension base="def_nonempty_string">
+                                             <xs:attribute name="ListItem" use="required" type="def_int_ge0"/>
+                                             <xs:attribute name="Language" use="required">
+                                               <xs:simpleType>             
+                                                 <xs:restriction base="xs:language">
+                                                   <xs:pattern value="[a-z][a-z]"/>
+                                                 </xs:restriction>         
+                                               </xs:simpleType>            
+                                             </xs:attribute>               
+                                           </xs:extension>                 
+                                         </xs:simpleContent>               
+                                       </xs:complexType>                   
+                                    </xs:element>
+     
+                                  </xs:sequence>
+                                    <xs:attribute name="Name" use="required">
+                                      <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                          <xs:enumeration value="included services"/>
+                                        </xs:restriction>
+                                      </xs:simpleType>
+                                    </xs:attribute>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="MealsIncluded" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:attribute name="Breakfast" type="def_bool"/>
+                                  <xs:attribute name="Lunch"     type="def_bool"/>
+                                  <xs:attribute name="Dinner"    type="def_bool"/>
+                                  <xs:attribute name="MealPlanCodes">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="1"/>
+                                        <xs:enumeration value="3"/>
+                                        <xs:enumeration value="10"/>
+                                        <xs:enumeration value="12"/>
+                                        <xs:enumeration value="14"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                  <xs:attribute name="MealPlanIndicator">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="1"/>
+                                        <xs:enumeration value="true"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                </xs:complexType>
+                              </xs:element>
+                      
+                            </xs:sequence>
+                            <xs:attribute name="MinGuestApplicable" type="def_int_gt0"/>
+                            <xs:attribute name="Start"              type="def_date"/>
+                            <xs:attribute name="End"                type="def_date"/>
+                            <xs:attribute name="RateTimeUnit">
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:enumeration value="Day"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:attribute>
+                            <xs:attribute name="UnitMultiplier"     type="def_int_gt0"/>
+                            <xs:attribute name="Mon"                type="def_bool"/>
+                            <xs:attribute name="Tue"                type="def_bool"/>
+                            <xs:attribute name="Weds"               type="def_bool"/>
+                            <xs:attribute name="Thur"               type="def_bool"/>
+                            <xs:attribute name="Fri"                type="def_bool"/>
+                            <xs:attribute name="Sat"                type="def_bool"/>
+                            <xs:attribute name="Sun"                type="def_bool"/>
+                            <xs:attribute name="Duration">
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:pattern value="P[0-9]+N"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:attribute>
+                            <xs:attribute name="InvTypeCode" type="def_invTypeCode_string"/>
+
+                          </xs:complexType>
+                        </xs:element>
+                      
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+
+                  <!-- RatePlans > RatePlan > Supplements {0,1} -->
+
+                  <xs:element name="Supplements" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+
+                        <xs:element name="Supplement" maxOccurs="unbounded">
+                          <xs:complexType>
+                            <xs:sequence>
+                              <xs:choice>
+                                <xs:element name="PrerequisiteInventory" minOccurs="0" maxOccurs="1">
+                                  <xs:complexType>
+                                      <xs:attribute name="InvCode" use="required" type="def_nonempty_string"/>
+                                      <xs:attribute name="InvType" use="required">
+                                        <xs:simpleType>
+                                          <xs:restriction base="xs:string">
+                                            <xs:enumeration value="ALPINEBITSDOW"/>
+                                            <xs:enumeration value="ROOMTYPE"/>
+                                          </xs:restriction>
+                                        </xs:simpleType>
+                                      </xs:attribute>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:choice>
+                              <!-- RatePlans > RatePlan > Supplements > Supplement > Description {0,5} -->
+                      
+                              <xs:element name="Description" minOccurs="0" maxOccurs="5">
+                                <xs:complexType>
+                                  <xs:sequence>
+                      
+                                    <xs:choice maxOccurs="unbounded">
+                      
+                                      <xs:element name="ListItem" type="def_nonempty_string"/>
+                      
+                                      <xs:element name="Image" type="def_url_string"/>
+                      
+                                      <xs:element name="Text">
+                                        <xs:complexType>                    
+                                           <xs:simpleContent>                
+                                             <xs:extension base="def_nonempty_string">
+                                               <xs:attribute name="TextFormat" use="required">
+                                                 <xs:simpleType>             
+                                                   <xs:restriction base="xs:string">
+                                                     <xs:enumeration value="PlainText"/>
+                                                     <xs:enumeration value="HTML"/> 
+                                                   </xs:restriction>         
+                                                 </xs:simpleType>            
+                                               </xs:attribute>               
+                                               <xs:attribute name="Language">
+                                                 <xs:simpleType>             
+                                                   <xs:restriction base="xs:language">
+                                                     <xs:pattern value="[a-z][a-z]"/>
+                                                   </xs:restriction>         
+                                                 </xs:simpleType>            
+                                               </xs:attribute>               
+                                             </xs:extension>                 
+                                           </xs:simpleContent>               
+                                         </xs:complexType>                   
+                                      </xs:element>
+                                  
+                                      <xs:element name="URL" type="def_url_string"/>
+                      
+                                    </xs:choice>
+                      
+                                  </xs:sequence>
+                      
+                                  <xs:attribute name="Name" use="required">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="title"/>
+                                        <xs:enumeration value="intro"/>
+                                        <xs:enumeration value="description"/>
+                                        <xs:enumeration value="gallery"/>
+                                        <xs:enumeration value="codelist"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                </xs:complexType>
+                              </xs:element>
+
+                            </xs:sequence>
+
+                            <xs:attribute name="AddToBasicRateIndicator">
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:enumeration value="1"/>
+                                  <xs:enumeration value="true"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:attribute>
+
+                            <xs:attribute name="ChargeTypeCode">
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:enumeration value="1"/>
+                                  <xs:enumeration value="12"/>
+                                  <xs:enumeration value="18"/>
+                                  <xs:enumeration value="19"/>
+                                  <xs:enumeration value="20"/>
+                                  <xs:enumeration value="21"/>
+                                  <xs:enumeration value="24"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:attribute>
+
+                            <xs:attribute name="Amount" type="def_decimal_ge0"/>
+
+                            <xs:attribute name="InvType" use="required">
+                              <xs:simpleType>
+                                <xs:restriction base="xs:string">
+                                  <xs:enumeration value="EXTRA"/>
+                                  <xs:enumeration value="ALPINEBITSEXTRA"/>
+                                </xs:restriction>
+                              </xs:simpleType>
+                            </xs:attribute>
+
+                            <xs:attribute name="InvCode" type="def_nonempty_string" use="required"/>
+
+                            <xs:attribute name="MandatoryIndicator" type="def_bool"/>
+
+                            <xs:attribute name="Start" type="def_date"/>
+                            <xs:attribute name="End"   type="def_date"/>
+
+                          </xs:complexType>
+                        </xs:element>  <!-- close Supplement -->
+
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+
+                  <!-- RatePlans > RatePlan > Offers {0,1} -->
+
+                  <xs:element name="Offers" minOccurs="0">
+                    <xs:complexType>
+                      <xs:sequence>
+
+                        <xs:element name="Offer" maxOccurs="3">
+                          <xs:complexType>
+                            <xs:sequence>
+
+                              <xs:element name="OfferRules" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+
+                                    <xs:element name="OfferRule" minOccurs="0">
+                                      <xs:complexType>
+                                        <xs:sequence>
+                                  
+                                          <xs:element name="LengthsOfStay" minOccurs="0">
+                                            <xs:complexType>
+                                              <xs:sequence>
+                                  
+                                                <xs:element name="LengthOfStay" maxOccurs="unbounded">
+                                                  <xs:complexType>
+                                                    <xs:attribute name="Time" use="required" type="def_decimal_ge0"/>
+                                                    <xs:attribute name="TimeUnit" use="required">
+                                                      <xs:simpleType>
+                                                        <xs:restriction base="xs:string">
+                                                          <xs:enumeration value="Day"/>
+                                                        </xs:restriction>
+                                                      </xs:simpleType>
+                                                    </xs:attribute>
+                                                    <xs:attribute name="MinMaxMessageType" use="required">
+                                                      <xs:simpleType>
+                                                        <xs:restriction base="xs:string">
+                                                          <xs:enumeration value="SetMinLOS"/>
+                                                          <xs:enumeration value="SetMaxLOS"/>
+                                                          <xs:enumeration value=""/>
+                                                        </xs:restriction>
+                                                      </xs:simpleType>
+                                                    </xs:attribute>
+                                                  </xs:complexType>
+                                                </xs:element>
+                                  
+                                              </xs:sequence>
+                                            </xs:complexType>
+                                          </xs:element>
+                                  
+                                          <xs:element name="DOW_Restrictions" minOccurs="0">
+                                            <xs:complexType>
+                                              <xs:sequence>
+                                                <xs:element name="ArrivalDaysOfWeek" minOccurs="0">
+                                                  <xs:complexType>
+                                                    <xs:attribute name="Mon"  type="def_bool"/>
+                                                    <xs:attribute name="Tue"  type="def_bool"/>
+                                                    <xs:attribute name="Weds" type="def_bool"/>
+                                                    <xs:attribute name="Thur" type="def_bool"/>
+                                                    <xs:attribute name="Fri"  type="def_bool"/>
+                                                    <xs:attribute name="Sat"  type="def_bool"/>
+                                                    <xs:attribute name="Sun"  type="def_bool"/>
+                                                  </xs:complexType>
+                                                </xs:element>
+                                                <xs:element name="DepartureDaysOfWeek" minOccurs="0">
+                                                  <xs:complexType>
+                                                    <xs:attribute name="Mon"  type="def_bool"/>
+                                                    <xs:attribute name="Tue"  type="def_bool"/>
+                                                    <xs:attribute name="Weds" type="def_bool"/>
+                                                    <xs:attribute name="Thur" type="def_bool"/>
+                                                    <xs:attribute name="Fri"  type="def_bool"/>
+                                                    <xs:attribute name="Sat"  type="def_bool"/>
+                                                    <xs:attribute name="Sun"  type="def_bool"/>
+                                                  </xs:complexType>
+                                                </xs:element>
+                                              </xs:sequence>
+                                            </xs:complexType>
+                                          </xs:element>
+                                  
+                                          <xs:element name="Occupancy" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                              <xs:attribute name="AgeQualifyingCode" use="required">
+                                                <xs:simpleType>
+                                                  <xs:restriction base="xs:string">
+                                                    <xs:enumeration value="8"/>
+                                                    <xs:enumeration value="10"/>
+                                                  </xs:restriction>
+                                                </xs:simpleType>
+                                              </xs:attribute>
+                                              <xs:attribute name="MinAge" type="def_int_gt0"/>
+                                              <xs:attribute name="MaxAge" type="def_int_gt0"/>
+                                              <xs:attribute name="MinOccupancy" type="def_int_ge0"/>
+                                              <xs:attribute name="MaxOccupancy" type="def_int_gt0"/>
+                                            </xs:complexType>
+                                          </xs:element>
+                                  
+                                        </xs:sequence>
+                                  
+                                        <xs:attribute name="MinAdvancedBookingOffset">
+                                          <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                              <xs:pattern value="P[0-9]+D"/>
+                                            </xs:restriction>
+                                          </xs:simpleType>
+                                        </xs:attribute>
+                                        <xs:attribute name="MaxAdvancedBookingOffset">
+                                          <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                              <xs:pattern value="P[0-9]+D"/>
+                                            </xs:restriction>
+                                          </xs:simpleType>
+                                        </xs:attribute>
+                                  
+                                      </xs:complexType>
+                                    </xs:element>
+
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="Discount" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:attribute name="Percent" use="required">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:enumeration value="100"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                  <xs:attribute name="NightsRequired"   type="def_int_gt0"/>
+                                  <xs:attribute name="NightsDiscounted" type="def_int_gt0"/>
+                                  <xs:attribute name="DiscountPattern">
+                                    <xs:simpleType>
+                                      <xs:restriction base="xs:string">
+                                        <xs:pattern value="0*1*"/>
+                                      </xs:restriction>
+                                    </xs:simpleType>
+                                  </xs:attribute>
+                                </xs:complexType>
+                              </xs:element>
+
+                              <xs:element name="Guests" minOccurs="0">
+                                <xs:complexType>
+                                  <xs:sequence>
+
+                                    <xs:element name="Guest">
+                                      <xs:complexType>
+                                        <xs:attribute name="AgeQualifyingCode" use="required" type="def_int_gt0"/>
+                                        <xs:attribute name="MaxAge"            use="required" type="def_int_gt0"/>
+                                        <xs:attribute name="MinCount"          use="required" type="def_int_ge0"/>
+                                          <xs:attribute name="FirstQualifyingPosition" use="required">
+                                            <xs:simpleType>
+                                              <xs:restriction base="xs:string">
+                                                <xs:enumeration value="1"/>
+                                              </xs:restriction>
+                                            </xs:simpleType>
+                                          </xs:attribute>
+                                          <xs:attribute name="LastQualifyingPosition" use="required" type="def_int_gt0"/>
+                                      </xs:complexType>
+                                    </xs:element>
+
+                                  </xs:sequence>
+                                </xs:complexType>
+                              </xs:element>
+
+                            </xs:sequence>
+                          </xs:complexType>
+                        </xs:element>
+
+                      </xs:sequence>
+                    </xs:complexType>
+                  </xs:element>
+
+                  <!-- RatePlans > RatePlan > Description {0,5} -->
+
+                  <xs:element name="Description" minOccurs="0" maxOccurs="5">
+                    <xs:complexType>
+                      <xs:sequence>
+
+                        <xs:choice maxOccurs="unbounded">
+
+                          <xs:element name="ListItem" type="def_nonempty_string"/>
+
+                          <xs:element name="Image" type="def_url_string"/>
+
+                          <xs:element name="Text">
+                            <xs:complexType>                    
+                               <xs:simpleContent>                
+                                 <xs:extension base="def_nonempty_string">
+                                   <xs:attribute name="TextFormat" use="required">
+                                     <xs:simpleType>             
+                                       <xs:restriction base="xs:string">
+                                         <xs:enumeration value="PlainText"/>
+                                         <xs:enumeration value="HTML"/> 
+                                       </xs:restriction>         
+                                     </xs:simpleType>            
+                                   </xs:attribute>               
+                                   <xs:attribute name="Language">
+                                     <xs:simpleType>             
+                                       <xs:restriction base="xs:language">
+                                         <xs:pattern value="[a-z][a-z]"/>
+                                       </xs:restriction>         
+                                     </xs:simpleType>            
+                                   </xs:attribute>               
+                                 </xs:extension>                 
+                               </xs:simpleContent>               
+                             </xs:complexType>                   
+                          </xs:element>
+                      
+                          <xs:element name="URL" type="def_url_string"/>
+
+                        </xs:choice>
+
+                      </xs:sequence>
+
+                      <xs:attribute name="Name" use="required">
+                        <xs:simpleType>
+                          <xs:restriction base="xs:string">
+                            <xs:enumeration value="title"/>
+                            <xs:enumeration value="intro"/>
+                            <xs:enumeration value="description"/>
+                            <xs:enumeration value="gallery"/>
+                            <xs:enumeration value="codelist"/>
+                          </xs:restriction>
+                        </xs:simpleType>
+                      </xs:attribute>
+                    </xs:complexType>
+                  </xs:element>
+
+                </xs:sequence>
+                <xs:attribute name="Start" type="def_date"/>
+                <xs:attribute name="End"   type="def_date"/>
+                <xs:attribute name="RatePlanNotifType">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                      <xs:enumeration value="Overlay"/>
+                      <xs:enumeration value="New"/>
+                      <xs:enumeration value="Remove"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="CurrencyCode">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                      <xs:enumeration value="EUR"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="RatePlanCode" type="def_nonempty_string"/>
+                <xs:attribute name="RatePlanType">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                      <xs:enumeration value="12"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:attribute>                
+                <xs:attribute name="RatePlanCategory" type="def_nonempty_string"/>
+                <xs:attribute name="RatePlanID" type="def_nonempty_string"/>
+                <xs:attribute name="RatePlanQualifier" type="def_bool"/>
+              </xs:complexType>
+            </xs:element> <!-- close RatePlan -->
+
+          </xs:sequence>
+          <xs:attribute name="HotelCode" type="def_nonempty_string"/>
+          <xs:attribute name="HotelName" type="def_nonempty_string"/>
+        </xs:complexType>
+
+      </xs:element>
+
+    </xs:sequence>
+
+  </xs:group>
+
+   
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for success/advisory/warning/error responses                -->
+  <!-- ******************************************************************************* -->
+
+  <xs:group name="def_generic_response">
+    <xs:choice>
+
+      <!-- choice: Errors {1} -->
+
+      <xs:element name="Errors">
+        <xs:complexType>
+          <xs:sequence>
+
+            <!-- Errors > Error {1,} -->
+
+            <xs:element name="Error" maxOccurs="unbounded">
+              <xs:complexType mixed="true">
+                <xs:attribute name="Type" use="required">
+                  <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                      <xs:enumeration value="13"/>
+                    </xs:restriction>
+                  </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="Code" use="required" type="def_int_gt0"/>
+              </xs:complexType>
+            </xs:element>
+
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+
+      <!-- choice: Success {1} + Warnings {0,1} -->
+
+      <xs:sequence>
+
+        <xs:element name="Success"/>
+
+        <xs:element name="Warnings" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+
+            <!-- Warnings > Warning {1,} -->
+
+              <xs:element name="Warning" maxOccurs="unbounded">
+                <xs:complexType mixed="true">
+                  <xs:attribute name="Type"     use="required" type="def_int_gt0"/>
+                  <xs:attribute name="RecordID"                type="def_nonempty_string"/>
+                </xs:complexType>
+              </xs:element>
+
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+
+      </xs:sequence>
+
+    </xs:choice>
+  </xs:group>
+
+
+  <!-- ******************************************************************************* -->
+  <!-- * common definition for recurring, simple types                                 -->
+  <!-- ******************************************************************************* -->
+
+  <!-- A generic non-empty string type. -->
+
+  <xs:simpleType name="def_nonempty_string">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic string type containing an @ char, like an email address -->
+
+  <xs:simpleType name="def_email_string">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="\S+@\S+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- String type defining room category codes (like InvTypeCode)  -->
+
+  <xs:simpleType name="def_invTypeCode_string">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+      <xs:maxLength value="8"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic string type starting with http:// or https:// -->
+
+  <xs:simpleType name="def_url_string">
+    <xs:restriction base="xs:anyURI">
+      <xs:pattern value="https?://.+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+  <!-- A generic integer > 0 type. -->
+
+  <xs:simpleType name="def_int_gt0">
+    <xs:restriction base="xs:positiveInteger">
+      <xs:pattern value="[0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic integer >= 0 type. -->
+
+  <xs:simpleType name="def_int_ge0">
+    <xs:restriction base="xs:nonNegativeInteger">
+      <xs:pattern value="[0-9]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic decimal >= 0 type. -->
+
+  <xs:simpleType name="def_decimal_ge0">
+    <xs:restriction base="xs:decimal">
+      <xs:minInclusive value="0.0"/>
+      <xs:pattern value="[0-9]*\.?[0-9]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic decimal > 0 type. -->
+
+  <xs:simpleType name="def_decimal_gt0">
+    <xs:restriction base="xs:decimal">
+      <xs:minExclusive value="0.0"/>
+      <xs:pattern value="[0-9]*\.?[0-9]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic date type. -->
+
+  <xs:simpleType name="def_date">
+    <xs:restriction base="xs:date">
+      <xs:pattern value="\S+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic datetime type. -->
+
+  <xs:simpleType name="def_datetime">
+    <xs:restriction base="xs:dateTime">
+      <xs:pattern value="\S+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <!-- A generic boolean type (1,true,0,false). -->
+
+  <xs:simpleType name="def_bool">
+    <xs:restriction base="xs:boolean">
+      <xs:pattern value="\S+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+
+</xs:schema>

--- a/alpinebits-xml/impl/src/test/resources/web/context.xml
+++ b/alpinebits-xml/impl/src/test/resources/web/context.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Context>
+    <!--
+        Disable manifest scanning in Arquillian Tomcat, since
+        Tomcat had issues loading jing dependencies that are
+        defined in jing's manifest file
+    -->
+    <JarScanner scanManifest="false" />
+</Context>

--- a/alpinebits-xml/impl/src/test/resources/web/web-not-validating-xml-request-wrapping-middleware-integration-test.xml
+++ b/alpinebits-xml/impl/src/test/resources/web/web-not-validating-xml-request-wrapping-middleware-integration-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=" http://java.sun.com/xml/ns/javaee
+    http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <servlet>
+        <servlet-name>AlpineBits Servlet</servlet-name>
+        <servlet-class>it.bz.idm.alpinebits.servlet.impl.AlpineBitsServlet</servlet-class>
+        <init-param>
+            <param-name>MIDDLEWARE_CLASSNAME</param-name>
+            <param-value>it.bz.idm.alpinebits.xml.middleware.utils.NotValidatingXmlRequestMappingMiddleware</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>AlpineBits Servlet</servlet-name>
+        <url-pattern>/AlpineBits</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/alpinebits-xml/impl/src/test/resources/web/web-not-validating-xml-response-wrapping-middleware-integration-test.xml
+++ b/alpinebits-xml/impl/src/test/resources/web/web-not-validating-xml-response-wrapping-middleware-integration-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=" http://java.sun.com/xml/ns/javaee
+    http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <servlet>
+        <servlet-name>AlpineBits Servlet</servlet-name>
+        <servlet-class>it.bz.idm.alpinebits.servlet.impl.AlpineBitsServlet</servlet-class>
+        <init-param>
+            <param-name>MIDDLEWARE_CLASSNAME</param-name>
+            <param-value>it.bz.idm.alpinebits.xml.middleware.utils.NotValidatingXmlResponseMappingMiddleware</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>AlpineBits Servlet</servlet-name>
+        <url-pattern>/AlpineBits</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/alpinebits-xml/impl/src/test/resources/web/web-rng-validating-error-xml-response-wrapping-middleware-integration-test.xml
+++ b/alpinebits-xml/impl/src/test/resources/web/web-rng-validating-error-xml-response-wrapping-middleware-integration-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=" http://java.sun.com/xml/ns/javaee
+    http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <servlet>
+        <servlet-name>AlpineBits Servlet</servlet-name>
+        <servlet-class>it.bz.idm.alpinebits.servlet.impl.AlpineBitsServlet</servlet-class>
+        <init-param>
+            <param-name>MIDDLEWARE_CLASSNAME</param-name>
+            <param-value>it.bz.idm.alpinebits.xml.middleware.utils.RngValidatingErrorXmlResponseMappingMiddleware</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>AlpineBits Servlet</servlet-name>
+        <url-pattern>/AlpineBits</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/alpinebits-xml/impl/src/test/resources/web/web-rng-validating-xml-request-wrapping-middleware-integration-test.xml
+++ b/alpinebits-xml/impl/src/test/resources/web/web-rng-validating-xml-request-wrapping-middleware-integration-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=" http://java.sun.com/xml/ns/javaee
+    http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <servlet>
+        <servlet-name>AlpineBits Servlet</servlet-name>
+        <servlet-class>it.bz.idm.alpinebits.servlet.impl.AlpineBitsServlet</servlet-class>
+        <init-param>
+            <param-name>MIDDLEWARE_CLASSNAME</param-name>
+            <param-value>it.bz.idm.alpinebits.xml.middleware.utils.RngValidatingXmlRequestMappingMiddleware</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>AlpineBits Servlet</servlet-name>
+        <url-pattern>/AlpineBits</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/alpinebits-xml/impl/src/test/resources/web/web-rng-validating-xml-response-wrapping-middleware-integration-test.xml
+++ b/alpinebits-xml/impl/src/test/resources/web/web-rng-validating-xml-response-wrapping-middleware-integration-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=" http://java.sun.com/xml/ns/javaee
+    http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <servlet>
+        <servlet-name>AlpineBits Servlet</servlet-name>
+        <servlet-class>it.bz.idm.alpinebits.servlet.impl.AlpineBitsServlet</servlet-class>
+        <init-param>
+            <param-name>MIDDLEWARE_CLASSNAME</param-name>
+            <param-value>it.bz.idm.alpinebits.xml.middleware.utils.RngValidatingXmlResponseMappingMiddleware</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>AlpineBits Servlet</servlet-name>
+        <url-pattern>/AlpineBits</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/alpinebits-xml/impl/src/test/resources/web/web-xsd-validating-error-xml-response-wrapping-middleware-integration-test.xml
+++ b/alpinebits-xml/impl/src/test/resources/web/web-xsd-validating-error-xml-response-wrapping-middleware-integration-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=" http://java.sun.com/xml/ns/javaee
+    http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <servlet>
+        <servlet-name>AlpineBits Servlet</servlet-name>
+        <servlet-class>it.bz.idm.alpinebits.servlet.impl.AlpineBitsServlet</servlet-class>
+        <init-param>
+            <param-name>MIDDLEWARE_CLASSNAME</param-name>
+            <param-value>it.bz.idm.alpinebits.xml.middleware.utils.XsdValidatingErrorXmlResponseMappingMiddleware</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>AlpineBits Servlet</servlet-name>
+        <url-pattern>/AlpineBits</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/alpinebits-xml/impl/src/test/resources/web/web-xsd-validating-xml-request-wrapping-middleware-integration-test.xml
+++ b/alpinebits-xml/impl/src/test/resources/web/web-xsd-validating-xml-request-wrapping-middleware-integration-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=" http://java.sun.com/xml/ns/javaee
+    http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <servlet>
+        <servlet-name>AlpineBits Servlet</servlet-name>
+        <servlet-class>it.bz.idm.alpinebits.servlet.impl.AlpineBitsServlet</servlet-class>
+        <init-param>
+            <param-name>MIDDLEWARE_CLASSNAME</param-name>
+            <param-value>it.bz.idm.alpinebits.xml.middleware.utils.XsdValidatingXmlRequestMappingMiddleware</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>AlpineBits Servlet</servlet-name>
+        <url-pattern>/AlpineBits</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/alpinebits-xml/impl/src/test/resources/web/web-xsd-validating-xml-response-wrapping-middleware-integration-test.xml
+++ b/alpinebits-xml/impl/src/test/resources/web/web-xsd-validating-xml-response-wrapping-middleware-integration-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation=" http://java.sun.com/xml/ns/javaee
+    http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <servlet>
+        <servlet-name>AlpineBits Servlet</servlet-name>
+        <servlet-class>it.bz.idm.alpinebits.servlet.impl.AlpineBitsServlet</servlet-class>
+        <init-param>
+            <param-name>MIDDLEWARE_CLASSNAME</param-name>
+            <param-value>it.bz.idm.alpinebits.xml.middleware.utils.XsdValidatingXmlResponseMappingMiddleware</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>AlpineBits Servlet</servlet-name>
+        <url-pattern>/AlpineBits</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/alpinebits-xml/pom.xml
+++ b/alpinebits-xml/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>it.bz.idm.alpinebits</groupId>
+        <artifactId>alpinebits-root</artifactId>
+        <version>0.0.9</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>alpinebits-xml</artifactId>
+    <version>0.0.9</version>
+
+    <packaging>pom</packaging>
+    <name>IDM AlpineBits XML</name>
+
+    <modules>
+        <module>api</module>
+        <module>impl</module>
+    </modules>
+</project>

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>alpinebits-root</artifactId>
         <groupId>it.bz.idm.alpinebits</groupId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/examples/housekeeping/pom.xml
+++ b/examples/housekeeping/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>examples-root</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>examples-housekeeping</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <packaging>war</packaging>
     <name>IDM AlpineBits examples - housekeeping</name>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>it.bz.idm.alpinebits</groupId>
         <artifactId>alpinebits-root</artifactId>
-        <version>0.0.8</version>
+        <version>0.0.9</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>examples-root</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <packaging>pom</packaging>
     <name>IDM AlpineBits examples - root</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>it.bz.idm.alpinebits</groupId>
     <artifactId>alpinebits-root</artifactId>
-    <version>0.0.8</version>
+    <version>0.0.9</version>
 
     <packaging>pom</packaging>
     <name>IDM AlpineBits</name>
@@ -18,6 +18,7 @@
         <module>alpinebits-routing</module>
         <module>alpinebits-server</module>
         <module>alpinebits-servlet</module>
+        <module>alpinebits-xml</module>
         <module>build-tools</module>
         <module>examples</module>
     </modules>
@@ -42,6 +43,7 @@
         <gitflow-maven-plugin.version>1.10.0</gitflow-maven-plugin.version>
 
         <servlet.version>3.0.1</servlet.version>
+        <mapstruct.version>1.2.0.Final</mapstruct.version>
 
         <testng.version>6.14.3</testng.version>
         <mockito.version>2.22.0</mockito.version>
@@ -136,67 +138,77 @@
             <dependency>
                 <groupId>it.bz.idm.alpinebits</groupId>
                 <artifactId>alpinebits-common-api</artifactId>
-                <version>0.0.8</version>
+                <version>0.0.9</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.idm.alpinebits</groupId>
                 <artifactId>alpinebits-common-utils</artifactId>
-                <version>0.0.8</version>
+                <version>0.0.9</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.idm.alpinebits</groupId>
                 <artifactId>alpinebits-housekeeping-api</artifactId>
-                <version>0.0.8</version>
+                <version>0.0.9</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.idm.alpinebits</groupId>
                 <artifactId>alpinebits-housekeeping-impl</artifactId>
-                <version>0.0.8</version>
+                <version>0.0.9</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.idm.alpinebits</groupId>
                 <artifactId>alpinebits-middleware-api</artifactId>
-                <version>0.0.8</version>
+                <version>0.0.9</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.idm.alpinebits</groupId>
                 <artifactId>alpinebits-middleware-impl</artifactId>
-                <version>0.0.8</version>
+                <version>0.0.9</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.idm.alpinebits</groupId>
                 <artifactId>alpinebits-routing-api</artifactId>
-                <version>0.0.8</version>
+                <version>0.0.9</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.idm.alpinebits</groupId>
                 <artifactId>alpinebits-routing-impl</artifactId>
-                <version>0.0.8</version>
+                <version>0.0.9</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.idm.alpinebits</groupId>
                 <artifactId>alpinebits-server-api</artifactId>
-                <version>0.0.8</version>
+                <version>0.0.9</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.idm.alpinebits</groupId>
                 <artifactId>alpinebits-server-impl</artifactId>
-                <version>0.0.8</version>
+                <version>0.0.9</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.idm.alpinebits</groupId>
                 <artifactId>alpinebits-servlet-api</artifactId>
-                <version>0.0.8</version>
+                <version>0.0.9</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.idm.alpinebits</groupId>
                 <artifactId>alpinebits-servlet-impl</artifactId>
-                <version>0.0.8</version>
+                <version>0.0.9</version>
+            </dependency>
+            <dependency>
+                <groupId>it.bz.idm.alpinebits</groupId>
+                <artifactId>alpinebits-xml-api</artifactId>
+                <version>0.0.9</version>
+            </dependency>
+            <dependency>
+                <groupId>it.bz.idm.alpinebits</groupId>
+                <artifactId>alpinebits-xml-impl</artifactId>
+                <version>0.0.9</version>
             </dependency>
             <dependency>
                 <groupId>it.bz.idm.alpinebits</groupId>
                 <artifactId>examples-housekeeping</artifactId>
-                <version>0.0.8</version>
+                <version>0.0.9</version>
             </dependency>
 
             <dependency>
@@ -209,6 +221,11 @@
                 <artifactId>javax.servlet-api</artifactId>
                 <version>${servlet.version}</version>
                 <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mapstruct</groupId>
+                <artifactId>mapstruct-jdk8</artifactId>
+                <version>${mapstruct.version}</version>
             </dependency>
 
             <!-- Test dependencies -->
@@ -282,6 +299,18 @@
                     <configuration>
                         <source>1.8</source>
                         <target>1.8</target>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>org.mapstruct</groupId>
+                                <artifactId>mapstruct-processor</artifactId>
+                                <version>${mapstruct.version}</version>
+                            </path>
+                        </annotationProcessorPaths>
+                        <compilerArgs>
+                            <compilerArg>
+                                 -Amapstruct.unmappedTargetPolicy=ERROR
+                            </compilerArg>
+                        </compilerArgs>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
The new module converts XML files to AlpineBits objects and vice versa
using the default JAXB implementation. The module supports also XML
schema checks with XSD and RNG, the RNG check is performed with jing.

The AlpineBits objects are generated by maven (see jaxb2-maven-plugin)
and xjc. Some customization is done for the object generation itself.
After xjc has finished, some additional steps on the generated sources
are taken to prevent JAXB issues (namely: variables of type Object
are converted to type String).

The unit tests do a full conversion of all example XML files, provided
by AlpineBits repos (see https://gitlab.com/alpinebits/developers-kit)
to ensure, that the conversion for each message type succeeds.